### PR TITLE
Fix RunPod image: musl-claude, sshd foothold, verilator>=5.036, supervisor entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,16 @@ RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
 
 ENV PATH="/root/.nix-profile/bin:${PATH}"
 
-RUN npm install -g @anthropic-ai/claude-code
+# Nix-built Node sets npm's default prefix into the read-only Nix store,
+# so `npm install -g` "succeeds" (the package extracts) but the bin
+# symlink can't land anywhere on PATH -- `which claude` then comes back
+# empty, the orchestrator Popens cmd[0]="" and the pipeline crashes
+# deep inside generate_uarch_spec. Pin the prefix to a writable dir we
+# explicitly put on PATH so global installs are actually usable.
+ENV NPM_CONFIG_PREFIX=/opt/npm-global
+ENV PATH="/opt/npm-global/bin:${PATH}"
+RUN mkdir -p /opt/npm-global \
+ && npm install -g @anthropic-ai/claude-code
 
 # Capture the resolved Claude CLI path at build time and bake it as
 # CLAUDE_CLI_PATH so runtime resolution can't drift if PATH changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,11 +53,42 @@ FROM ghcr.io/efabless/openlane2:2.3.10 AS socmate
 # without a default `nixpkgs` user channel.
 RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
  && nix-channel --update \
- && nix-env -iA nixpkgs.nodejs_20 nixpkgs.gnumake
+ && nix-env -iA nixpkgs.nodejs_20 nixpkgs.gnumake nixpkgs.openssh
 
 ENV PATH="/root/.nix-profile/bin:${PATH}"
 
 RUN npm install -g @anthropic-ai/claude-code
+
+# Capture the resolved Claude CLI path at build time and bake it as
+# CLAUDE_CLI_PATH so runtime resolution can't drift if PATH changes
+# under us. Also fail the build loud if the install didn't actually
+# put `claude` on PATH (the runtime "PermissionError: ''" failure mode
+# is much harder to debug than a build-time missing-binary error).
+RUN set -eux \
+ && CLAUDE_BIN="$(command -v claude)" \
+ && test -x "${CLAUDE_BIN}" \
+ && claude --version \
+ && printf 'CLAUDE_CLI_PATH=%s\n' "${CLAUDE_BIN}" > /etc/socmate.env
+
+# sshd setup so RunPod / interactive users can ssh in (and the web
+# terminal works because PID 1 stays alive even after the pipeline
+# exits -- see runpod_entrypoint.sh's pipeline keep-alive). Host keys
+# are baked into the image; per-deploy authorized_keys is written by
+# the entrypoint from the PUBLIC_KEY env var.
+RUN mkdir -p /etc/ssh /var/run/sshd /run/sshd /root/.ssh \
+ && chmod 700 /root/.ssh \
+ && ssh-keygen -A \
+ && { \
+        echo "Port 22"; \
+        echo "PermitRootLogin prohibit-password"; \
+        echo "PasswordAuthentication no"; \
+        echo "PubkeyAuthentication yes"; \
+        echo "AuthorizedKeysFile /root/.ssh/authorized_keys"; \
+        echo "ChallengeResponseAuthentication no"; \
+        echo "UsePAM no"; \
+        echo "PrintMotd no"; \
+        echo "AcceptEnv LANG LC_*"; \
+    } > /etc/ssh/sshd_config
 
 # -----------------------------------------------------------------------------
 # Python venv + socmate deps. Done in two layers so a code-only edit

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,42 +53,50 @@ FROM ghcr.io/efabless/openlane2:2.3.10 AS socmate
 # without a default `nixpkgs` user channel.
 RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
  && nix-channel --update \
- && nix-env -iA nixpkgs.nodejs_20 nixpkgs.gnumake nixpkgs.openssh
+ && nix-env -iA \
+        nixpkgs.nodejs_20 \
+        nixpkgs.gnumake \
+        nixpkgs.openssh \
+        nixpkgs.patchelf \
+        nixpkgs.gcc-unwrapped.lib
 
 ENV PATH="/root/.nix-profile/bin:${PATH}"
 
 # Nix-built Node sets npm's default prefix into the read-only Nix store,
 # so `npm install -g` "succeeds" (the package extracts) but the bin
-# symlink can't land anywhere on PATH -- `which claude` then comes back
-# empty, the orchestrator Popens cmd[0]="" and the pipeline crashes
-# deep inside generate_uarch_spec. Pin the prefix to a writable dir we
-# explicitly put on PATH so global installs are actually usable.
+# symlink can't land anywhere on PATH. Pin the prefix to a writable
+# dir we explicitly put on PATH so global installs are actually usable.
 ENV NPM_CONFIG_PREFIX=/opt/npm-global
 ENV PATH="/opt/npm-global/bin:${PATH}"
 
 RUN mkdir -p /opt/npm-global \
  && npm install -g @anthropic-ai/claude-code
 
-# Rewrite the npm-installed `claude` launcher's shebang to the absolute
-# path of the nix-profile node binary. The default `#!/usr/bin/env node`
-# shebang is fragile: the openlane2 nix base may not ship /usr/bin/env,
-# /usr/bin/env may be a stale symlink to a /nix/store path that no
-# longer exists, or env may not have node on its PATH at exec time. An
-# absolute interpreter path side-steps all of those.
+# `npm install -g @anthropic-ai/claude-code` ships a Bun-compiled
+# native ELF (claude.exe) on Linux x64, NOT a JS script. The openlane2
+# nix base has no /lib64/ld-linux-x86-64.so.2 at the FHS path, so any
+# alien ELF dies with the kernel's opaque "required file not found"
+# error before its main runs. Two fixes layered:
 #
-# `npm install -g` may create the bin as either a symlink to the
-# package's cli.js or as a small wrapper script -- handle both by
-# resolving the symlink first and rewriting the shebang on the actual
-# script we end up exec'ing.
+#   1. patchelf the binary's ELF interpreter and rpath to point at the
+#      nix-profile glibc + libstdc++/libgcc dirs.
+#   2. Symlink /lib64/ld-linux-x86-64.so.2 -> nix-profile loader, as a
+#      belt-and-suspenders for any other ELF that lands in this image.
 RUN set -eux \
- && NODE_BIN="$(command -v node)" \
- && CLAUDE_LINK="/opt/npm-global/bin/claude" \
+ && CLAUDE_LINK=/opt/npm-global/bin/claude \
  && CLAUDE_REAL="$(readlink -f "${CLAUDE_LINK}")" \
