### PR TITLE
Timeout multiplier + disk-first uarch + RTL reasoning budget + opencode shim + dep bumps

### DIFF
--- a/examples/expgolomb_enc/blocks.yaml
+++ b/examples/expgolomb_enc/blocks.yaml
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Exp-Golomb encoder block — the variable-length coding (VLC) stage of an
+# H.264-style intra image codec. Compatible with the bitstream format
+# produced/consumed by github.com/balbekov/PyH264 (specifically the
+# expgolomb_enc / expgolomb_dec functions in h264/VLC.py).
+#
+# This block does NOT do DCT, quantization, or intra-prediction — those
+# stay in Python (the testbench uses PyH264.TransformBlock to produce
+# quantized coefficients, then drives this block coefficient-by-coefficient).
+# The roundtrip is closed in software: PyH264.VLC.expgolomb_dec consumes
+# the bits this hardware emits.
+
+blocks:
+  expgolomb_enc:
+    tier: 1
+    rtl_target: "rtl/expgolomb_enc/expgolomb_enc.v"
+    testbench: "tb/cocotb/test_expgolomb_enc.py"
+    description: |
+      Single-coefficient Exp-Golomb encoder for an H.264-style intra image
+      codec. Consumes ONE signed integer coefficient per handshake and
+      emits its variable-length codeword as (codeword, length) pair.
+      Bit-exact compatible with PyH264's VLC.expgolomb_enc/dec (see
+      golden model below).
+
+      Encoding rule (PyH264 expgolomb_enc semantics):
+        value 0           -> '1'
+        positive value N  -> let codenum = 2*N - 1
+        negative value N  -> let codenum = 2*|N|
+        emit:   (count_bits-1) zeros, then bin(codenum + 1)
+                where count_bits = number of bits in bin(codenum + 1)
+        Examples:
+              N=0  -> '1'         (length 1)
+              N=1  -> '010'       (length 3)
+              N=-1 -> '011'       (length 3)
+              N=2  -> '00100'     (length 5)
+              N=-2 -> '00101'     (length 5)
+              N=3  -> '00110'     (length 5)
+              N=4  -> '0001000'   (length 7)
+
+      Coefficient magnitude is bounded — after DCT+quant in PyH264 with
+      QP=26 on natural images, |coefficient| typically <= 512, well within
+      a 12-bit signed range. The block ACCEPTS a 16-bit signed input port
+      but the spec guarantees output fits in a 32-bit codeword + 6-bit
+      length. (Worst case: |value|=32767 -> codenum 65535 -> 33-bit code.
+      The block must FLAG via err_o for any input whose codeword would
+      exceed 32 bits, and emit a safe zero-length output for that beat.)
+
+      Module interface (top-level expgolomb_enc, AXI-Stream both sides):
+        input              clk
+        input              rst_n        -- active-low synchronous reset
+        // Input stream: one signed coefficient per beat
+        input  [15:0]      s_tdata      -- signed 16-bit coefficient
+        input              s_tvalid
+        output             s_tready
+        // Output stream: one codeword per accepted input beat
+        output [31:0]      m_tdata      -- packed codeword, MSB-aligned
+                                           (bit 31 = first transmitted bit;
+                                           bits 31 down to (32-m_tlen) are
+                                           valid; bits below that are 0)
+        output [5:0]       m_tlen       -- number of valid bits in m_tdata
+                                           (1..32; for input 0 this is 1)
+        output             m_tvalid
+        input              m_tready
+        output             err_o        -- 1-cycle pulse when an input
+                                           required a codeword > 32 bits
+                                           (output for that beat is zeroed)
+
+      Latency: 1 clock from accepted s_tvalid to m_tvalid (single-cycle
+      combinational encode would be acceptable but a registered output is
+      preferred for timing). Throughput: 1 coefficient per cycle when
+      downstream is ready (m_tready high).
+
+      Constraints (Sky130 sky130_fd_sc_hd):
+        - Verilog-2005, synchronous design only
+        - No async resets, no latches, no tri-states
+        - Reset is active-low SYNCHRONOUS on rst_n
+        - Implementation hint: the codeword for codenum X is just
+          bin(X+1) with (bitlen(X+1)-1) leading zeros — so length is
+          2*bitlen(codenum+1)-1, and the codeword bits are simply
+          codenum+1 with the leading 1 included. A combinational
+          priority-encoder on (codenum+1) gives both pieces in one shot.
+        - 8-bit barrel shifter / leading-one-detect on a 17-bit value is
+          enough (max codenum+1 fits in 17 bits for the 32-bit-output
+          guarantee; anything wider trips err_o).

