### PR TITLE
devcontainer: pull from coresmith:latest (was socmate:latest)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     // `:latest` (= last green main). For Dockerfile/toolchain work, build
     // locally with `docker build -t socmate:dev .` and test outside
     // Codespaces, or temporarily flip this back to a `build` block.
-    "image": "ghcr.io/facebookexperimental/socmate:latest",
+    "image": "ghcr.io/facebookexperimental/coresmith:latest",
 
     // The openlane2 base image already runs as root with /nix/store on
     // PATH; keep the dev container as root so the entrypoint can write


### PR DESCRIPTION
Repo was renamed; publish-image tags coresmith:* now. devcontainer.json was still pointing at the frozen pre-rename socmate:latest. Repoint so codespaces pick up the fresh image with PR #11's sshd FHS shim baked in.