### PR TITLE
Pipeline + architecture robustness, telemetry, config fallback (4 commits)

### DIFF
--- a/orchestrator/architecture/specialists/prd_spec.py
+++ b/orchestrator/architecture/specialists/prd_spec.py
@@ -39,6 +39,43 @@ SYSTEM_PROMPT = _PROMPT_FILE.read_text()
 
 
 # ---------------------------------------------------------------------------
+# Prompt context helpers
+# ---------------------------------------------------------------------------
+
+def _build_answers_context(
+    user_answers: dict[str, str] | None,
+    previous_questions: list[dict] | None = None,
+) -> str:
+    """Format architect answers without dropping unmatched manual context."""
+    if not user_answers:
+        return ""
+
+    lines = ["USER ANSWERS TO SIZING QUESTIONS:"]
+    seen: set[str] = set()
+
+    if previous_questions:
+        for q in previous_questions:
+            qid = str(q.get("id", "") or "")
+            if not qid:
+                continue
+            seen.add(qid)
+            answer = user_answers.get(qid, "(not answered)")
+            lines.append(f"  {qid}: {q.get('question', '')}")
+            lines.append(f"    Answer: {answer}")
+
+    extras = [(str(qid), answer) for qid, answer in user_answers.items()
+              if str(qid) not in seen]
+    if extras:
+        if previous_questions:
+            lines.append("")
+            lines.append("ADDITIONAL ARCHITECT ANSWERS AND REVIEW FEEDBACK:")
+        for qid, answer in extras:
+            lines.append(f"  {qid}: {answer}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -76,20 +113,7 @@ async def gather_prd(
         # Build context sections
         pdk_context = pdk_summary if pdk_summary else "No PDK information available."
 
-        answers_context = ""
-        if user_answers and previous_questions:
-            lines = ["USER ANSWERS TO SIZING QUESTIONS:"]
-            for q in previous_questions:
-                qid = q.get("id", "")
-                answer = user_answers.get(qid, "(not answered)")
-                lines.append(f"  {qid}: {q.get('question', '')}")
-                lines.append(f"    Answer: {answer}")
-            answers_context = "\n".join(lines)
-        elif user_answers:
-            lines = ["USER ANSWERS TO SIZING QUESTIONS:"]
-            for qid, answer in user_answers.items():
-                lines.append(f"  {qid}: {answer}")
-            answers_context = "\n".join(lines)
+        answers_context = _build_answers_context(user_answers, previous_questions)
 
         # Build the system prompt with template variables filled in
         system_prompt = SYSTEM_PROMPT.format(

--- a/orchestrator/langchain/agents/integration_lead.py
+++ b/orchestrator/langchain/agents/integration_lead.py
@@ -93,11 +93,73 @@ class IntegrationLeadAgent:
             result = self._parse_response(content, design_name)
 
             verilog = result.pop("verilog", "")
-            if verilog and output_path:
+
+            # The LLM may have used a file-edit tool to write the top RTL
+            # directly to disk and then returned a JSON whose `verilog`
+            # field is a self-`include` or other placeholder (seen with
+            # Codex/gpt-5.5: the response wrote `\`include "<output_path>"\``
+            # which trivially compiles to a recursive include).  Refuse to
+            # overwrite a working on-disk module with a broken one-liner,
+            # and refuse to write a broken one-liner from scratch -- raise
+            # so the integration_check node escalates with a retry-able
+            # error.
+            def _has_real_module(text: str, design_name: str) -> bool:
+                if not text:
+                    return False
+                if "module" not in text:
+                    return False
+                if f"module {design_name}" not in text and "module " not in text:
+                    return False
+                if len(text.strip().splitlines()) < 5:
+                    return False
+                # Reject obvious self-include placeholders.
+                stripped = text.strip()
+                if (
+                    stripped.startswith("`include")
+                    and output_path
+                    and output_path in stripped
+                ):
+                    return False
+                return True
+
+            disk_content = ""
+            if output_path:
+                disk_path = Path(output_path)
+                if disk_path.exists():
+                    try:
+                        disk_content = disk_path.read_text(encoding="utf-8")
+                    except OSError:
+                        disk_content = ""
+
+            chosen_verilog = ""
+            if _has_real_module(verilog, design_name):
+                chosen_verilog = verilog
+            elif _has_real_module(disk_content, design_name):
+                chosen_verilog = disk_content
+                result.setdefault("notes", "")
+                result["notes"] += (
+                    " (used existing on-disk integration top because the LLM "
+                    "response did not contain a valid module declaration)"
+                )
+
+            if chosen_verilog and output_path:
                 out = Path(output_path)
                 out.parent.mkdir(parents=True, exist_ok=True)
-                out.write_text(verilog, encoding="utf-8")
+                out.write_text(chosen_verilog, encoding="utf-8")
                 result["rtl_path"] = output_path
+            elif output_path:
+                # Neither the response nor disk has a valid module.
+                # Raise so the pipeline retries instead of writing junk
+                # that produces a recursive-include lint error.
+                result["rtl_path"] = ""
+                raise RuntimeError(
+                    "Integration Lead returned no valid top-level Verilog "
+                    f"module for '{design_name}'. The response `verilog` "
+                    f"field had {len(verilog)} chars but did not contain a "
+                    f"proper module declaration, and the on-disk file at "
+                    f"{output_path} did not contain a valid module either. "
+                    "Retry."
+                )
             else:
                 result["rtl_path"] = ""
 

--- a/orchestrator/langchain/agents/socmate_llm.py
+++ b/orchestrator/langchain/agents/socmate_llm.py
@@ -178,6 +178,7 @@ def _log_llm_call(
     error: str = "",
     timed_out: bool = False,
     usage: dict | None = None,
+    start_ts_ns: int | None = None,
 ) -> None:
     """Write an LLM call record to the JSONL log and an OTel span.
 
@@ -223,6 +224,8 @@ def _log_llm_call(
     if tracer is not None:
         try:
             from opentelemetry import trace
+            end_ns = _time_mod.time_ns()
+            start_ns = start_ts_ns or (end_ns - int(duration_s * 1_000_000_000))
             attrs = {
                 "llm.model_name": model,
                 "llm.provider": provider,
@@ -253,11 +256,12 @@ def _log_llm_call(
             span = tracer.start_span(
                 f"LLM {model} ({provider})",
                 attributes=attrs,
+                start_time=start_ns,
             )
             if error:
                 span.set_attribute("error", error[:1000])
                 span.set_status(trace.StatusCode.ERROR, error[:200])
-            span.end()
+            span.end(end_time=end_ns)
         except Exception:
             pass  # telemetry must never break the LLM call
 
@@ -690,6 +694,7 @@ class ClaudeLLM:
         )
 
         t0 = _time_mod.monotonic()
+        span_start_ns = _time_mod.time_ns()
         max_retries = 3
 
         # ``_generate_via_cli`` is itself dispatched via
@@ -722,6 +727,7 @@ class ClaudeLLM:
                     duration_s=elapsed,
                     timeout=self.timeout,
                     error=error_msg,
+                    start_ts_ns=span_start_ns,
                 )
                 return output
 
@@ -746,6 +752,7 @@ class ClaudeLLM:
                     error=error_msg,
                     timed_out=True,
                     usage=usage,
+                    start_ts_ns=span_start_ns,
                 )
                 self._write_llm_event(project_root, f"llm_{reason}", {
                     "model": resolved_model,
@@ -770,6 +777,7 @@ class ClaudeLLM:
                 )
                 _time_mod.sleep(wait)
                 t0 = _time_mod.monotonic()
+                span_start_ns = _time_mod.time_ns()
                 continue
             break
 
@@ -808,6 +816,7 @@ class ClaudeLLM:
             duration_s=elapsed,
             timeout=self.timeout,
             usage=usage,
+            start_ts_ns=span_start_ns,
         )
 
         return output
@@ -849,6 +858,7 @@ class ClaudeLLM:
         logger.info("Codex CLI cmd (first 200): %s", " ".join(cmd)[:200])
 
         t0 = _time_mod.monotonic()
+        span_start_ns = _time_mod.time_ns()
         try:
             output, stderr_text, returncode, elapsed, timed_out, stalled, usage = (
                 self._run_cli_with_watchdog(
@@ -871,6 +881,7 @@ class ClaudeLLM:
                 duration_s=elapsed,
                 timeout=self.timeout,
                 error=error_msg,
+                start_ts_ns=span_start_ns,
             )
             return output
 
@@ -894,6 +905,7 @@ class ClaudeLLM:
                 error=error_msg,
                 timed_out=True,
                 usage=usage,
+                start_ts_ns=span_start_ns,
             )
             self._write_llm_event(project_root, f"llm_{reason}", {
                 "model": resolved_model,
@@ -939,6 +951,7 @@ class ClaudeLLM:
             duration_s=elapsed,
             timeout=self.timeout,
             usage=usage,
+            start_ts_ns=span_start_ns,
         )
 
         return output

--- a/orchestrator/langgraph/architecture_graph.py
+++ b/orchestrator/langgraph/architecture_graph.py
@@ -123,6 +123,7 @@ class ArchGraphState(TypedDict):
     # PRD (Product Requirements Document) -- "What functionality is needed?"
     prd_spec: Optional[dict]       # Full PRD document (Phase 2 output)
     prd_questions: Optional[list]  # Sizing questions (Phase 1 output)
+    prd_answers: Optional[dict]    # Architect answers used to draft the PRD
 
     # SAD (System Architecture Document) -- "How do we get there and why?"
     sad_spec: Optional[dict]
@@ -285,6 +286,31 @@ def _persist_prd(
 
     md_path = arch_dir / "prd_spec.md"
     atomic_write(md_path, "\n".join(md_lines))
+
+
+def _feedback_revision_target(feedback: str) -> str:
+    """Route final-review feedback to the earliest document it criticizes."""
+    text = str(feedback or "").lower()
+    if any(
+        token in text
+        for token in (
+            "prd",
+            "product requirement",
+            "requirements document",
+            "sizing question",
+            "not answered",
+            "manual answer",
+            "target frame",
+            "frame rate",
+            "golden model path",
+        )
+    ):
+        return "Gather Requirements"
+    if any(token in text for token in ("sad", "system architecture")):
+        return "System Architecture"
+    if any(token in text for token in ("frd", "functional requirement")):
+        return "Functional Requirements"
+    return "Block Diagram"
 
 
 def _persist_sad(project_root: str, sad_result: dict) -> None:
@@ -770,6 +796,13 @@ async def gather_requirements_node(state: ArchGraphState) -> dict:
         previous_questions = state.get("prd_questions")
         if has_hr:
             user_answers = human_response.get("answers")
+            if (
+                not user_answers
+                and human_response.get("action") == "feedback"
+                and human_response.get("feedback")
+            ):
+                user_answers = dict(state.get("prd_answers") or {})
+                user_answers["architect_final_review_feedback"] = human_response.get("feedback", "")
 
         span.set_attribute("has_answers", user_answers is not None)
         if user_answers:
@@ -800,6 +833,8 @@ async def gather_requirements_node(state: ArchGraphState) -> dict:
                 )
 
             update["prd_spec"] = result
+            if user_answers:
+                update["prd_answers"] = user_answers
             update["requirements"] = enriched_requirements
 
             _persist_prd(state["project_root"], result, previous_questions, user_answers)
@@ -2042,8 +2077,7 @@ def route_after_final_review(state: ArchGraphState) -> str:
         # OK2DEV -- proceed to completion
         target = "Architecture Complete"
     elif action == "feedback":
-        # REVISE -- loop back to Block Diagram with feedback
-        target = "Block Diagram"
+        target = _feedback_revision_target(response.get("feedback", ""))
     else:
         # Default to accept
         target = "Architecture Complete"
@@ -2061,6 +2095,9 @@ def route_after_final_review(state: ArchGraphState) -> str:
 
 route_after_final_review.__edge_labels__ = {
     "Architecture Complete": "OK2DEV",
+    "Gather Requirements": "REVISE_PRD",
+    "System Architecture": "REVISE_SAD",
+    "Functional Requirements": "REVISE_FRD",
     "Block Diagram": "REVISE",
     "Abort": "ABORT",
 }

--- a/orchestrator/langgraph/event_stream.py
+++ b/orchestrator/langgraph/event_stream.py
@@ -43,6 +43,7 @@ RED = "\033[91m"
 RESET = "\033[0m"
 
 _LOG_RELPATH = ".socmate/pipeline_events.jsonl"
+_VALID_EXIT_STATUS = {"ok", "error", "skipped", "interrupted"}
 
 
 # ---------------------------------------------------------------------------
@@ -89,12 +90,16 @@ def write_graph_event(
     log_path = Path(project_root) / _LOG_RELPATH
     log_path.parent.mkdir(parents=True, exist_ok=True)
     ts = time.time()
+    payload = dict(data or {})
+    if event_type == "graph_node_exit":
+        payload["status"] = _derive_exit_status(payload)
+
     record = {
         "ts": ts,
         "iso": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(ts)),
         "event": event_type,
         "node": node_name,
-        **(data or {}),
+        **payload,
     }
     line = json.dumps(record, default=str) + "\n"
     with _write_lock:
@@ -119,6 +124,57 @@ async def _safe_hook(
         await hook(project_root, node_name, record)
     except Exception:
         logger.exception("Exit hook %s failed for node %s", hook.__name__, node_name)
+
+
+def _derive_exit_status(data: dict) -> str:
+    """Return a uniform status for a graph-node exit event.
+
+    Historically most callers wrote ad hoc fields such as ``passed``,
+    ``success``, ``clean``, or ``error``.  Keeping this normalization in the
+    writer makes existing nodes observable without forcing every graph to be
+    migrated in one large patch.
+    """
+    explicit = str(data.get("status", "")).strip().lower()
+    aliases = {
+        "true": "ok",
+        "pass": "ok",
+        "passed": "ok",
+        "success": "ok",
+        "fail": "error",
+        "failed": "error",
+        "failure": "error",
+        "abort": "interrupted",
+        "aborted": "interrupted",
+    }
+    explicit = aliases.get(explicit, explicit)
+    if explicit in _VALID_EXIT_STATUS:
+        return explicit
+
+    if data.get("pipeline_aborted") or data.get("interrupted"):
+        return "interrupted"
+
+    if data.get("skipped") is True or data.get("skip") is True:
+        return "skipped"
+    result = str(data.get("result", "")).strip().lower()
+    if result in {"skip", "skipped"}:
+        return "skipped"
+
+    for key in (
+        "passed",
+        "success",
+        "clean",
+        "ok",
+        "synth_ok",
+        "integration_ok",
+        "validation_ok",
+    ):
+        if key in data and data.get(key) is False:
+            return "error"
+
+    if data.get("error") or data.get("exception") or data.get("failure"):
+        return "error"
+
+    return "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -954,7 +954,12 @@ include $(shell cocotb-config --makefiles)/Makefile.sim
 """
     (sim_dir / "Makefile").write_text(makefile_content)
 
-    sim_tb_path = sim_dir / f"test_{design_name}.py"
+    # Copy the TB under its ORIGINAL stem so the cocotb MODULE name (which is
+    # Path(tb_path).stem) resolves on PYTHONPATH=sim_dir.  Validation DV TBs
+    # are named test_<design>_validation.py, so the previous hardcoded
+    # f"test_{design_name}.py" copy renamed them to test_<design>.py and
+    # cocotb failed import at 0 ns with `No module named test_<design>_validation`.
+    sim_tb_path = sim_dir / f"{Path(tb_path).stem}.py"
     shutil.copy2(tb_path, sim_tb_path)
     _normalize_cocotb_timing_keywords(sim_tb_path)
 

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -1896,12 +1896,30 @@ async def integration_review_node(state: OrchestratorState) -> dict:
         )
         action = "revise"
     if action == "approve" and issues_fixed:
-        log(
-            "  [INTEGRATION REVIEW] Approval rejected because uArch specs "
-            "were edited after block artifacts were generated; treating as revise",
-            YELLOW,
-        )
-        action = "revise"
+        # NOTE: The integration_review agent edits specs on every run, even
+        # cosmetically, so this auto-revise creates an infinite loop:
+        # revise -> restart_block -> integration_review edits again -> revise...
+        # When the outer agent (human or run_top_headless auto-approve)
+        # explicitly approves, trust that decision; the integration_check
+        # node at RTL level will catch any real cross-block lint/wiring
+        # mismatch and surface it as a normal failure. Setting
+        # SOCMATE_STRICT_INTEGRATION_REVIEW=1 restores the old auto-revise.
+        import os as _os
+        if _os.environ.get("SOCMATE_STRICT_INTEGRATION_REVIEW") == "1":
+            log(
+                "  [INTEGRATION REVIEW] Approval rejected because uArch specs "
+                "were edited after block artifacts were generated; treating as revise "
+                "(SOCMATE_STRICT_INTEGRATION_REVIEW=1)",
+                YELLOW,
+            )
+            action = "revise"
+        else:
+            log(
+                "  [INTEGRATION REVIEW] Spec edits were made; honoring explicit "
+                "approve (integration_check at RTL level will catch real mismatches). "
+                "Export SOCMATE_STRICT_INTEGRATION_REVIEW=1 to force revise.",
+                YELLOW,
+            )
     if action == "revise" and issues_found == 0 and not review_failed:
         log(
             "  [INTEGRATION REVIEW] Clean review returned revise; "

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -45,7 +45,13 @@ PROJECT_ROOT = Path(
         str(Path(__file__).resolve().parent.parent.parent),
     )
 )
-CONFIG_PATH = PROJECT_ROOT / "orchestrator" / "config.yaml"
+CODE_ROOT = Path(__file__).resolve().parent.parent.parent
+CONFIG_PATH = Path(
+    os.environ.get(
+        "SOCMATE_CONFIG_PATH",
+        str(PROJECT_ROOT / "orchestrator" / "config.yaml"),
+    )
+)
 PDK_ROOT = PROJECT_ROOT / ".pdk"
 def _find_liberty_file() -> Path:
     """Locate the Sky130 liberty file, checking both sky130A and sky130B."""
@@ -222,7 +228,13 @@ def load_config() -> dict:
     nightly e2e job to swap in a small reference design without touching
     the canonical config.
     """
-    with open(CONFIG_PATH) as f:
+    config_path = CONFIG_PATH
+    if not config_path.exists():
+        repo_config = CODE_ROOT / "orchestrator" / "config.yaml"
+        if repo_config.exists():
+            config_path = repo_config
+
+    with open(config_path) as f:
         config = yaml.safe_load(f)
 
     blocks_override = os.environ.get("SOCMATE_BLOCKS_FILE")

--- a/orchestrator/tests/test_event_stream.py
+++ b/orchestrator/tests/test_event_stream.py
@@ -59,7 +59,22 @@ class TestWriteGraphEvent:
         assert "iso" in record
         assert "event" in record
         assert "node" in record
+        assert record["status"] == "ok"
         assert isinstance(record["ts"], float)
+
+    def test_graph_node_exit_derives_uniform_status(self, event_project):
+        write_graph_event(event_project, "Pass Node", "graph_node_exit", {"passed": True})
+        write_graph_event(event_project, "Fail Node", "graph_node_exit", {"passed": False})
+        write_graph_event(event_project, "Skip Node", "graph_node_exit", {"skipped": True})
+        write_graph_event(event_project, "Abort Node", "graph_node_exit", {"pipeline_aborted": True})
+
+        events = read_events(event_project)
+        assert [event["status"] for event in events] == [
+            "ok",
+            "error",
+            "skipped",
+            "interrupted",
+        ]
 
     def test_multiple_events_append(self, event_project):
         write_graph_event(event_project, "A", "graph_node_enter")

--- a/orchestrator/tests/test_final_review_routing.py
+++ b/orchestrator/tests/test_final_review_routing.py
@@ -1,0 +1,24 @@
+from orchestrator.langgraph.architecture_graph import (
+    _feedback_revision_target,
+    route_after_final_review,
+)
+
+
+def test_final_review_feedback_about_prd_routes_to_gather_requirements():
+    assert _feedback_revision_target("PRD says 30 fps but manual answer was 1 fps") == (
+        "Gather Requirements"
+    )
+    assert route_after_final_review({
+        "human_response": {
+            "action": "feedback",
+            "feedback": "PRD has not answered sizing questions",
+        }
+    }) == "Gather Requirements"
+
+
+def test_final_review_feedback_about_frd_routes_to_functional_requirements():
+    assert _feedback_revision_target("FRD PSNR KPI is missing") == "Functional Requirements"
+
+
+def test_final_review_feedback_defaults_to_block_diagram():
+    assert _feedback_revision_target("Split the predictor into two blocks") == "Block Diagram"

--- a/orchestrator/tests/test_flow_fixes.py
+++ b/orchestrator/tests/test_flow_fixes.py
@@ -28,6 +28,22 @@ from pathlib import Path
 import pytest
 
 
+def test_load_config_falls_back_to_repo_config_when_project_root_is_external(tmp_path, monkeypatch):
+    """Architecture helpers must work when SOCMATE_PROJECT_ROOT is a run dir."""
+    import importlib
+
+    monkeypatch.setenv("SOCMATE_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.delenv("SOCMATE_CONFIG_PATH", raising=False)
+
+    import orchestrator.langgraph.pipeline_helpers as ph
+
+    ph = importlib.reload(ph)
+    cfg = ph.load_config()
+
+    assert isinstance(cfg, dict)
+    assert "blocks" in cfg
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # P0-1: Testbench Regeneration (force_regen_tb flag)
 # ═══════════════════════════════════════════════════════════════════════════

--- a/orchestrator/tests/test_headless_question_answers.py
+++ b/orchestrator/tests/test_headless_question_answers.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_runner_module():
+    path = Path(__file__).resolve().parents[2] / "scripts" / "run_top_headless.py"
+    spec = importlib.util.spec_from_file_location("run_top_headless_for_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_question_answer_ids_include_remaining_choice_questions():
+    runner = _load_runner_module()
+    payload = {
+        "ask_question": {
+            "questions": [{"id": "target_pdk_selection"}],
+            "remaining_choice_questions": [{"id": "frame_rate_target"}],
+            "auto_answerable": [{"id": "sky130_library_flavor"}],
+        }
+    }
+
+    assert runner._question_answer_ids_from_escalation(payload) == [
+        "target_pdk_selection",
+        "frame_rate_target",
+        "sky130_library_flavor",
+    ]
+
+
+def test_question_answer_validation_rejects_partial_answer_files():
+    runner = _load_runner_module()
+    payload = {
+        "ask_question": {
+            "questions": [{"id": "target_pdk_selection"}],
+            "remaining_choice_questions": [{"id": "frame_rate_target"}],
+        }
+    }
+
+    missing, extras = runner._validate_question_answers(
+        {"target_pdk": "legacy sky130 answer"},
+        payload,
+    )
+
+    assert missing == ["target_pdk_selection", "frame_rate_target"]
+    assert extras == ["target_pdk"]
+
+
+def test_normalize_answer_payload_accepts_wrapped_answers():
+    runner = _load_runner_module()
+
+    assert runner._normalize_answer_payload({"answers": {"q1": "a1"}}) == {"q1": "a1"}

--- a/orchestrator/tests/test_pipeline_graph.py
+++ b/orchestrator/tests/test_pipeline_graph.py
@@ -651,7 +651,66 @@ class TestRouteAfterIntegrationReview:
         assert result["integration_review_failed"] is True
 
     @pytest.mark.asyncio
-    async def test_fixed_uarch_review_blocks_stale_artifact_approval(self, tmp_path, monkeypatch):
+    async def test_fixed_uarch_review_honors_explicit_approve_by_default(self, tmp_path, monkeypatch):
+        """Default mode: when issues_fixed>0 and the outer agent explicitly
+        approves, integration_review_node honors the approve. The previous
+        auto-revise on issues_fixed>0 caused a non-terminating loop because
+        the integration-review LLM agent edits specs on every run."""
+        monkeypatch.delenv("SOCMATE_STRICT_INTEGRATION_REVIEW", raising=False)
+        from orchestrator.langchain.agents import integration_review_agent
+
+        def fake_init(self, *args, **kwargs):
+            pass
+
+        async def fake_review(self, block_names, project_root):
+            spec_dir = tmp_path / "arch" / "uarch_specs"
+            spec_dir.mkdir(parents=True, exist_ok=True)
+            (spec_dir / "adder32.md").write_text("updated spec", encoding="utf-8")
+            return {
+                "summary": "Fixed status bus layout in adder32 uArch.",
+                "issues_found": 1,
+                "issues_fixed": 1,
+            }
+
+        captured_payload = {}
+
+        def fake_interrupt(payload):
+            captured_payload.update(payload)
+            return {"action": "approve"}
+
+        monkeypatch.setattr(
+            integration_review_agent.IntegrationReviewAgent,
+            "__init__",
+            fake_init,
+        )
+        monkeypatch.setattr(
+            integration_review_agent.IntegrationReviewAgent,
+            "review",
+            fake_review,
+        )
+        monkeypatch.setattr(pipeline_graph, "interrupt", fake_interrupt)
+
+        result = await pipeline_graph.integration_review_node({
+            "project_root": str(tmp_path),
+            "block_queue": [{"name": "adder32", "tier": 1}],
+            "tier_list": [1],
+            "current_tier_index": 0,
+            "completed_blocks": [{"name": "adder32", "success": True}],
+        })
+
+        # Payload still reports the failure for outer-agent visibility.
+        assert captured_payload["review_failed"] is True
+        assert captured_payload["issues_fixed"] == 1
+        assert "Blocking uArch edits" in captured_payload["review_summary"]
+        # But the explicit approve is honored.
+        assert result["integration_review_action"] == "approve"
+        assert result["integration_review_failed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fixed_uarch_review_blocks_approve_under_strict_mode(self, tmp_path, monkeypatch):
+        """SOCMATE_STRICT_INTEGRATION_REVIEW=1 restores the original
+        approve->revise auto-conversion when issues_fixed>0."""
+        monkeypatch.setenv("SOCMATE_STRICT_INTEGRATION_REVIEW", "1")
         from orchestrator.langchain.agents import integration_review_agent
 
         def fake_init(self, *args, **kwargs):

--- a/orchestrator/tests/test_prd_answer_context.py
+++ b/orchestrator/tests/test_prd_answer_context.py
@@ -1,0 +1,36 @@
+from orchestrator.architecture.specialists.prd_spec import _build_answers_context
+
+
+def test_prd_answer_context_preserves_unmatched_answers():
+    context = _build_answers_context(
+        {
+            "frame_rate_target": "1 fps sustained",
+            "target_frame_rate": "Legacy answer: 1 fps, not 30 fps",
+            "architect_final_review_feedback": "Fix PRD contradictions before OK2DEV.",
+        },
+        previous_questions=[
+            {
+                "id": "frame_rate_target",
+                "question": "What sustained frame rate is required?",
+            }
+        ],
+    )
+
+    assert "frame_rate_target" in context
+    assert "1 fps sustained" in context
+    assert "ADDITIONAL ARCHITECT ANSWERS" in context
+    assert "target_frame_rate: Legacy answer: 1 fps, not 30 fps" in context
+    assert "architect_final_review_feedback: Fix PRD contradictions before OK2DEV." in context
+
+
+def test_prd_answer_context_marks_missing_asked_answers():
+    context = _build_answers_context(
+        {"target_pdk": "sky130"},
+        previous_questions=[
+            {"id": "frame_rate_target", "question": "What frame rate?"},
+        ],
+    )
+
+    assert "frame_rate_target: What frame rate?" in context
+    assert "Answer: (not answered)" in context
+    assert "target_pdk: sky130" in context

--- a/orchestrator/tests/test_socmate_llm.py
+++ b/orchestrator/tests/test_socmate_llm.py
@@ -30,6 +30,7 @@ from orchestrator.langchain.agents.socmate_llm import (
     _CODEX_MODEL_MAP,
     _CLI_MODEL_MAP,
     _detect_provider,
+    _log_llm_call,
     _parse_codex_json,
     _resolve_model,
     _register_process,
@@ -119,6 +120,51 @@ class TestCodexJsonParsing:
         text, usage = _parse_codex_json(stdout)
         assert text == "hello"
         assert usage == {"input_tokens": 10, "output_tokens": 2}
+
+
+class TestLLMTelemetry:
+    def test_log_llm_call_backdates_otel_span(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SOCMATE_PROJECT_ROOT", str(tmp_path))
+        recorded = {}
+
+        class FakeSpan:
+            def set_attribute(self, *args):
+                pass
+
+            def set_status(self, *args):
+                pass
+
+            def end(self, end_time=None):
+                recorded["end_time"] = end_time
+
+        class FakeTracer:
+            def start_span(self, name, attributes=None, start_time=None):
+                recorded["name"] = name
+                recorded["attributes"] = attributes or {}
+                recorded["start_time"] = start_time
+                return FakeSpan()
+
+        start_ns = time.time_ns() - 2_500_000_000
+        with patch(
+            "orchestrator.langchain.agents.socmate_llm._get_llm_tracer",
+            return_value=FakeTracer(),
+        ):
+            _log_llm_call(
+                model="gpt-5.5",
+                provider="codex_cli",
+                system_prompt="system",
+                user_prompt="prompt",
+                response="response",
+                duration_s=2.5,
+                timeout=60,
+                start_ts_ns=start_ns,
+            )
+
+        assert recorded["name"] == "LLM gpt-5.5 (codex_cli)"
+        assert recorded["start_time"] == start_ns
+        assert recorded["end_time"] is not None
+        assert recorded["end_time"] - recorded["start_time"] >= 2_400_000_000
+        assert recorded["attributes"]["llm.duration_s"] == 2.5
 
 
 class TestProcessRegistry:

--- a/scripts/run_top_headless.py
+++ b/scripts/run_top_headless.py
@@ -52,6 +52,41 @@ def _write_question_escalation(kind: str, state: dict) -> Path:
     return path
 
 
+def _question_answer_ids_from_escalation(payload: dict) -> list[str]:
+    """Return all answer IDs the outer agent must cover for this escalation."""
+    ask = payload.get("ask_question") or {}
+    ids: list[str] = []
+    seen: set[str] = set()
+    for section in ("questions", "remaining_choice_questions", "auto_answerable"):
+        for item in ask.get(section, []) or []:
+            qid = str(item.get("id", "") or "").strip()
+            if qid and qid not in seen:
+                seen.add(qid)
+                ids.append(qid)
+    return ids
+
+
+def _normalize_answer_payload(value: object) -> dict | None:
+    if not isinstance(value, dict):
+        return None
+    nested = value.get("answers")
+    if isinstance(nested, dict):
+        # Accept either the documented raw mapping or a defensive wrapper.
+        return nested
+    return value
+
+
+def _validate_question_answers(answers: dict, escalation_payload: dict) -> tuple[list[str], list[str]]:
+    """Return (missing_required_ids, extra_answer_ids)."""
+    required = _question_answer_ids_from_escalation(escalation_payload)
+    if not required:
+        return [], []
+    answer_ids = {str(k) for k in answers.keys()}
+    missing = [qid for qid in required if qid not in answer_ids]
+    extras = sorted(answer_ids - set(required))
+    return missing, extras
+
+
 def _recent_text(path: Path, max_lines: int = 160, max_chars: int = 20000) -> str:
     if not path.exists():
         return ""
@@ -110,14 +145,41 @@ def _write_decision_escalation(kind: str, state: dict, allowed_actions: list[str
     return path
 
 
-async def _wait_for_question_answers(kind: str, poll_s: float) -> dict:
+async def _wait_for_question_answers(
+    kind: str,
+    poll_s: float,
+    escalation_path: Path | None = None,
+) -> dict:
     esc_dir = _project_root() / ".socmate" / "escalations"
     answers_path = esc_dir / f"{kind}.answers.json"
     print(f"[arch] escalation pending: write answers JSON to {answers_path}", flush=True)
     while True:
         if answers_path.exists():
-            answers = json.loads(answers_path.read_text())
+            raw_answers = json.loads(answers_path.read_text())
+            answers = _normalize_answer_payload(raw_answers)
             if isinstance(answers, dict):
+                if escalation_path and escalation_path.exists():
+                    payload = json.loads(escalation_path.read_text())
+                    missing, extras = _validate_question_answers(answers, payload)
+                    if missing:
+                        invalid_path = answers_path.with_name(
+                            f"{answers_path.name}.invalid-{time.strftime('%Y%m%d-%H%M%S', time.gmtime())}"
+                        )
+                        answers_path.replace(invalid_path)
+                        print(
+                            "[arch] rejected incomplete escalation answers; "
+                            f"missing {len(missing)} required id(s): {missing[:20]}. "
+                            f"Moved invalid file to {invalid_path}",
+                            flush=True,
+                        )
+                        await asyncio.sleep(max(5.0, poll_s))
+                        continue
+                    if extras:
+                        print(
+                            "[arch] escalation answers include extra context keys "
+                            f"not in current question set: {extras[:20]}",
+                            flush=True,
+                        )
                 print(f"[arch] loaded escalation answers from {answers_path}", flush=True)
                 return answers
             raise RuntimeError(f"Escalation answers at {answers_path} must be a JSON object")
@@ -376,7 +438,7 @@ async def run(args: argparse.Namespace) -> int:
                     else:
                         path = _write_question_escalation(itype, state)
                         print(f"[arch] wrote question escalation to {path}", flush=True)
-                        answers = await _wait_for_question_answers(itype, args.poll_s)
+                        answers = await _wait_for_question_answers(itype, args.poll_s, path)
                     print(await mcp.resume_architecture("continue", json.dumps(answers)), flush=True)
                 elif itype == "final_review":
                     payload_state = {


### PR DESCRIPTION
Cherry-picks the four substantive commits that were sitting on the now-defunct \`ci/github-models-smoketest\` branch onto a fresh base of current \`main\`. The two GitHub-Models smoketest yaml commits were left off this PR -- GH Models is blocked at the org level (see #18 discussion), so those workflow files have no current utility.

## Summary
1. **\`telemetry: record LLM durations and exit status\`** (\`socmate_llm.py\`, \`event_stream.py\` + tests) — surfaces per-call latency and exit code through the event stream so we can spot slow / failing LLM invocations from telemetry alone.
2. **\`config: fall back to repo config for external run roots\`** (\`pipeline_helpers.py\` + test) — when the active project root is outside the repo (e.g. a \`socmate-runs/...\` dir), helper config lookup now falls back to the repo-local config instead of failing.
3. **\`architecture: preserve PRD answer context on revision\`** (\`prd_spec.py\`, \`architecture_graph.py\`, 3 new test files, \`run_top_headless.py\`) — fixes the architecture-revision path so PRD answer context survives a revision loop. Covered by three new tests (\`test_final_review_routing\`, \`test_headless_question_answers\`, \`test_prd_answer_context\`).
4. **\`orchestrator: 3 pipeline robustness fixes\`** — generic bugs surfaced during a codec run with Codex/gpt-5.5 (not codec-specific); the commit body has full details. Includes a routing test update so \`TestRouteAfterIntegrationReview\` covers both default-honor-approve and strict-mode-revise branches (all 8 tests in the class pass locally).

## Test plan
- [x] \`ruff check orchestrator/\` — clean
- [x] Routing-test suite green locally (per author note on f88ebfb)
- [ ] CI green on this PR
- [ ] Note: two pre-existing failures on \`main\` (\`test_three_blocks_same_tier_all_pass\` KeyError: 'skipped', \`test_uses_default_model\` opus-vs-sonnet) are unrelated to this PR and will still show up in the test job.