- && echo "node=${NODE_BIN}  claude_link=${CLAUDE_LINK}  claude_real=${CLAUDE_REAL}" \
- && test -f "${CLAUDE_REAL}" \
- && head -1 "${CLAUDE_REAL}" \
- && sed -i "1c#!${NODE_BIN}" "${CLAUDE_REAL}" \
- && head -1 "${CLAUDE_REAL}"
+ && GLIBC_LIBC="$(readlink -f /root/.nix-profile/lib/libc.so.6)" \
+ && GLIBC_DIR="$(dirname "${GLIBC_LIBC}")" \
+ && LD_LINUX="${GLIBC_DIR}/ld-linux-x86-64.so.2" \
+ && GCC_LIB_DIR="$(dirname "$(readlink -f /root/.nix-profile/lib/libstdc++.so.6 2>/dev/null || readlink -f /root/.nix-profile/lib/libgcc_s.so.1)")" \
+ && echo "claude_real=${CLAUDE_REAL}  ld=${LD_LINUX}  glibc_dir=${GLIBC_DIR}  gcc_dir=${GCC_LIB_DIR}" \
+ && test -e "${LD_LINUX}" \
+ && mkdir -p /lib64 \
+ && ln -sf "${LD_LINUX}" /lib64/ld-linux-x86-64.so.2 \
+ && patchelf \
+        --set-interpreter "${LD_LINUX}" \
+        --set-rpath "${GLIBC_DIR}:${GCC_LIB_DIR}" \
+        "${CLAUDE_REAL}"
 
 # Capture the resolved Claude CLI path at build time and bake it as
 # CLAUDE_CLI_PATH so runtime resolution can't drift if PATH changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,14 @@ RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
         nixpkgs.gnumake \
         nixpkgs.openssh \
         nixpkgs.musl \
+        nixpkgs.gcc \
  # Pull verilator from nixos-unstable so we get >= 5.036; the openlane2
  # base ships 5.018 which cocotb 2.0+ refuses ("cocotb requires
  # Verilator 5.036 or later"). Our PATH (set below) puts
  # /root/.nix-profile/bin before the base's verilator dir so this wins.
+ # nixpkgs.gcc bundles gcc + g++; verilator shells out to `g++` to
+ # compile the simulator binary and the openlane2 base does not put a
+ # C++ compiler on PATH for non-yosys subprocesses.
  && nix-env -iA nixos-unstable.verilator
 
 ENV PATH="/root/.nix-profile/bin:${PATH}"
@@ -64,10 +68,15 @@ ENV PATH="/root/.nix-profile/bin:${PATH}"
 # Verify the unstable-channel verilator is on PATH and >= 5.036
 # (cocotb >= 2.0 requires it). Fails the build loud if PATH ordering
 # accidentally resurfaces the openlane2 base's stale 5.018.
+# Also verify g++ is reachable -- verilator shells out to it to
+# compile the testbench simulator and the missing-compiler error
+# only surfaces when sim runs, which is too late.
 RUN set -eux \
  && which verilator \
  && verilator --version \
- && verilator --version | python3 -c "import sys,re; v=sys.stdin.read().strip(); m=re.search(r'(\d+)\.(\d+)', v); maj,min=int(m.group(1)),int(m.group(2)); assert (maj,min) >= (5,36), f'verilator too old: {v}'; print(f'verilator OK: {v}')"
+ && verilator --version | python3 -c "import sys,re; v=sys.stdin.read().strip(); m=re.search(r'(\d+)\.(\d+)', v); maj,min=int(m.group(1)),int(m.group(2)); assert (maj,min) >= (5,36), f'verilator too old: {v}'; print(f'verilator OK: {v}')" \
+ && which g++ \
+ && g++ --version | head -1
 
 # Make the musl ELF interpreter resolvable at the FHS path the binary
 # is hard-linked against. nix's musl ships ld-musl-x86_64.so.1 which is

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@
 #     socmate:latest
 
 # -----------------------------------------------------------------------------
-# Base: efabless/openlane:2024.10.18 ships Yosys, OpenROAD, Magic, netgen,
+# Base: efabless/openlane:1.0.0 ships Yosys, OpenROAD, Magic, netgen,
 # KLayout and the Sky130 PDK on a Debian/Ubuntu userland (~5 GB compressed,
 # ~15 GB extracted). The Debian base matters: the npm-published Claude CLI
 # is now a Bun-compiled native ELF that expects a standard FHS dynamic
@@ -43,7 +43,7 @@
 # laptop. Codespaces users should pull the published image instead of
 # building from source, or use a larger Codespace machine.
 # -----------------------------------------------------------------------------
-FROM efabless/openlane:2024.10.18 AS socmate
+FROM efabless/openlane:1.0.0 AS socmate
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_MAJOR=20

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,30 @@ RUN set -eux \
 # exits -- see runpod_entrypoint.sh's pipeline keep-alive). Host keys
 # are baked into the image; per-deploy authorized_keys is written by
 # the entrypoint from the PUBLIC_KEY env var.
-RUN mkdir -p /etc/ssh /var/run/sshd /run/sshd /root/.ssh \
+#
+# Three quirks of the openlane2 nix-only base we work around here:
+#   1. No `sshd` privsep user exists -- nix's openssh refuses to start
+#      without one ("Privilege separation user sshd does not exist").
+#      We add it via useradd; UsePrivilegeSeparation=no would also work
+#      but is deprecated in modern OpenSSH.
+#   2. No /bin/bash -- the openlane2 base ships only nix-store paths,
+#      so RunPod's `docker exec /bin/bash` (used by their SSH proxy
+#      and web terminal) fails. Symlink to the nix-store bash.
+#   3. /var/empty (the privsep chroot) must exist and be root-owned.
+RUN BASH_BIN="$(command -v bash)" \
+ && test -x "${BASH_BIN}" \
+ && ln -sf "${BASH_BIN}" /bin/bash \
+ && if ! getent passwd sshd >/dev/null 2>&1; then \
+        if command -v useradd >/dev/null 2>&1; then \
+            useradd -r -M -d /var/empty -s /usr/sbin/nologin sshd; \
+        else \
+            echo 'sshd:x:74:74:Privilege-separated SSH:/var/empty:/usr/sbin/nologin' >> /etc/passwd \
+         && echo 'sshd:x:74:' >> /etc/group; \
+        fi; \
+    fi \
+ && mkdir -p /etc/ssh /var/run/sshd /run/sshd /root/.ssh /var/empty \
  && chmod 700 /root/.ssh \