--- a/examples/expgolomb_enc/expgolomb_enc_model.py
+++ b/examples/expgolomb_enc/expgolomb_enc_model.py
@@ -1,0 +1,56 @@
+"""Python golden model for expgolomb_enc — bit-exact to PyH264.VLC.expgolomb_enc.
+
+Interface mirrors the Verilog block's per-coefficient encode call so the
+cocotb testbench can compare DUT output against this on every beat.
+"""
+from __future__ import annotations
+
+
+def _encode_one(value: int) -> tuple[int, int]:
+    """Return (codeword_msb_aligned, length_bits) for one int16 coefficient.
+
+    codeword bit (31) is the first transmitted bit; bits below
+    (32 - length_bits) are zero. length_bits is 1..32 (0 → length=1, code='1').
+    Returns (0, 0) for any value whose codeword would exceed 32 bits.
+    """
+    if value == 0:
+        codenum = 0
+    elif value > 0:
+        codenum = 2 * value - 1
+    else:
+        codenum = -2 * value
+
+    coded = codenum + 1  # bin(coded) starts with the leading '1'
+    nbits = coded.bit_length()
+    length = 2 * nbits - 1  # (nbits - 1) leading zeros + nbits-bit binary
+    if length > 32:
+        return (0, 0)
+    codeword_msb = coded << (32 - length)
+    return (codeword_msb & 0xFFFFFFFF, length)
+
+
+def encode(value: int) -> tuple[int, int]:
+    """Public name for the testbench."""
+    return _encode_one(int(value))
+
+
+def expected_bitstring(value: int) -> str:
+    """Return the codeword as a '0'/'1' string (used to cross-check PyH264 LUT)."""
+    cw, length = _encode_one(value)
+    if length == 0:
+        return ""
+    return format(cw >> (32 - length), f"0{length}b")
+
+
+# Sanity self-test (matches the table in blocks.yaml)
+_SELF_TEST = {
+    0: "1", 1: "010", -1: "011",
+    2: "00100", -2: "00101",
+    3: "00110", -3: "00111",
+    4: "0001000", -4: "0001001",
+}
+if __name__ == "__main__":
+    for v, want in _SELF_TEST.items():
+        got = expected_bitstring(v)
+        assert got == want, f"value={v} got={got} want={want}"
+    print("OK — golden matches PyH264 reference table")

--- a/orchestrator/_timeouts.py
+++ b/orchestrator/_timeouts.py
@@ -1,0 +1,44 @@
+"""Single source of truth for socmate's subprocess timeouts.
+
+Every long-running LLM / EDA tool call goes through one of these helpers so
+that a single environment variable -- SOCMATE_TIMEOUT_MULTIPLIER -- can scale
+every timeout in the pipeline at once.  This is the easiest knob to turn for
+slow local models (e.g. Qwen 3.6 27B at ~25 tok/s on a single RTX PRO 6000,
+which can need 22+ minutes for a single UARCH spec versus Claude's ~3 minutes).
+
+Usage::
+
+    from orchestrator._timeouts import scaled
+
+    proc = subprocess.run(cmd, timeout=scaled(1200))
+    # or with an existing per-site env override:
+    proc = subprocess.run(cmd, timeout=scaled(1800, env="SOCMATE_TB_TIMEOUT"))
+
+Setting SOCMATE_TIMEOUT_MULTIPLIER=3 triples every timeout for the run.
+The per-site env vars still win for the *base* value, the multiplier is
+applied on top.
+"""
+from __future__ import annotations
+
+import os
+
+
+def multiplier() -> float:
+    """Read SOCMATE_TIMEOUT_MULTIPLIER fresh each call so live env changes
+    take effect on the next subprocess invocation (the multiplier isn't
+    cached at module-import time)."""
+    try:
+        return float(os.environ.get("SOCMATE_TIMEOUT_MULTIPLIER", "1.0"))
+    except ValueError:
+        return 1.0
+
+
+def scaled(base_seconds: float, env: str | None = None) -> int:
+    """Return base_seconds (or env override) multiplied by the timeout
+    multiplier.  Always returns an int because most subprocess APIs prefer it."""
+    if env:
+        try:
+            base_seconds = float(os.environ.get(env, str(base_seconds)))
+        except ValueError:
+            pass
+    return int(base_seconds * multiplier())

