### PR TITLE
Gate preflight on verilator >= 5.0 + auto-install OSS-CAD-Suite

### DIFF
--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -60,6 +60,32 @@ LIBERTY_FILE = _find_liberty_file()
 # Preflight check -- validate PDK/EDA tools before burning retry budgets
 # ---------------------------------------------------------------------------
 
+
+def _verilator_version() -> tuple[int, int] | None:
+    """Return (major, minor) for `verilator --version`, or None if it can't
+    be parsed. Used by preflight_check to guard against the Ubuntu-22.04
+    apt build (4.038) which is too old for socmate's lint flags.
+    """
+    try:
+        out = subprocess.run(
+            ["verilator", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        ).stdout
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+    # Expected first-line shape: "Verilator 5.049 devel rev v5.048-37-..."
+    # or "Verilator 4.038 2020-07-11 ..." for the apt build.
+    import re
+    m = re.search(r"Verilator\s+(\d+)\.(\d+)", out)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+
+
 def preflight_check(phases: list[str] | None = None) -> dict:
     """Validate that required PDK files and EDA tools exist.
 
@@ -81,6 +107,20 @@ def preflight_check(phases: list[str] | None = None) -> dict:
             errors.append(f"Liberty file not found: {LIBERTY_FILE}")
         if not shutil.which("verilator"):
             errors.append("verilator not found on PATH")
+        else:
+            # The lint step uses Verilator-5-only flags (e.g. -Wno-EOFNEWLINE).
+            # Apt on Ubuntu 22.04 ships 4.038, which silently passes the
+            # "binary on PATH" check and then fails the very first lint with
+            # "Unknown warning specified". Gate on >= 5.0 here so the user
+            # learns about the upgrade before burning a pipeline run.
+            ver = _verilator_version()
+            if ver is not None and ver < (5, 0):
+                errors.append(
+                    f"verilator version {'.'.join(str(p) for p in ver)} "
+                    f"is too old (need >= 5.0). Install OSS-CAD-Suite "
+                    "(https://github.com/YosysHQ/oss-cad-suite-build/releases/latest) "
+                    "or build verilator from source."
+                )
         if not shutil.which("yosys"):
             errors.append("yosys not found on PATH")
         if not PDK_ROOT.exists():

--- a/scripts/install_toolchain.sh
+++ b/scripts/install_toolchain.sh
@@ -128,6 +128,62 @@ install_riscv_toolchain() {
 }
 
 # --------------------------------------------------------------------------
+# 6a. OSS-CAD-Suite (newer yosys + verilator 5; only on Linux when apt's
+#     versions are too old to run the pipeline)
+# --------------------------------------------------------------------------
+install_oss_cad_suite_if_needed() {
+    if [[ "$OS" != "Linux" ]]; then
+        return 0
+    fi
+
+    local need_install=0
+    local vv
+    if command -v verilator &>/dev/null; then
+        vv="$(verilator --version 2>&1 | grep -oE 'Verilator [0-9]+\.[0-9]+' | awk '{print $2}')"
+        if [[ -n "$vv" ]] && awk -v v="$vv" 'BEGIN{exit !(v+0 < 5.0)}'; then
+            need_install=1
+        fi
+    else
+        need_install=1
+    fi
+
+    if [[ "$need_install" -eq 0 ]]; then
+        return 0
+    fi
+
+    echo ""
+    echo "--- Installing OSS-CAD-Suite (apt-installed verilator $vv is too old) ---"
+
+    local install_dir="${OSS_CAD_SUITE_ROOT:-/opt/oss-cad-suite}"
+    if [[ -x "${install_dir}/bin/verilator" ]]; then
+        echo "OSS-CAD-Suite already at ${install_dir}; reusing."
+    else
+        # Fetch the latest release URL via GitHub's redirect (no jq dep).
+        local release_url
+        release_url="$(curl -sIL https://github.com/YosysHQ/oss-cad-suite-build/releases/latest \
+                       | grep -i '^location:' | tail -1 \
+                       | awk '{print $2}' | tr -d '\r\n')"
+        local release_tag="${release_url##*/}"
+        # Tag format is YYYY-MM-DD; the asset filename is YYYYMMDD with no dashes.
+        local asset_date="${release_tag//-/}"
+        local asset_url="https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${release_tag}/oss-cad-suite-linux-x64-${asset_date}.tgz"
+
+        echo "Downloading ${asset_url} (~700 MB)..."
+        sudo mkdir -p "$(dirname "$install_dir")"
+        sudo curl -L --fail -o "/tmp/oss-cad-suite.tgz" "$asset_url"
+        echo "Extracting to ${install_dir}..."
+        sudo tar -xzf /tmp/oss-cad-suite.tgz -C "$(dirname "$install_dir")"
+        rm -f /tmp/oss-cad-suite.tgz
+    fi
+
+    # Prepend the suite to PATH for subsequent steps and verify().
+    export PATH="${install_dir}/bin:${PATH}"
+    echo "OSS-CAD-Suite ready at ${install_dir}; PATH updated for this session."
+    echo "To pick it up in new shells, add to your ~/.bashrc:"
+    echo "  source ${install_dir}/environment"
+}
+
+# --------------------------------------------------------------------------
 # 6. Verify installations
 # --------------------------------------------------------------------------
 verify() {
@@ -183,6 +239,7 @@ verify() {
 # Main
 # --------------------------------------------------------------------------
 install_system_deps
+install_oss_cad_suite_if_needed
 setup_python_env
 install_sky130
 install_openlane


### PR DESCRIPTION
## Summary
Found while running `make demo` end-to-end on a fresh RunPod CPU pod via the `scripts/install_toolchain.sh` path:

1. `apt-get install verilator` on Ubuntu 22.04 (jammy) gives **verilator 4.038**.
2. `make preflight` checks "is verilator on PATH?" → returns `{"ok": true}`.
3. The pipeline runs RTL gen via Claude (~5 min), then the lint step calls `verilator --lint-only … -Wno-EOFNEWLINE …`.
4. Verilator 4 doesn't know `-Wno-EOFNEWLINE` (it's 5+) → `%Error: Unknown warning specified` on every retry → block escalates to human, demo exits 0/0 blocks passed after burning ~9 min of LLM credits.

The install script's own `verify` step prints `[STALE] verilator 4.038 -- README requires >= 5.0` but only as a **warning**, and the Python preflight doesn't check at all. So the failure is silent until LLM tokens are already spent.

## Fix

- **`orchestrator/langgraph/pipeline_helpers.py`** — add `_verilator_version()` (parses `verilator --version`) and gate `preflight_check()` with a hard error if `< 5.0`. Error message points at the OSS-CAD-Suite releases page.
- **`scripts/install_toolchain.sh`** — new `install_oss_cad_suite_if_needed()` step. If apt's verilator is < 5, it grabs the latest OSS-CAD-Suite tarball (~700 MB) from the YosysHQ releases page, extracts to `/opt/oss-cad-suite`, and prepends `${OSS_CAD_SUITE_ROOT}/bin` to PATH for the remainder of the install. Re-uses an existing install if present. Linux-only (macOS Homebrew already ships fresh-enough verilator).

The `verify()` step's existing `[STALE]` warning is unchanged — it still surfaces a stale apt-installed copy if you skip the auto-install (`OSS_CAD_SUITE_ROOT=…` to point elsewhere, etc.).

## Repro / verification
On a fresh Ubuntu 22.04 box (or a RunPod pod with `runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04`):

```bash
git clone https://github.com/facebookexperimental/socmate.git
cd socmate
./scripts/install_toolchain.sh   # now auto-installs OSS-CAD-Suite if apt's verilator < 5
source orchestrator/.venv/bin/activate
make preflight                   # would now FAIL on a stale verilator (was: silently {"ok": true})
make demo                        # works end-to-end with verilator 5
```

Verified manually on RunPod pod `pi8awsl32n6n75`: with OSS-CAD-Suite (`Verilator 5.049 devel rev v5.048-37-…`) the demo's lint step now passes its first attempt instead of the dead-end error.

## Test plan
- [x] `python3 -c "import ast; ast.parse('pipeline_helpers.py')"` clean
- [x] `bash -n install_toolchain.sh` clean
- [ ] CI green on this PR (lint + collection sanity)
- [ ] (manual) Re-run `./scripts/install_toolchain.sh` on a pod and confirm OSS-CAD-Suite auto-installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)