### PR TITLE
Dockerfile: surface nix-store libstdc++ via LD_LIBRARY_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,15 @@ RUN nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs \
  # C++ compiler on PATH for non-yosys subprocesses.
  && nix-env -iA nixos-unstable.verilator
 
+# nixpkgs.gcc's runtime libstdc++ lives under /root/.nix-profile/lib but
+# isn't on the dynamic loader's default search path. PyPI's manylinux
+# wheels for numpy 2.4+ are linked against libstdc++.so.6 at the standard
+# FHS location -- without LD_LIBRARY_PATH, the wavekit sdist build fails
+# its `import numpy as np` with
+#   ImportError: libstdc++.so.6: cannot open shared object file
+# Surface the nix-store libstdc++ at the loader's default search path.
+ENV LD_LIBRARY_PATH="/root/.nix-profile/lib:${LD_LIBRARY_PATH}"
+
 ENV PATH="/root/.nix-profile/bin:${PATH}"
 
 # Verify the unstable-channel verilator is on PATH and >= 5.036


### PR DESCRIPTION
publish-image has been failing on every push for the last 4 runs at:

\`\`\`
pip install wavekit
  -> ImportError: libstdc++.so.6: cannot open shared object file
\`\`\`

\`nixpkgs.gcc\` is already installed and provides libstdc++ in \`/root/.nix-profile/lib\`, but pip's build-isolation venv runs the manylinux numpy wheel which dlopens libstdc++ at the standard FHS search path. Setting \`LD_LIBRARY_PATH\` at image-build level surfaces the nix-store libstdc++ to the loader.

## Why now
The published \`ghcr.io/facebookexperimental/socmate:latest\` predates PR #11 (FHS sshd symlinks), so \`gh codespace ssh\` fails out of the box. Multiple devcontainer-side shim attempts (sshd feature, onCreateCommand, derived Dockerfile) all fail at the codespace agent's sshd check. Getting publish-image green is the canonical fix -- a fresh \`:latest\` carries PR #11's bootstrap and the shims become unnecessary.

## Test plan
- [x] Lint: nothing else changes
- [ ] CI publish-image goes green on merge to main
- [ ] Confirmed by creating a fresh codespace from main afterward