--- a/orchestrator/langchain/agents/integration_testbench_generator.py
+++ b/orchestrator/langchain/agents/integration_testbench_generator.py
@@ -135,9 +135,9 @@ class IntegrationTestbenchGenerator:
 
             if not testbench or test_count == 0:
                 raise RuntimeError(
-                    f"Integration testbench generation failed: "
-                    f"claude CLI returned no usable Python code block "
-                    f"with @cocotb.test() functions"
+                    "Integration testbench generation failed: "
+                    "claude CLI returned no usable Python code block "
+                    "with @cocotb.test() functions"
                 )
             if not output_path:
                 raise RuntimeError(

--- a/orchestrator/langchain/agents/opencode_patch.py
+++ b/orchestrator/langchain/agents/opencode_patch.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 from orchestrator._timeouts import scaled
-import json
 import logging
 import os
 import shutil

--- a/orchestrator/langchain/agents/opencode_patch.py
+++ b/orchestrator/langchain/agents/opencode_patch.py
@@ -1,0 +1,81 @@
+# Minimal monkey-patch: replace ClaudeLLM._generate_via_cli with an opencode equivalent.
+# Drop this into orchestrator/langchain/agents/ as opencode_patch.py and import it from
+# wherever you'd normally import ClaudeLLM (or use sitecustomize.py to auto-load it).
+
+from __future__ import annotations
+from orchestrator._timeouts import scaled
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+
+from orchestrator.langchain.agents import socmate_llm as _slm
+
+logger = logging.getLogger(__name__)
+
+# Find opencode binary (npm-global install puts it at /usr/local/bin/opencode)
+_OPENCODE_PATH = shutil.which("opencode") or "/usr/local/bin/opencode"
+
+# How socmate names models -> what opencode calls them.
+# socmate config.yaml lets you pin per-agent models; map them to whatever local
+# provider you've registered in ~/.config/opencode/opencode.json.
+# Examples assume a "local" provider pointing at a vLLM endpoint with
+# Qwen/Qwen3.6-27B registered.
+_MODEL_MAP = {
+    "claude-opus-4-7":            "local/Qwen/Qwen3.6-27B",
+    "claude-sonnet-4-6":          "local/Qwen/Qwen3.6-27B",
+    "claude-haiku-4-5-20251001":  "local/Qwen/Qwen3.6-27B",
+}
+
+
+def _opencode_call(self, system_prompt: str, user_prompt: str) -> str:
+    """Drop-in for ClaudeLLM._generate_via_cli, backed by `opencode run`."""
+    resolved = _slm._resolve_model(self.model)
+    opencode_model = _MODEL_MAP.get(resolved, "local/Qwen/Qwen3.6-27B")
+
+    # opencode doesn't have --system-prompt; prepend as a system marker.
+    full_prompt = (
+        f"<system>{system_prompt}</system>\n\n{user_prompt}"
+        if system_prompt else user_prompt
+    )
+
+    cmd = [
+        _OPENCODE_PATH,
+        "run",
+        "--model", opencode_model,
+        # opencode run reads positional message args
+        full_prompt,
+    ]
+    logger.info("opencode invocation: model=%s prompt_len=%d", opencode_model, len(full_prompt))
+
+    t0 = time.monotonic()
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=scaled(self._STALL_THRESHOLD_S),
+        cwd=os.environ.get("SOCMATE_PROJECT_ROOT", os.getcwd()),
+    )
+    elapsed = time.monotonic() - t0
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"opencode failed (rc={proc.returncode}, t={elapsed:.1f}s): "
+            f"{proc.stderr[:500]}"
+        )
+
+    # opencode run prints the assistant's final reply to stdout in default mode.
+    # Strip TUI escape sequences.
+    import re
+    text = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", proc.stdout).strip()
+
+    logger.info("opencode reply: chars=%d elapsed=%.1fs", len(text), elapsed)
+    return text
+
+
+# Monkey-patch
+_slm.ClaudeLLM._generate_via_cli = _opencode_call
+_slm.ClaudeLLM.claude_path = _OPENCODE_PATH  # bypass the "Claude CLI not found" check
+logger.warning("ClaudeLLM._generate_via_cli has been monkey-patched to use opencode")

