### PR TITLE
ci: install Claude Code CLI before running pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Node + Claude CLI
+        # Tests instantiate ClaudeLLM() at import time, which calls
+        # _find_claude_binary() and raises FileNotFoundError when the
+        # `claude` binary is missing from PATH.
+        run: |
+          curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
+          sudo apt-get install -y nodejs
+          sudo npm install -g @anthropic-ai/claude-code
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

CI on `main` has been red on every run since #9 (`8fd1ddf`) merged on 2026-05-10. Example failed run: https://github.com/facebookexperimental/socmate/actions/runs/25703638173

Every failure is the same:

```
FileNotFoundError: Claude CLI not found. Install it with: npm install -g @anthropic-ai/claude-code
```

Root cause: several tests under `orchestrator/tests/` (`test_integration_lead.py`, `test_pipeline_efficiency.py`, `test_pipeline_graph.py`, `test_stability.py`, ...) instantiate `ClaudeLLM()` at module import time. The constructor calls `_find_claude_binary()` in `orchestrator/langchain/agents/socmate_llm.py:363`, which raises `FileNotFoundError` when `claude` isn't on `PATH`. GitHub Actions `ubuntu-latest` runners don't ship with it, so collection blows up before any test runs.

## Change

Add a step to `.github/workflows/ci.yml` that installs Node 22 from NodeSource and globally installs `@anthropic-ai/claude-code` *before* `pip install` / `ruff` / `pytest`. The binary just needs to be discoverable; the tests don't actually shell out to it (they mock or skip the CLI subprocess paths via the `not live_llm` / `not e2e` markers already in use).

Adds roughly 30 s per CI run.

Considered the cleaner alternative of refactoring `_find_claude_binary()` to defer the `FileNotFoundError` until `_generate_via_cli()` actually launches the binary, but that touches `socmate_llm.py` plus several test files and is well over the ~20 LOC threshold worth doing here. Happy to follow up in a separate PR if desired.

## Test plan

- [ ] GitHub Actions `test (3.11)` job is green
- [ ] GitHub Actions `test (3.12)` job is green
- [ ] Lint step still passes

Local `pytest` was not executed in the sandbox because `claude` is not installed there; the failure mode and fix are entirely a CI-environment issue, so the GH Actions run on this PR is the meaningful signal.

Generated with Claude Code.