### PR TITLE
ci: install Claude Code CLI before running pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Node + Claude CLI
+        # Tests instantiate ClaudeLLM() at import time, which calls
+        # _find_claude_binary() and raises FileNotFoundError when the
+        # `claude` binary is missing from PATH.
+        run: |
+          curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
+          sudo apt-get install -y nodejs
+          sudo npm install -g @anthropic-ai/claude-code
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Cherry-picks the single commit from #13 (`bf1b061`) onto current `main`. PR #13 itself is stale: its base hasn't been updated since 2026-05-11, so its diff against today's `main` shows a net −8396 lines because all the post-#14 features would be reverted. This PR carries just the 9-line `.github/workflows/ci.yml` change.

## Why
`ClaudeLLM.__init__()` eagerly calls `_find_claude_binary()` and raises `FileNotFoundError` when the `claude` binary isn't on `PATH`. Every test that constructs a `ClaudeLLM` or an agent that wraps one explodes at import/instantiation time on CI runners, even though the tests then patch out `.call()` and never invoke Claude. Installing the CLI satisfies the binary lookup; no API key / auth is required because tests don't actually call Claude.

## Summary
- Installs Node 22 + `@anthropic-ai/claude-code` globally before the `pytest` step.

## Test plan
- [x] Confirmed locally that the failing tests on PR #15 / #16 all mock `.call()` or higher-level helpers — they only need the binary to exist on PATH.
- [ ] CI green on this PR.
- [ ] Known unrelated remainder after merge: `test_only_successful_blocks_used` still fails with `KeyError: 'skipped'` — separate bug, not addressed here.

Closes #13.