### PR TITLE
Add publish-image workflow (ghcr.io)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Build the socmate Dockerfile and publish to ghcr.io so RunPod templates
+# (and other downstream consumers) can pull a ready-to-run image instead
+# of building locally.
+#
+# Triggers:
+#   - push to main (publishes :latest + :<sha>)
+#   - tag push v*  (publishes :<tag> + :latest + :<sha>)
+#   - workflow_dispatch (manual rebuild from any branch; useful while a
+#                        Dockerfile fix is still on a PR branch)
+
+name: Publish image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          IMAGE=ghcr.io/${{ github.repository }}
+          IMAGE=${IMAGE,,}   # ghcr requires lowercase
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE}:${GITHUB_SHA::12}"
+            if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+              echo "${IMAGE}:${GITHUB_REF_NAME}"
+              echo "${IMAGE}:latest"
+            elif [ "${GITHUB_REF_NAME}" = "main" ]; then
+              echo "${IMAGE}:latest"
+            else
+              # workflow_dispatch from a non-main branch: tag with branch
+              # name (slashes -> dashes) so the runpod template can pin it.
+              SAFE_BRANCH=$(echo "${GITHUB_REF_NAME}" | tr '/' '-')
+              echo "${IMAGE}:${SAFE_BRANCH}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Summary
+        run: |
+          echo "### Published" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.tags.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Lands `.github/workflows/publish-image.yml` on `main` so it registers as a workflow GitHub will dispatch. The workflow publishes the socmate Dockerfile to `ghcr.io/facebookexperimental/socmate`:
- `:<sha>` on every push to main
- `:latest` + `:<tag>` on tag pushes
- branch-tagged image on `workflow_dispatch` (so RunPod templates can pin a pre-merge image off PR #3 before the Dockerfile fixes land)

The workflow uses the built-in `GITHUB_TOKEN` with `packages: write`, so no extra secrets are needed.

This PR doesn't change the Dockerfile and is independent of #3 — but #3 must merge (or be `workflow_dispatch`ed against) before the *first* publish will succeed, since the current `main` Dockerfile still pins the broken `efabless/openlane:1.0.0` base.

## Test plan
- [ ] Merge this PR
- [ ] `gh workflow run publish-image.yml --ref fix/codespace-iic-osic-tools-base` succeeds and pushes a `:fix-codespace-iic-osic-tools-base` tag to ghcr
- [ ] Image pulls cleanly: `docker pull ghcr.io/facebookexperimental/socmate:fix-codespace-iic-osic-tools-base`

🤖 Generated with [Claude Code](https://claude.com/claude-code)