--- a/orchestrator/langchain/agents/socmate_llm.py
+++ b/orchestrator/langchain/agents/socmate_llm.py
@@ -32,6 +32,8 @@ import threading
 import time as _time_mod
 from pathlib import Path
 
+from orchestrator._timeouts import scaled
+
 logger = logging.getLogger(__name__)
 
 
@@ -505,7 +507,10 @@ class ClaudeLLM:
     # Stall detection: if no new stdout/stderr output for this many seconds
     # the process is likely hung on a permission prompt or similar.
     # Set to 1200s (20 min) for slower specialist calls (clock tree, memory map, etc.)
-    _STALL_THRESHOLD_S: int = 1200
+    # Scaled by SOCMATE_TIMEOUT_MULTIPLIER (default 1.0) so slow local models
+    # like Qwen 3.6 27B (~25 tok/s on a single RTX PRO 6000) can finish
+    # their 25-30K-token reasoning + write trajectories without being killed.
+    _STALL_THRESHOLD_S: int = 1200  # scaled by scaled() at use sites; see orchestrator._timeouts
     # How often to poll the subprocess and emit heartbeat events.
     _POLL_INTERVAL_S: float = 2.0
     # Heartbeat events are written every N poll cycles (to avoid log spam).
@@ -802,7 +807,7 @@ class ClaudeLLM:
 
                 # Stall detection (no output activity)
                 stall_time = _time_mod.monotonic() - last_activity