+ && chmod 755 /var/empty \
  && ssh-keygen -A \
  && { \
         echo "Port 22"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,14 +46,28 @@
 FROM ghcr.io/efabless/openlane2:2.3.10 AS socmate
 
 RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
+ && nix-channel --add https://nixos.org/channels/nixos-unstable nixos-unstable \
  && nix-channel --update \
  && nix-env -iA \
         nixpkgs.nodejs_20 \
         nixpkgs.gnumake \
         nixpkgs.openssh \
-        nixpkgs.musl
+        nixpkgs.musl \
+ # Pull verilator from nixos-unstable so we get >= 5.036; the openlane2
+ # base ships 5.018 which cocotb 2.0+ refuses ("cocotb requires
+ # Verilator 5.036 or later"). Our PATH (set below) puts
+ # /root/.nix-profile/bin before the base's verilator dir so this wins.
+ && nix-env -iA nixos-unstable.verilator
 
 ENV PATH="/root/.nix-profile/bin:${PATH}"
+
+# Verify the unstable-channel verilator is on PATH and >= 5.036
+# (cocotb >= 2.0 requires it). Fails the build loud if PATH ordering
+# accidentally resurfaces the openlane2 base's stale 5.018.
+RUN set -eux \
+ && which verilator \
+ && verilator --version \
+ && verilator --version | python3 -c "import sys,re; v=sys.stdin.read().strip(); m=re.search(r'(\d+)\.(\d+)', v); maj,min=int(m.group(1)),int(m.group(2)); assert (maj,min) >= (5,36), f'verilator too old: {v}'; print(f'verilator OK: {v}')"
 
 # Make the musl ELF interpreter resolvable at the FHS path the binary
 # is hard-linked against. nix's musl ships ld-musl-x86_64.so.1 which is
@@ -134,6 +148,18 @@ RUN BASH_BIN="$(command -v bash)" \
  && chmod 700 /root/.ssh \
  && chmod 755 /var/empty \
  && ssh-keygen -A \
+ # The openlane2 base leaves root with `!` in /etc/shadow (locked
+ # password placeholder). nix-built openssh checks shadow even with
+ # `PermitRootLogin without-password` and rejects pubkey auth as
+ # "User root not allowed because account is locked". Replace `!` with
+ # `*` (no-password, but not locked) so pubkey auth is permitted.
+ # We use python because sed/passwd/usermod aren't on the base PATH.
+ && python3 -c "p='/etc/shadow'; t=open(p).read(); open(p,'w').write(t.replace('root:!:','root:*:',1))" \
+ # Locate sftp-server from the nix openssh package so SCP/SFTP work
+ # over our sshd (`Subsystem sftp` is required; otherwise scp gets
+ # "subsystem request failed"). Symlink for sshd_config stability.
+ && SFTP_SERVER="$(find /nix/store -path '*openssh*/libexec/sftp-server' -type f 2>/dev/null | head -1)" \
+ && test -x "${SFTP_SERVER}" \
  && { \
         echo "Port 22"; \
         echo "PermitRootLogin prohibit-password"; \
@@ -144,6 +170,7 @@ RUN BASH_BIN="$(command -v bash)" \
         echo "UsePAM no"; \
         echo "PrintMotd no"; \
         echo "AcceptEnv LANG LC_*"; \
+        echo "Subsystem sftp ${SFTP_SERVER}"; \
     } > /etc/ssh/sshd_config
 
 # -----------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,24 +66,35 @@ ENV PATH="/root/.nix-profile/bin:${PATH}"
 ENV NPM_CONFIG_PREFIX=/opt/npm-global
 ENV PATH="/opt/npm-global/bin:${PATH}"
 
-# The openlane2 nix base doesn't ship the standard /usr/bin/env, so
-# scripts whose shebang is `#!/usr/bin/env node` (which is what
-# `claude` from npm uses) fail to exec with "required file not found"
-# even when both env and node are present further up in PATH. Symlink
-# from the nix profile to the conventional location, idempotently.
-RUN if [ ! -e /usr/bin/env ]; then \
-        mkdir -p /usr/bin && \
-        ln -s "$(command -v env)" /usr/bin/env; \
-    fi
-
 RUN mkdir -p /opt/npm-global \
  && npm install -g @anthropic-ai/claude-code
 
+# Rewrite the npm-installed `claude` launcher's shebang to the absolute
+# path of the nix-profile node binary. The default `#!/usr/bin/env node`
+# shebang is fragile: the openlane2 nix base may not ship /usr/bin/env,
+# /usr/bin/env may be a stale symlink to a /nix/store path that no
+# longer exists, or env may not have node on its PATH at exec time. An
+# absolute interpreter path side-steps all of those.
+#
+# `npm install -g` may create the bin as either a symlink to the
+# package's cli.js or as a small wrapper script -- handle both by
+# resolving the symlink first and rewriting the shebang on the actual
+# script we end up exec'ing.
+RUN set -eux \
+ && NODE_BIN="$(command -v node)" \
+ && CLAUDE_LINK="/opt/npm-global/bin/claude" \
+ && CLAUDE_REAL="$(readlink -f "${CLAUDE_LINK}")" \
+ && echo "node=${NODE_BIN}  claude_link=${CLAUDE_LINK}  claude_real=${CLAUDE_REAL}" \
+ && test -f "${CLAUDE_REAL}" \
+ && head -1 "${CLAUDE_REAL}" \
+ && sed -i "1c#!${NODE_BIN}" "${CLAUDE_REAL}" \
+ && head -1 "${CLAUDE_REAL}"
+
 # Capture the resolved Claude CLI path at build time and bake it as
 # CLAUDE_CLI_PATH so runtime resolution can't drift if PATH changes
-# under us. Also fail the build loud if the install didn't actually
-# put `claude` on PATH (the runtime "PermissionError: ''" failure mode
-# is much harder to debug than a build-time missing-binary error).
+# under us. Also fail the build loud if `claude --version` fails (the
+# runtime "PermissionError: ''" failure mode is much harder to debug
+# than a build-time missing-binary error).
 RUN set -eux \
  && CLAUDE_BIN="$(command -v claude)" \
  && test -x "${CLAUDE_BIN}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,17 @@ ENV PATH="/root/.nix-profile/bin:${PATH}"
 # explicitly put on PATH so global installs are actually usable.
 ENV NPM_CONFIG_PREFIX=/opt/npm-global
 ENV PATH="/opt/npm-global/bin:${PATH}"
+
+# The openlane2 nix base doesn't ship the standard /usr/bin/env, so
+# scripts whose shebang is `#!/usr/bin/env node` (which is what
+# `claude` from npm uses) fail to exec with "required file not found"
+# even when both env and node are present further up in PATH. Symlink
+# from the nix profile to the conventional location, idempotently.
+RUN if [ ! -e /usr/bin/env ]; then \
+        mkdir -p /usr/bin && \
+        ln -s "$(command -v env)" /usr/bin/env; \
+    fi
+
 RUN mkdir -p /opt/npm-global \
  && npm install -g @anthropic-ai/claude-code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,56 +28,73 @@
 #     socmate:latest
 
 # -----------------------------------------------------------------------------
-# Base: efabless/openlane:1.0.0 ships Yosys, OpenROAD, Magic, netgen,
-# KLayout and the Sky130 PDK on a Debian/Ubuntu userland (~5 GB compressed,
-# ~15 GB extracted). The Debian base matters: the npm-published Claude CLI
-# is now a Bun-compiled native ELF that expects a standard FHS dynamic
-# linker at /lib64/ld-linux-x86-64.so.2, which Nix-built images don't ship.
-# We previously tried `ghcr.io/efabless/openlane2:2.3.10` (Nix, ~1.5 GB)
-# and ended up with brittle patchelf / glibc-symlink hacks; the Debian
-# base just runs claude.exe directly without any of that.
+# Base: ghcr.io/efabless/openlane2 is a Nix-built image (~1.5 GB compressed)
+# that bundles Yosys, OpenROAD, Magic, netgen, KLayout, Verilator, iverilog
+# and OpenSTA already on PATH, plus a Python 3.11 environment. We layer
+# Node + the Claude CLI on top via the image's bundled Nix.
 #
-# Disk impact: this base no longer fits a default 32 GB Codespace
-# (`docker build` hits ~25 GB cap). It does fit GHA `ubuntu-latest` after
-# the disk-cleanup step in publish-image.yml, RunPod, and any normal
-# laptop. Codespaces users should pull the published image instead of
-# building from source, or use a larger Codespace machine.
+# All efabless/openlane* images are Nix-only -- there is no Debian-based
+# variant to fall back on. Earlier builds tried patching the glibc ELF
+# (`@anthropic-ai/claude-code-linux-x64`); it segfaulted because the
+# Bun-compiled binary's glibc ABI assumptions don't survive the move
+# from FHS to nix-store paths even after patchelf. The musl variant
+# (`@anthropic-ai/claude-code-linux-x64-musl`) is dynamically linked
+# against /lib/ld-musl-x86_64.so.1, which on musl is also the libc --
+# one symlink to nixpkgs.musl resolves the entire dependency, no
+# patchelf needed.
 # -----------------------------------------------------------------------------
-FROM efabless/openlane:1.0.0 AS socmate
+FROM ghcr.io/efabless/openlane2:2.3.10 AS socmate
 
-ARG DEBIAN_FRONTEND=noninteractive
-ARG NODE_MAJOR=20
+RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
+ && nix-channel --update \
+ && nix-env -iA \
+        nixpkgs.nodejs_20 \
+        nixpkgs.gnumake \
+        nixpkgs.openssh \
+        nixpkgs.musl
 
-# OpenLane's image runs as a non-root UID 1000; switch to root for
-# package installs and the layered changes below.
-USER root
+ENV PATH="/root/.nix-profile/bin:${PATH}"
 
-# System packages -- single layer to keep the apt cache tight.
-#
-# - ca-certificates curl git gnupg make sudo: build essentials
-# - openssh-server: lets the entrypoint stand up sshd when PUBLIC_KEY is
-#   set (RunPod web terminal + ssh from anywhere)
-# - python3.11 + venv: the orchestrator pins 3.11; the openlane base ships
-#   only python3.6 so we install fresh from apt
-# - verilator: lint + sim driver for the RTL phase
-# - nodejs: just for npm so we can install the Claude CLI; Node 20 LTS
-#   from NodeSource (the Debian-shipped Node is too old for the CLI)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl git gnupg make sudo \
-        openssh-server \
-        python3.11 python3.11-venv python3-pip \
-        verilator \
-    && curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
+# Make the musl ELF interpreter resolvable at the FHS path the binary
+# is hard-linked against. nix's musl ships ld-musl-x86_64.so.1 which is
+# also the libc; one symlink covers both. Without this, every musl
+# binary on this image dies with the kernel's "required file not found".
+RUN MUSL_LD="$(find /nix/store -maxdepth 4 -name 'ld-musl-x86_64.so.1' \
+        \( -type f -o -type l \) 2>/dev/null | head -1)" \
+ && test -n "${MUSL_LD}" \
+ && mkdir -p /lib \
+ && ln -sf "${MUSL_LD}" /lib/ld-musl-x86_64.so.1 \
+ && echo "musl_ld=${MUSL_LD}"
 
-RUN npm install -g @anthropic-ai/claude-code
+# Nix-built Node sets npm's default prefix into the read-only Nix store,
+# so `npm install -g` "succeeds" but the bin can't symlink anywhere on
+# PATH. Pin the prefix to a writable dir we explicitly put on PATH.
+ENV NPM_CONFIG_PREFIX=/opt/npm-global
+ENV PATH="/opt/npm-global/bin:${PATH}"
+
+# Install the wrapper package + the Linux-x64-musl native variant
+# explicitly. Setting `--include=optional` and listing the musl
+# subpackage by name forces the right binary regardless of what
+# install.cjs's runtime detection thinks (Nix Node is glibc-built so
+# `process.report` would otherwise pick the glibc variant).
+RUN mkdir -p /opt/npm-global \
+ && npm install -g \
+        @anthropic-ai/claude-code \
+        @anthropic-ai/claude-code-linux-x64-musl
+
+# `npm install -g`'s postinstall on the wrapper package may have copied
+# the glibc binary over bin/claude.exe (because Nix Node is glibc-
+# built). Force-replace bin/claude with a symlink to the musl-variant's
+# native binary so we use the version that actually runs on this image.
+RUN set -eux \
+ && MUSL_BIN=/opt/npm-global/lib/node_modules/@anthropic-ai/claude-code-linux-x64-musl/claude \
+ && test -x "${MUSL_BIN}" \
+ && ln -sf "${MUSL_BIN}" /opt/npm-global/bin/claude
 
 # Capture the resolved Claude CLI path at build time and bake it as
 # CLAUDE_CLI_PATH so runtime resolution can't drift if PATH changes
 # under us. Also fail the build loud if `claude --version` fails -- the
-# runtime "PermissionError: ''" failure mode is much harder to debug
-# than a build-time missing-binary error.
+# runtime "PermissionError: ''" failure mode is much harder to debug.
 RUN set -eux \
  && CLAUDE_BIN="$(command -v claude)" \
  && test -x "${CLAUDE_BIN}" \
@@ -89,22 +106,28 @@ RUN set -eux \
 # exits -- see runpod_entrypoint.sh's pipeline keep-alive). Host keys
 # are baked into the image; per-deploy authorized_keys is written by
 # the entrypoint from the PUBLIC_KEY env var.
-RUN mkdir -p /var/run/sshd /run/sshd /root/.ssh \
+RUN mkdir -p /etc/ssh /var/run/sshd /run/sshd /root/.ssh \
  && chmod 700 /root/.ssh \
  && ssh-keygen -A \
- && sed -i \
-        -e 's|^#\?\s*PermitRootLogin.*|PermitRootLogin prohibit-password|' \
-        -e 's|^#\?\s*PasswordAuthentication.*|PasswordAuthentication no|' \
-        -e 's|^#\?\s*PubkeyAuthentication.*|PubkeyAuthentication yes|' \
-        -e 's|^#\?\s*UsePAM.*|UsePAM no|' \
-        /etc/ssh/sshd_config
+ && { \
+        echo "Port 22"; \
+        echo "PermitRootLogin prohibit-password"; \
+        echo "PasswordAuthentication no"; \
+        echo "PubkeyAuthentication yes"; \
+        echo "AuthorizedKeysFile /root/.ssh/authorized_keys"; \
+        echo "ChallengeResponseAuthentication no"; \
+        echo "UsePAM no"; \
+        echo "PrintMotd no"; \
+        echo "AcceptEnv LANG LC_*"; \
+    } > /etc/ssh/sshd_config
 
 # -----------------------------------------------------------------------------
 # Python venv + socmate deps. Done in two layers so a code-only edit
-# doesn't bust the dependency cache.
+# doesn't bust the dependency cache. The base image's python3 is 3.11.9 so
+# we use it directly (no deadsnakes / system Python dance).
 # -----------------------------------------------------------------------------
 ENV VIRTUAL_ENV=/opt/socmate-venv
-RUN python3.11 -m venv "${VIRTUAL_ENV}"
+RUN python3 -m venv "${VIRTUAL_ENV}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 WORKDIR /socmate
@@ -132,10 +155,10 @@ RUN pip install volare \
         "${SKY130_PDK_COMMIT}"
 
 # -----------------------------------------------------------------------------
-# Tool wrappers: the openlane base exposes yosys / openroad / magic /
-# netgen / klayout / verilator at the bare names on $PATH, so the
-# scripts/*-nix.sh wrappers just need to exec the real binary. Override
-# config.yaml to point at bare names.
+# Tool wrappers: openlane2 already exposes yosys / openroad / magic / netgen
+# / klayout / verilator at the bare names on $PATH, so the scripts/*-nix.sh
+# wrappers just need to exec the real binary. We override config.yaml to
+# point at bare names.
 # -----------------------------------------------------------------------------
 RUN python3 -c "import yaml, pathlib; \
 p = pathlib.Path('orchestrator/config.yaml'); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,84 +28,56 @@
 #     socmate:latest
 
 # -----------------------------------------------------------------------------
-# Base: ghcr.io/efabless/openlane2 is a Nix-built image (~1.5 GB compressed)
-# that bundles Yosys, OpenROAD, Magic, netgen, KLayout, Verilator, iverilog
-# and OpenSTA already on PATH, plus a Python 3.11 environment. We layer
-# Node + the Claude CLI on top via the official Node tarball (the image has
-# no apt) and a per-project venv for the orchestrator deps.
+# Base: efabless/openlane:2024.10.18 ships Yosys, OpenROAD, Magic, netgen,
+# KLayout and the Sky130 PDK on a Debian/Ubuntu userland (~5 GB compressed,
+# ~15 GB extracted). The Debian base matters: the npm-published Claude CLI
+# is now a Bun-compiled native ELF that expects a standard FHS dynamic
+# linker at /lib64/ld-linux-x86-64.so.2, which Nix-built images don't ship.
+# We previously tried `ghcr.io/efabless/openlane2:2.3.10` (Nix, ~1.5 GB)
+# and ended up with brittle patchelf / glibc-symlink hacks; the Debian
+# base just runs claude.exe directly without any of that.
 #
-# Why not the IIC-OSIC-TOOLS or efabless/openlane:1.x image? They're 5 GB+
-# compressed, ~15 GB extracted, and overflow the 32 GB Codespaces disk
-# during `docker buildx build` -- the build then falls through to the
-# alpine recovery container.
+# Disk impact: this base no longer fits a default 32 GB Codespace
+# (`docker build` hits ~25 GB cap). It does fit GHA `ubuntu-latest` after
+# the disk-cleanup step in publish-image.yml, RunPod, and any normal
+# laptop. Codespaces users should pull the published image instead of
+# building from source, or use a larger Codespace machine.
 # -----------------------------------------------------------------------------
-FROM ghcr.io/efabless/openlane2:2.3.10 AS socmate
+FROM efabless/openlane:2024.10.18 AS socmate
 
-# The image already runs as root with /nix/store on PATH, so we don't need
-# USER/WORKDIR juggling. We *do* need Node + npm for the Claude CLI;
-# openlane2 doesn't bundle Node, so we install via the image's bundled
-# Nix (a multi-stage COPY from node:20-slim doesn't work because that
-# binary needs /lib/x86_64-linux-gnu/libc.so.6 which the Nix-only base
-# doesn't provide).
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=20
+
+# OpenLane's image runs as a non-root UID 1000; switch to root for
+# package installs and the layered changes below.
+USER root
+
+# System packages -- single layer to keep the apt cache tight.
 #
-# `nix-env -iA nixpkgs.nodejs_20` installs into /root/.nix-profile/bin;
-# we add a channel first because the openlane2 image is built declaratively
-# without a default `nixpkgs` user channel.
-RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
- && nix-channel --update \
- && nix-env -iA \
-        nixpkgs.nodejs_20 \
-        nixpkgs.gnumake \
-        nixpkgs.openssh \
-        nixpkgs.patchelf \
-        nixpkgs.glibc \
-        nixpkgs.gcc-unwrapped.lib
+# - ca-certificates curl git gnupg make sudo: build essentials
+# - openssh-server: lets the entrypoint stand up sshd when PUBLIC_KEY is
+#   set (RunPod web terminal + ssh from anywhere)
+# - python3.11 + venv: the orchestrator pins 3.11; the openlane base ships
+#   only python3.6 so we install fresh from apt
+# - verilator: lint + sim driver for the RTL phase
+# - nodejs: just for npm so we can install the Claude CLI; Node 20 LTS
+#   from NodeSource (the Debian-shipped Node is too old for the CLI)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg make sudo \
+        openssh-server \
+        python3.11 python3.11-venv python3-pip \
+        verilator \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/root/.nix-profile/bin:${PATH}"
-
-# Nix-built Node sets npm's default prefix into the read-only Nix store,
-# so `npm install -g` "succeeds" (the package extracts) but the bin
-# symlink can't land anywhere on PATH. Pin the prefix to a writable
-# dir we explicitly put on PATH so global installs are actually usable.
-ENV NPM_CONFIG_PREFIX=/opt/npm-global
-ENV PATH="/opt/npm-global/bin:${PATH}"
-
-RUN mkdir -p /opt/npm-global \
- && npm install -g @anthropic-ai/claude-code
-
-# `npm install -g @anthropic-ai/claude-code` ships a Bun-compiled
-# native ELF (claude.exe) on Linux x64, NOT a JS script. The openlane2
-# nix base has no /lib64/ld-linux-x86-64.so.2 at the FHS path, so any
-# alien ELF dies with the kernel's opaque "required file not found"
-# error before its main runs. Two fixes layered:
-#
-#   1. patchelf the binary's ELF interpreter and rpath to point at the
-#      nix-profile glibc + libstdc++/libgcc dirs.
-#   2. Symlink /lib64/ld-linux-x86-64.so.2 -> nix-profile loader, as a
-#      belt-and-suspenders for any other ELF that lands in this image.
-RUN set -eux \
- && CLAUDE_LINK=/opt/npm-global/bin/claude \
- && CLAUDE_REAL="$(readlink -f "${CLAUDE_LINK}")" \
- && LD_LINUX="$(find /nix/store -maxdepth 4 -name 'ld-linux-x86-64.so.2' \
-        \( -type f -o -type l \) 2>/dev/null | head -1)" \
- && GLIBC_DIR="$(dirname "${LD_LINUX}")" \
- && GCC_LIB_DIR="$(dirname "$(readlink -f /root/.nix-profile/lib/libstdc++.so.6 2>/dev/null \
-        || readlink -f /root/.nix-profile/lib/libgcc_s.so.1)")" \
- && echo "claude_real=${CLAUDE_REAL}  ld=${LD_LINUX}  glibc_dir=${GLIBC_DIR}  gcc_dir=${GCC_LIB_DIR}" \
- && test -n "${LD_LINUX}" \
- && test -e "${LD_LINUX}" \
- && mkdir -p /lib64 \
- && ln -sf "${LD_LINUX}" /lib64/ld-linux-x86-64.so.2 \
- && patchelf \
-        --set-interpreter "${LD_LINUX}" \
-        --set-rpath "${GLIBC_DIR}:${GCC_LIB_DIR}" \
-        "${CLAUDE_REAL}"
+RUN npm install -g @anthropic-ai/claude-code
 
 # Capture the resolved Claude CLI path at build time and bake it as
 # CLAUDE_CLI_PATH so runtime resolution can't drift if PATH changes
-# under us. Also fail the build loud if `claude --version` fails (the
+# under us. Also fail the build loud if `claude --version` fails -- the
 # runtime "PermissionError: ''" failure mode is much harder to debug
-# than a build-time missing-binary error).
+# than a build-time missing-binary error.
 RUN set -eux \
  && CLAUDE_BIN="$(command -v claude)" \
  && test -x "${CLAUDE_BIN}" \
@@ -117,28 +89,22 @@ RUN set -eux \
 # exits -- see runpod_entrypoint.sh's pipeline keep-alive). Host keys
 # are baked into the image; per-deploy authorized_keys is written by
 # the entrypoint from the PUBLIC_KEY env var.
-RUN mkdir -p /etc/ssh /var/run/sshd /run/sshd /root/.ssh \
+RUN mkdir -p /var/run/sshd /run/sshd /root/.ssh \
  && chmod 700 /root/.ssh \
  && ssh-keygen -A \
- && { \
-        echo "Port 22"; \
-        echo "PermitRootLogin prohibit-password"; \
-        echo "PasswordAuthentication no"; \
-        echo "PubkeyAuthentication yes"; \
-        echo "AuthorizedKeysFile /root/.ssh/authorized_keys"; \
-        echo "ChallengeResponseAuthentication no"; \
-        echo "UsePAM no"; \
-        echo "PrintMotd no"; \
-        echo "AcceptEnv LANG LC_*"; \
-    } > /etc/ssh/sshd_config
+ && sed -i \
+        -e 's|^#\?\s*PermitRootLogin.*|PermitRootLogin prohibit-password|' \
+        -e 's|^#\?\s*PasswordAuthentication.*|PasswordAuthentication no|' \
+        -e 's|^#\?\s*PubkeyAuthentication.*|PubkeyAuthentication yes|' \
+        -e 's|^#\?\s*UsePAM.*|UsePAM no|' \
+        /etc/ssh/sshd_config
 
 # -----------------------------------------------------------------------------
 # Python venv + socmate deps. Done in two layers so a code-only edit
-# doesn't bust the dependency cache. The base image's python3 is 3.11.9 so
-# we use it directly (no deadsnakes / system Python dance).
+# doesn't bust the dependency cache.
 # -----------------------------------------------------------------------------
 ENV VIRTUAL_ENV=/opt/socmate-venv
-RUN python3 -m venv "${VIRTUAL_ENV}"
+RUN python3.11 -m venv "${VIRTUAL_ENV}"
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 WORKDIR /socmate
@@ -166,10 +132,10 @@ RUN pip install volare \
         "${SKY130_PDK_COMMIT}"
 
 # -----------------------------------------------------------------------------
-# Tool wrappers: openlane2 already exposes yosys / openroad / magic / netgen
-# / klayout / verilator at the bare names on $PATH, so the scripts/*-nix.sh
-# wrappers just need to exec the real binary. We override config.yaml to
-# point at bare names.
+# Tool wrappers: the openlane base exposes yosys / openroad / magic /
+# netgen / klayout / verilator at the bare names on $PATH, so the
+# scripts/*-nix.sh wrappers just need to exec the real binary. Override
+# config.yaml to point at bare names.
 # -----------------------------------------------------------------------------
 RUN python3 -c "import yaml, pathlib; \
 p = pathlib.Path('orchestrator/config.yaml'); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
         nixpkgs.gnumake \
         nixpkgs.openssh \
         nixpkgs.patchelf \
+        nixpkgs.glibc \
         nixpkgs.gcc-unwrapped.lib
 
 ENV PATH="/root/.nix-profile/bin:${PATH}"
@@ -85,11 +86,13 @@ RUN mkdir -p /opt/npm-global \
 RUN set -eux \
  && CLAUDE_LINK=/opt/npm-global/bin/claude \
  && CLAUDE_REAL="$(readlink -f "${CLAUDE_LINK}")" \
- && GLIBC_LIBC="$(readlink -f /root/.nix-profile/lib/libc.so.6)" \
- && GLIBC_DIR="$(dirname "${GLIBC_LIBC}")" \
- && LD_LINUX="${GLIBC_DIR}/ld-linux-x86-64.so.2" \
- && GCC_LIB_DIR="$(dirname "$(readlink -f /root/.nix-profile/lib/libstdc++.so.6 2>/dev/null || readlink -f /root/.nix-profile/lib/libgcc_s.so.1)")" \
+ && LD_LINUX="$(find /nix/store -maxdepth 4 -name 'ld-linux-x86-64.so.2' \
+        \( -type f -o -type l \) 2>/dev/null | head -1)" \
+ && GLIBC_DIR="$(dirname "${LD_LINUX}")" \
+ && GCC_LIB_DIR="$(dirname "$(readlink -f /root/.nix-profile/lib/libstdc++.so.6 2>/dev/null \
+        || readlink -f /root/.nix-profile/lib/libgcc_s.so.1)")" \
  && echo "claude_real=${CLAUDE_REAL}  ld=${LD_LINUX}  glibc_dir=${GLIBC_DIR}  gcc_dir=${GCC_LIB_DIR}" \
+ && test -n "${LD_LINUX}" \
  && test -e "${LD_LINUX}" \
  && mkdir -p /lib64 \
  && ln -sf "${LD_LINUX}" /lib64/ld-linux-x86-64.so.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,13 +72,16 @@ RUN MUSL_LD="$(find /nix/store -maxdepth 4 -name 'ld-musl-x86_64.so.1' \
 ENV NPM_CONFIG_PREFIX=/opt/npm-global
 ENV PATH="/opt/npm-global/bin:${PATH}"
 
-# Install the wrapper package + the Linux-x64-musl native variant
-# explicitly. Setting `--include=optional` and listing the musl
-# subpackage by name forces the right binary regardless of what
-# install.cjs's runtime detection thinks (Nix Node is glibc-built so
-# `process.report` would otherwise pick the glibc variant).
+# Install the wrapper package + the Linux-x64-musl native variant.
+# `--libc=musl` lies to npm's resolver about the host libc so it
+# accepts the musl subpackage (Nix Node is glibc-built, so npm would
+# otherwise reject it with EBADPLATFORM). `--force` is belt-and-braces
+# in case the resolver still complains. The wrapper's install.cjs
+# postinstall will still pick the glibc variant for bin/claude.exe
+# because it reads process.report.glibcVersionRuntime directly -- the
+# RUN below replaces that with a symlink to the musl binary.
 RUN mkdir -p /opt/npm-global \
- && npm install -g \
+ && npm install -g --force --libc=musl \
         @anthropic-ai/claude-code \
         @anthropic-ai/claude-code-linux-x64-musl
 

--- a/orchestrator/langchain/agents/integration_testbench_generator.py
+++ b/orchestrator/langchain/agents/integration_testbench_generator.py
@@ -125,21 +125,36 @@ class IntegrationTestbenchGenerator:
                 run_name=f"Integration Testbench [{design_name}]",
             )
 
