### PR TITLE
Fix codespace build: pin to existing efabless/openlane tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@
 # and the Sky130 PDK pinned at known-good versions, plus a working tcl/tk env.
 # We layer Python 3.11, Verilator, cocotb, Node + Claude CLI on top.
 # -----------------------------------------------------------------------------
-FROM efabless/openlane:2024.10.18 AS socmate
+FROM efabless/openlane:1.0.0 AS socmate
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_MAJOR=20


### PR DESCRIPTION
## Summary
- Codespace creation was failing on `docker pull efabless/openlane:2024.10.18` — that tag has never been published to Docker Hub, so the devcontainer build aborts and Codespaces falls back to the alpine recovery container.
- Repins the base image to `efabless/openlane:1.0.0`, the official semver-tagged stable release (published 2024-10-28, same digest as `superstable`).

## Repro (from the failing Codespace log)
```
Error fetching image details: No manifest found for docker.io/efabless/openlane:2024.10.18.
Error: Command failed: docker pull efabless/openlane:2024.10.18
Error code: 1302 (UnifiedContainersErrorFatalCreatingContainer)
```

## Test plan
- [ ] Open a fresh Codespace on this branch and confirm the devcontainer builds without falling through to the recovery container
- [ ] `docker build -t socmate:latest .` succeeds locally
- [ ] `make preflight` passes inside the built container (PDK + EDA binaries on `$PATH`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)