-                if stall_time > self._STALL_THRESHOLD_S:
+                if stall_time > scaled(self._STALL_THRESHOLD_S):
                     partial = "".join(stderr_chunks + stdout_chunks)
                     logger.error(
                         "Claude CLI stalled for %.0fs with no output (pid=%d). "

--- a/orchestrator/langchain/agents/testbench_generator.py
+++ b/orchestrator/langchain/agents/testbench_generator.py
@@ -17,7 +17,6 @@ Strategy:
 from __future__ import annotations
 
 from orchestrator._timeouts import scaled
-import os
 import re
 from pathlib import Path
 from typing import Any

--- a/orchestrator/langchain/agents/testbench_generator.py
+++ b/orchestrator/langchain/agents/testbench_generator.py
@@ -16,6 +16,7 @@ Strategy:
 
 from __future__ import annotations
 
+from orchestrator._timeouts import scaled
 import os
 import re
 from pathlib import Path
@@ -49,7 +50,7 @@ class TestbenchGeneratorAgent:
         # whose testbenches need many turns of tool use.
         self.llm = ClaudeLLM(
             model=model,
-            timeout=int(os.environ.get("SOCMATE_TB_TIMEOUT", "1800")),
+            timeout=scaled(1800, env="SOCMATE_TB_TIMEOUT"),
         )
 
     async def generate(

--- a/orchestrator/langchain/agents/timing_closure.py
+++ b/orchestrator/langchain/agents/timing_closure.py
@@ -17,6 +17,7 @@ All modifications are traced via OpenTelemetry for auditability.
 
 from __future__ import annotations
 
+from orchestrator._timeouts import scaled
 import json
 import os
 import re
@@ -79,7 +80,7 @@ class TimingClosureAgent:
     def __init__(self, model: str = DEFAULT_MODEL, temperature: float = 0.1):
         self.llm = ClaudeLLM(
             model=model,
-            timeout=int(os.environ.get("SOCMATE_TIMING_CLOSURE_TIMEOUT", "2700")),
+            timeout=scaled(2700, env="SOCMATE_TIMING_CLOSURE_TIMEOUT"),
         )
 
     async def fix_timing(

--- a/orchestrator/langchain/agents/timing_closure.py
+++ b/orchestrator/langchain/agents/timing_closure.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from orchestrator._timeouts import scaled
 import json
-import os
 import re
 from pathlib import Path
 from typing import Any

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -16,6 +16,7 @@ before writing Verilog.
 
 from __future__ import annotations
 
+from orchestrator._timeouts import scaled
 import json
 import os
 import re
@@ -46,7 +47,7 @@ class UarchSpecGenerator:
     def __init__(self, model: str = DEFAULT_MODEL, temperature: float = 0.2):
         self.llm = ClaudeLLM(
             model=model,
-            timeout=int(os.environ.get("SOCMATE_UARCH_TIMEOUT", "2700")),
+            timeout=scaled(2700, env="SOCMATE_UARCH_TIMEOUT"),
         )
 
     async def generate(

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from orchestrator._timeouts import scaled
 import json
-import os
 import re
 from pathlib import Path
 from typing import Any

--- a/orchestrator/langchain/prompts/rtl_generator.md
+++ b/orchestrator/langchain/prompts/rtl_generator.md
@@ -8,6 +8,15 @@ constraints, golden model). Write the Verilog output to the path specified
 in the user message. On retry attempts, prefer using Edit to make targeted
 fixes to existing RTL instead of regenerating from scratch.
 
+REASONING BUDGET (CRITICAL):
+- Reason briefly (under ~4 000 tokens of internal thought) before acting.
+- You MUST call the Write tool with the Verilog source within THIS response.
+- DO NOT keep reasoning indefinitely. After deciding the design, COMMIT it
+  to disk via Write. The pipeline checks for the file on disk and will fail
+  this attempt if no Write call lands.
+- Re-derivations and sanity-checks belong in inline Verilog comments, not
+  in continued thought.
+
 RULES:
 1. Output ONLY valid {rtl_language} (no constructs from other HDL variants).
 2. Use AXI-Stream (tdata/tvalid/tready/tlast) for data interfaces.

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -22,6 +22,7 @@ Provides:
 
 from __future__ import annotations
 
+from orchestrator._timeouts import scaled
 import os
 import shutil
 import subprocess
@@ -336,7 +337,22 @@ async def generate_uarch_spec(
     spec_dir = PROJECT_ROOT / ARCH_DOC_DIR / "uarch_specs"
     spec_dir.mkdir(parents=True, exist_ok=True)
     spec_path = spec_dir / f"{block['name']}.md"
-    spec_path.write_text(result["spec_text"])
+    # Disk-first: if the agent wrote a richer spec via its write/edit tool
+    # (e.g. opencode), prefer that on-disk content over the text we got back
+    # through stdout. Only fall back to result["spec_text"] when the disk file
+    # is empty or much smaller than the model's stdout response.
+    spec_returned = result.get("spec_text") or ""
+    if spec_path.exists():
+        on_disk = spec_path.read_text()
+        # If the on-disk file is meaningfully larger than the stdout text,
+        # the agent wrote a real spec via its tools -- keep the disk version
+        # and surface that as the canonical spec.
+        if len(on_disk) > max(len(spec_returned), 256):
+            result["spec_text"] = on_disk
+        else:
+            spec_path.write_text(spec_returned)
+    else:
+        spec_path.write_text(spec_returned)
     result["spec_path"] = str(spec_path)
 
     return result
@@ -397,7 +413,7 @@ def lint_rtl(rtl_path: str, block_name: str, attempt: int = 1) -> dict:
     cmd.append(rtl_path)
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=scaled(60))
         log_path = _write_step_log(block_name, "lint", cmd, result, attempt)
         stderr = result.stderr.strip()
         has_errors = "%Error" in stderr
@@ -484,7 +500,7 @@ include $(shell cocotb-config --makefiles)/Makefile.sim
             [make_bin, "-C", str(sim_dir)],
             capture_output=True,
             text=True,
-            timeout=900,
+            timeout=scaled(900),
             env=env,
         )
         log_path = _write_step_log(block_name, "simulate", [make_bin, "-C", str(sim_dir)], result, attempt)
@@ -623,7 +639,7 @@ write_verilog -noattr {netlist_path}
             ["yosys", "-s", str(script_path)],
             capture_output=True,
             text=True,
-            timeout=1800,
+            timeout=scaled(1800),
         )
 
         gate_count = 0
@@ -713,7 +729,7 @@ async def fix_lint_errors(
     block_title = block_name.replace("_", " ").title()
     llm = ClaudeLLM(
         model=DEFAULT_MODEL,
-        timeout=int(os.environ.get("SOCMATE_LINT_FIX_TIMEOUT", "600")),
+        timeout=scaled(600, env="SOCMATE_LINT_FIX_TIMEOUT"),
     )
 
     try:
@@ -767,7 +783,7 @@ async def fix_synth_errors(
     block_title = block_name.replace("_", " ").title()
     llm = ClaudeLLM(
         model=DEFAULT_MODEL,
-        timeout=int(os.environ.get("SOCMATE_SYNTH_FIX_TIMEOUT", "600")),
+        timeout=scaled(600, env="SOCMATE_SYNTH_FIX_TIMEOUT"),
     )
 
     try:
@@ -836,7 +852,7 @@ async def fix_testbench_errors(
     # didn't address the root cause.
     llm = ClaudeLLM(
         model=DEFAULT_MODEL,
-        timeout=int(os.environ.get("SOCMATE_TB_FIX_TIMEOUT", "600")),
+        timeout=scaled(600, env="SOCMATE_TB_FIX_TIMEOUT"),
     )
 
     try:

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -25,7 +25,7 @@ jsonpatch==1.33
 jsonpointer==3.1.1
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
-langchain-core==1.3.2
+langchain-core==1.3.3
 langchain-protocol==0.0.14
 langgraph==1.1.10
 langgraph-checkpoint==4.0.3
@@ -75,7 +75,7 @@ tenacity==9.1.4
 typing-inspect==0.9.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
-urllib3==2.6.3
+urllib3==2.7.0
 uuid_utils==0.14.1
 uvicorn==0.46.0
 volare==0.20.6


### PR DESCRIPTION
## Summary

Bundle of bench-driven improvements + two Dependabot fixes.

- **`SOCMATE_TIMEOUT_MULTIPLIER`** env knob — single var scales every subprocess timeout in the pipeline at once. Centralises every existing per-site env override under a small helper (`orchestrator/_timeouts.py`). Setting `=3` triples the 20-min stall threshold, the 45-min UARCH cap, the 30-min TB cap, and every fix-loop budget — which is what slower local models like Qwen 3.6 27B at ~25 tok/s on a single GPU need to land a 27K-token reasoning + 8K-token Verilog response.
- **Disk-first uarch spec** in `pipeline_helpers.generate_uarch_spec` — prefer the file the agent wrote via its `Write` tool over the text returned through stdout. Without this, opencode-driven runs would clobber a 5 KB markdown spec with the model's 140-byte chat-channel response (the `<|channel|>thought` leakage we wrote up at [coresmith.ai/blog/qwen-vs-gemma](https://coresmith.ai/blog/qwen-vs-gemma)). Matches what `generate_rtl` already does.
- **RTL reasoning-budget directive** at the top of `prompts/rtl_generator.md` — six lines telling the model to commit a `Write` call within the response and not keep reasoning indefinitely. Cuts Qwen's "no-commit" failure mode roughly in half; harmless for Claude.
- **`opencode_patch.py`** (new, opt-in import) — monkey-patches `ClaudeLLM._generate_via_cli` to subprocess `opencode run` instead of `claude -p`, so the pipeline can target a local vLLM endpoint via opencode's `@ai-sdk/openai-compatible` provider. Maps the Claude model strings socmate's config uses (`claude-opus-4-7`, etc.) onto a local entry in `~/.config/opencode/opencode.json`.
- **`examples/expgolomb_enc/`** — a new tier-1 example block. Single-coefficient Exp-Golomb encoder, bit-exact with [PyH264](https://github.com/balbekov/PyH264). Used as the canonical "small but bit-exactness-critical" target in the local-LLM bench.

## Dependabot fixes folded in
- `langchain-core` 1.3.2 → 1.3.3 — unsafe `load()` allowlists (high)
- `urllib3` 2.6.3 → 2.7.0 — decompression-bomb safeguards + cross-origin header forwarding in proxied redirects (high)

Both transitive; bumping in `requirements-lock.txt` only.

## Test plan

- [ ] `pytest orchestrator/tests/` — expect green.
- [ ] Smoke: `SOCMATE_BLOCKS_FILE=examples/expgolomb_enc/blocks.yaml python run_pipeline.py` with the default multiplier (1.0) under Claude — should land RTL + sim + synth.
- [ ] Smoke: same run with `SOCMATE_TIMEOUT_MULTIPLIER=3` under the opencode shim against a local Qwen 3.6 27B vLLM endpoint — should reproduce the bench result (~75 min wall, 5/7 cocotb tests pass, 0 mismatches on a 16,384-coefficient PyH264 roundtrip).
- [x] Vulnerable lock entries updated; rerun pip-audit shows clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)