+            # Don't trust ClaudeLLM.call to raise on CLI failure -- it
+            # returns an error string in the output position. Validate
+            # the response actually contains a Python code block with
+            # @cocotb.test() functions before claiming success; the
+            # previous max(test_count, 1) lied to downstream SIM.
             testbench = self._extract_python(content)
             test_count = len(re.findall(r"@cocotb\.test\(\)", testbench))
 
-            written_path = ""
-            if testbench and output_path:
-                out = Path(output_path)
-                out.parent.mkdir(parents=True, exist_ok=True)
-                out.write_text(testbench, encoding="utf-8")
-                written_path = output_path
+            if not testbench or test_count == 0:
+                raise RuntimeError(
+                    f"Integration testbench generation failed: "
+                    f"claude CLI returned no usable Python code block "
+                    f"with @cocotb.test() functions"
+                )
+            if not output_path:
+                raise RuntimeError(
+                    "Integration testbench generation failed: no "
+                    "output_path provided; cannot persist the testbench"
+                )
 
-            span.set_attribute("test_count", max(test_count, 1))
+            out = Path(output_path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(testbench, encoding="utf-8")
+            written_path = output_path
+
+            span.set_attribute("test_count", test_count)
 
             return {
                 "tb_path": written_path,
-                "test_count": max(test_count, 1),
+                "test_count": test_count,
             }
 
     def _extract_python(self, content: str) -> str:

--- a/orchestrator/langchain/agents/socmate_llm.py
+++ b/orchestrator/langchain/agents/socmate_llm.py
@@ -432,11 +432,12 @@ class ClaudeLLM:
         if not self.claude_path:
             self.claude_path = os.environ.get("CLAUDE_CLI_PATH", "")
             if not self.claude_path:
-                try:
-                    self.claude_path = _find_claude_binary()
-                    logger.info(f"Found Claude CLI at: {self.claude_path}")
-                except FileNotFoundError as e:
-                    logger.error(str(e))
+                # Let FileNotFoundError propagate -- we'd rather crash
+                # `__init__` clearly than leave self.claude_path empty
+                # and Popen with cmd[0]="" later, which surfaces as the
+                # opaque ``PermissionError: [Errno 13] Permission denied: ''``.
+                self.claude_path = _find_claude_binary()
+                logger.info(f"Found Claude CLI at: {self.claude_path}")
 
     async def call(
         self,

--- a/orchestrator/langchain/agents/testbench_generator.py
+++ b/orchestrator/langchain/agents/testbench_generator.py
@@ -108,13 +108,27 @@ class TestbenchGeneratorAgent:
                 run_name=run_name,
             )
 
+            # ClaudeLLM.call swallows non-zero exits (returns an error
+            # string instead of raising), so post-validate that the CLI
+            # actually wrote a real testbench. Without this check the
+            # downstream SIM step sees no file and logs the misleading
+            # "Skipped -- testbench file not found", and the previous
+            # max(test_count, 1) pretended the step generated 1 test.
             tb_file = Path(testbench_path) if testbench_path else None
-            test_count = 0
-            if tb_file and tb_file.exists():
-                tb_text = tb_file.read_text()
-                test_count = len(re.findall(r"@cocotb\.test\(\)", tb_text))
+            if not tb_file or not tb_file.exists():
+                raise RuntimeError(
+                    f"Testbench generation failed: claude CLI did not "
+                    f"write {testbench_path}"
+                )
+            tb_text = tb_file.read_text()
+            test_count = len(re.findall(r"@cocotb\.test\(\)", tb_text))
+            if test_count == 0:
+                raise RuntimeError(
+                    f"Testbench at {testbench_path} contains no "
+                    f"@cocotb.test() functions"
+                )
 
             return {
                 "testbench_path": testbench_path,
-                "test_count": max(test_count, 1),
+                "test_count": test_count,
             }

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -739,12 +739,23 @@ async def generate_testbench_node(state: BlockState) -> dict:
             log(f"  [TB] Using existing (fresh): {block['testbench']}", GREEN)
         else:
             log("  [TB] Generating cocotb testbench...", YELLOW)
-            tb_result = await generate_testbench(
-                block,
-                callbacks=_callbacks(state),
-            )
-            test_count = tb_result.get("test_count", "?")
-            log(f"  [TB] Generated ({test_count} tests)", GREEN)
+            try:
+                tb_result = await generate_testbench(
+                    block,
+                    callbacks=_callbacks(state),
+                )
+            except RuntimeError as exc:
+                # The agent now raises if claude CLI failed to write
+                # a usable testbench. Fall through to the SIM-skipped
+                # path (preserves the existing retry semantics) but
+                # log the actual reason instead of a misleading
+                # "Generated (N tests)" / "testbench file not found"
+                # mirage.
+                log(f"  [TB] Generation failed: {exc}", RED)
+                tb_result = {"test_count": 0}
+            else:
+                test_count = tb_result.get("test_count", "?")
+                log(f"  [TB] Generated ({test_count} tests)", GREEN)
 
         tb_path = str(tb_path_obj)
 

--- a/scripts/runpod_entrypoint.sh
+++ b/scripts/runpod_entrypoint.sh
@@ -24,8 +24,25 @@
 #   SOCMATE_MODEL=sonnet-4.6   Pin a specific model (short name or full ID)
 #   SOCMATE_REQUIREMENTS_FILE  Path to a text file with architecture requirements
 #                              (used in mcp / pipeline modes that need a starter prompt)
+#   PUBLIC_KEY                 SSH public key to install for root. If set, the
+#                              entrypoint starts sshd in the background so the
+#                              container is reachable on port 22 (RunPod sets
+#                              this automatically from the pod template).
+#   SOCMATE_KEEP_ALIVE=1       In pipeline mode, keep the container running
+#                              after the pipeline exits (so SSH / RunPod web
+#                              terminal can still attach for inspection).
+#                              Implied when PUBLIC_KEY is set.
 
 set -euo pipefail
+
+# Pick up build-time-baked env (currently: CLAUDE_CLI_PATH so the orchestrator
+# can't fail to resolve `claude` if a downstream PATH munge drops the nix
+# profile dir).
+if [[ -f /etc/socmate.env ]]; then
+    # shellcheck disable=SC1091
+    . /etc/socmate.env
+    [[ -n "${CLAUDE_CLI_PATH:-}" ]] && export CLAUDE_CLI_PATH
+fi
 
 # --- Project root -----------------------------------------------------------
 PROJECT_ROOT="${SOCMATE_PROJECT_ROOT:-/socmate}"
@@ -33,6 +50,32 @@ cd "${PROJECT_ROOT}"
 
 mode="${SOCMATE_MODE:-shell}"
 echo "[socmate] entrypoint: mode=${mode} project_root=${PROJECT_ROOT}"
+
+# --- Optional sshd bootstrap (RunPod / interactive use) ---------------------
+# Started for every mode -- harmless if no PUBLIC_KEY is set (returns early).
+maybe_start_sshd() {
+    if [[ -z "${PUBLIC_KEY:-}" ]]; then
+        return 0
+    fi
+    local sshd_bin
+    sshd_bin="$(command -v sshd 2>/dev/null || true)"
+    if [[ -z "${sshd_bin}" ]]; then
+        echo "[socmate] PUBLIC_KEY set but sshd not installed; skipping ssh setup" >&2
+        return 0
+    fi
+    mkdir -p /root/.ssh /var/run/sshd /run/sshd
+    chmod 700 /root/.ssh
+    if ! grep -qxF "${PUBLIC_KEY}" /root/.ssh/authorized_keys 2>/dev/null; then
+        printf '%s\n' "${PUBLIC_KEY}" >> /root/.ssh/authorized_keys
+    fi
+    chmod 600 /root/.ssh/authorized_keys
+    if "${sshd_bin}"; then
+        echo "[socmate] sshd started on :22 (PUBLIC_KEY accepted)"
+    else
+        echo "[socmate] sshd failed to start (rc=$?)" >&2
+    fi
+}
+maybe_start_sshd
 
 # --- Auth check (skipped in shell mode so users can poke around) ------------
 require_auth() {
@@ -102,8 +145,30 @@ case "${mode}" in
     pipeline)
         require_auth
         run_preflight
-        echo "[socmate] starting frontend pipeline (run_pipeline.py)"
-        exec python3 run_pipeline.py "$@"
+        log_file="${SOCMATE_PIPELINE_LOG:-/socmate/.socmate/pipeline.log}"
+        mkdir -p "$(dirname "${log_file}")"
+        echo "[socmate] starting frontend pipeline (run_pipeline.py); log -> ${log_file}"
+
+        # Run the pipeline with stdout/stderr teed to a persistent log on
+        # the volume. Using `set +e` + PIPESTATUS so a non-zero pipeline
+        # rc doesn't kill the script before the keep-alive branch.
+        set +e
+        python3 run_pipeline.py "$@" 2>&1 | tee "${log_file}"
+        rc=${PIPESTATUS[0]}
+        set -e
+        echo "[socmate] pipeline exited rc=${rc}"
+
+        # Keep PID 1 alive on RunPod (PUBLIC_KEY set) or when the operator
+        # explicitly opts in via SOCMATE_KEEP_ALIVE=1, so SSH and the
+        # RunPod web terminal can still attach for post-mortem. For plain
+        # `docker run` users with neither set, exit cleanly with the
+        # pipeline's rc.
+        if [[ "${SOCMATE_KEEP_ALIVE:-0}" == "1" ]] || [[ -n "${PUBLIC_KEY:-}" ]]; then
+            echo "[socmate] keeping container alive for inspection (rc=${rc})."
+            echo "[socmate] tailing ${log_file} as PID 1; ssh in to inspect state."
+            exec tail -F "${log_file}"
+        fi
+        exit "${rc}"
         ;;
 
     mcp)


