### PR TITLE
Drop unused DEFAULT_MODEL imports left over from socmate_llm rename

### DIFF
--- a/orchestrator/langchain/agents/debug_agent.py
+++ b/orchestrator/langchain/agents/debug_agent.py
@@ -25,7 +25,7 @@ from typing import Any
 
 from opentelemetry import trace
 
-from .socmate_llm import DEFAULT_MODEL, ClaudeLLM
+from .socmate_llm import ClaudeLLM
 
 _tracer = trace.get_tracer(__name__)
 

--- a/orchestrator/langchain/agents/rtl_generator.py
+++ b/orchestrator/langchain/agents/rtl_generator.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from opentelemetry import trace
 
-from .socmate_llm import DEFAULT_MODEL, ClaudeLLM
+from .socmate_llm import ClaudeLLM
 
 _tracer = trace.get_tracer(__name__)
 

--- a/orchestrator/langchain/agents/testbench_generator.py
+++ b/orchestrator/langchain/agents/testbench_generator.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from opentelemetry import trace
 
-from .socmate_llm import DEFAULT_MODEL, ClaudeLLM
+from .socmate_llm import ClaudeLLM
 
 _tracer = trace.get_tracer(__name__)
 

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from opentelemetry import trace
 
-from .socmate_llm import DEFAULT_MODEL, ClaudeLLM
+from .socmate_llm import ClaudeLLM
 
 _tracer = trace.get_tracer(__name__)
 

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -329,7 +329,6 @@ async def generate_uarch_spec(
     Also writes the spec to ``arch/uarch_specs/<block_name>.md``.
     """
     from orchestrator.langchain.agents.uarch_spec_generator import UarchSpecGenerator
-    from orchestrator.langchain.agents.socmate_llm import DEFAULT_MODEL
 
     python_source_rel = block.get("python_source", "")
     if python_source_rel and python_source_rel.strip():


### PR DESCRIPTION
## Summary
- Removes 5 dead `DEFAULT_MODEL` imports across `orchestrator/langchain/agents/` and `orchestrator/langgraph/pipeline_helpers.py` — leftovers from the `cursor_llm` → `socmate_llm` rename where call-sites moved to `block_model()` or deliberately dropped the `model=` kwarg.
- `ruff check orchestrator/` has been failing on every PR since the rename landed (F401 × 5); this restores a clean lint run.

## Test plan
- [x] `ruff check orchestrator/` — all checks passed locally on this branch
- [ ] CI green on this PR