### PR TITLE
Symlink sshd at /usr/sbin/sshd so gh codespace ssh works

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,17 +36,6 @@
         }
     },
 
-    // Start sshd inside the codespace so `gh codespace ssh` works.
-    // The image (from fix/runpod-supervisor) installs openssh, the sshd
-    // privsep user, host keys, and a hardened sshd_config -- but its
-    // ENTRYPOINT is bypassed by the Codespaces VS Code agent, so the
-    // RunPod-side `maybe_start_sshd` never runs here. This hook fills
-    // that gap. Failure is non-fatal (`|| true`) so a future image
-    // without sshd doesn't break codespace creation; GitHub injects the
-    // user's pubkey into authorized_keys automatically once a listener
-    // is reachable.
-    "postCreateCommand": "sshd 2>/dev/null || true",
-
     // Run preflight on attach so users know immediately whether the
     // toolchain came up correctly. This does NOT call the LLM; it just
     // checks that the PDK and EDA binaries exist on $PATH.

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,9 +142,23 @@ RUN set -eux \
 #      so RunPod's `docker exec /bin/bash` (used by their SSH proxy
 #      and web terminal) fails. Symlink to the nix-store bash.
 #   3. /var/empty (the privsep chroot) must exist and be root-owned.
+#   4. No /usr/sbin/sshd -- the GitHub Codespaces agent does its
+#      "is sshd installed?" check by stat'ing standard FHS paths
+#      (/usr/sbin/sshd, /usr/bin/ssh-keygen). Without these symlinks
+#      it logs "Please check if an SSH server is installed" and
+#      `gh codespace ssh` is dead even though sshd is on $PATH.
+#      Same workaround as #1/#2: symlink the nix-store binary at
+#      the FHS path the consumer expects.
 RUN BASH_BIN="$(command -v bash)" \
+ && SSHD_BIN="$(command -v sshd)" \
+ && SSH_KEYGEN_BIN="$(command -v ssh-keygen)" \
  && test -x "${BASH_BIN}" \
+ && test -x "${SSHD_BIN}" \
+ && test -x "${SSH_KEYGEN_BIN}" \
  && ln -sf "${BASH_BIN}" /bin/bash \
+ && mkdir -p /usr/sbin /usr/bin \
+ && ln -sf "${SSHD_BIN}" /usr/sbin/sshd \
+ && ln -sf "${SSH_KEYGEN_BIN}" /usr/bin/ssh-keygen \
  && if ! getent passwd sshd >/dev/null 2>&1; then \
         if command -v useradd >/dev/null 2>&1; then \
             useradd -r -M -d /var/empty -s /usr/sbin/nologin sshd; \


### PR DESCRIPTION
## Summary

Even after #9 (sshd installed) and #10 (codespace consumes published image), `gh codespace ssh` still fails with:

> error getting ssh server details: failed to start SSH server:
> Please check if an SSH server is installed in the container.

### Root cause

The Codespaces agent's "is sshd installed?" check stats standard FHS paths (`/usr/sbin/sshd`, `/usr/bin/ssh-keygen`) rather than walking `$PATH`. The openlane2 nix-only base ships **neither directory** — `sshd` lives at `/root/.nix-profile/bin/sshd` via the user-environment profile, and `/usr/sbin` doesn't even exist as a directory in the merged filesystem (verified by streaming `docker export` and grepping the tar entries).

```
counts: etc/ssh=8 usr/sbin= usr/bin=2 sbin= var/run/sshd=1 var/empty=1
```

So the agent gives up before it can attempt to start the server. Same shape of bug as the `/bin/bash` workaround already in the Dockerfile (RunPod's SSH proxy `docker exec /bin/bash`'d into a directory that didn't exist either).

### Fix

`Dockerfile`: in the existing sshd-setup `RUN` block, resolve `sshd` and `ssh-keygen` via `command -v`, create `/usr/sbin` and `/usr/bin`, and symlink the nix-store binaries at the FHS paths the consumer expects.

```dockerfile
 && SSHD_BIN="$(command -v sshd)" \
 && SSH_KEYGEN_BIN="$(command -v ssh-keygen)" \
 ...
 && mkdir -p /usr/sbin /usr/bin \
 && ln -sf "${SSHD_BIN}" /usr/sbin/sshd \
 && ln -sf "${SSH_KEYGEN_BIN}" /usr/bin/ssh-keygen \
```

`.devcontainer/devcontainer.json`: drop the speculative `"postCreateCommand": "sshd 2>/dev/null || true"` line added in #10. The Codespaces agent invokes `sshd` itself once it finds the binary; running a second instance from `postCreate` would just contend for port 22 and never accept the GitHub-injected key anyway.

## Test plan

- [ ] After merge + `Publish image` rebuild of `:latest`, click the README Codespaces badge → fresh codespace reaches Available.
- [ ] `gh codespace ssh -c <name> -- 'whoami; uname -m; claude --version; cd /socmate && make preflight'` succeeds end-to-end (was returning the "no SSH server" error in #10).
- [ ] RunPod path unaffected — `runpod_entrypoint.sh`'s `maybe_start_sshd` already resolves `sshd` via `command -v`, doesn't depend on the FHS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