### PR DESCRIPTION
## Summary

Makes the published `ghcr.io/facebookexperimental/socmate:latest` image actually usable on RunPod (and anywhere else that consumes the prebuilt image) by fixing four runtime issues that were silently breaking it on the openlane2 Nix-only base. Stack of 15 commits is the trial-and-error history of getting `claude` to run on a base with no glibc-FHS layout; the end state is the musl-variant approach below.

### What changed

**`Dockerfile` (+150 lines)**
- **Claude CLI runtime** — install `@anthropic-ai/claude-code-linux-x64-musl` and force-symlink `bin/claude` at it. The glibc variant the wrapper picks by default segfaults on this base because the Bun-compiled binary's glibc ABI assumptions don't survive the move from FHS to nix-store paths even after `patchelf`. `nixpkgs.musl` is added; `/lib/ld-musl-x86_64.so.1` is symlinked at the FHS path the binary is hard-linked against.
- **`sshd` foothold** — `nixpkgs.openssh` installed; sshd privsep user added; host keys generated; hardened `sshd_config` baked (port 22, `PermitRootLogin prohibit-password`, no PAM, sftp subsystem from the nix-store path). Root unlocked in `/etc/shadow` (`!` → `*`) so pubkey auth isn't blocked.
- **`/bin/bash`** — symlinked to nix-store bash. RunPod's web terminal and `docker exec /bin/bash` both fail without it on a nix-only base.
- **Verilator ≥ 5.036** — pulled from `nixos-unstable` (openlane2 ships 5.018, which cocotb 2.0+ refuses). Build-time guard fails loud if PATH ordering accidentally resurfaces the stale 5.018.
- **`gcc` / `g++`** — verilator shells out to `g++` to compile the simulator binary; the openlane2 base doesn't put a C++ compiler on PATH for non-yosys subprocesses, so sim was failing late.
- **`CLAUDE_CLI_PATH` baked at build time** into `/etc/socmate.env` so runtime resolution can't drift if PATH changes.

**`scripts/runpod_entrypoint.sh` (+50 lines)**
- New `maybe_start_sshd` — if `PUBLIC_KEY` is set (RunPod sets it from the pod template), writes it to `/root/.ssh/authorized_keys` and starts `sshd` in the background.
- New keep-alive in `pipeline` mode — if `PUBLIC_KEY` or `SOCMATE_KEEP_ALIVE=1` is set, tails the pipeline log as PID 1 instead of exiting, so SSH and the RunPod web terminal can still attach for post-mortem.
- Sources `/etc/socmate.env` so `CLAUDE_CLI_PATH` is exported.

**Orchestrator fixes (3 commits at the tip)**
- `testbench_generator.py` / `integration_testbench_generator.py` — stop swallowing CLI failures.
- `pipeline_graph.py` — catch TB-gen `RuntimeError` in pipeline node, preserve SIM-skip retry path.

## Test plan

- [ ] `Publish image` workflow on merge produces a new `:latest` whose `docker run --rm socmate:latest claude --version` succeeds (current `:latest` segfaults).
- [ ] `docker run -e PUBLIC_KEY=... -p 2222:22 socmate:latest` accepts ssh on :22 with the pubkey.
- [ ] On RunPod with this image, `make pipeline` runs end-to-end on adder8.
- [ ] `make preflight` inside the container reports `verilator >= 5.036` and `g++` resolvable.
- [ ] Codespaces continues to build (PR doesn't change devcontainer.json).

## Follow-ups (not in this PR)

- `feat/devcontainer-use-published-image` — flips codespace to consume the fixed `:latest` post-merge, plus a `postCreateCommand` to start sshd inside codespaces too. Will open after this lands and `:latest` is republished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
