### PR TITLE
integration_helpers: accept prior_failure kwarg in TB-generator wrappers

### DIFF
--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -821,6 +821,7 @@ async def generate_integration_testbench(
     connections: list[dict],
     block_rtl_paths: dict[str, str],
     prd_summary: str = "",
+    prior_failure: str = "",
 ) -> dict:
     """Generate a cocotb integration testbench via the Lead DV agent.
 
@@ -855,6 +856,7 @@ async def generate_integration_testbench(
         prd_summary=prd_summary,
         block_rtl_paths=block_rtl_paths,
         output_path=output_path,
+        prior_failure=prior_failure,
     )
 
     result["testbench_path"] = result.get("tb_path", output_path)
@@ -868,6 +870,7 @@ async def generate_validation_testbench(
     connections: list[dict],
     block_rtl_paths: dict[str, str],
     ers_context: str,
+    prior_failure: str = "",
 ) -> dict:
     """Generate an ERS/KPI validation cocotb testbench via Lead Validation DV.
 
@@ -903,6 +906,7 @@ async def generate_validation_testbench(
         ers_context=ers_context,
         block_rtl_paths=block_rtl_paths,
         output_path=output_path,
+        prior_failure=prior_failure,
     )
 
     result["testbench_path"] = result.get("tb_path", output_path)


### PR DESCRIPTION
## Bug

\`integration_dv_node\` and \`validation_dv_node\` in pipeline_graph.py call:

\`\`\`python
generate_integration_testbench(..., prior_failure=_format_dv_retry_context(previous_dv))
generate_validation_testbench(..., prior_failure=_format_dv_retry_context(previous_dv))
\`\`\`

Neither wrapper in \`integration_helpers.py\` accepts \`prior_failure\`. Every retry attempt at integration-DV / validation-DV hits:

\`\`\`
TypeError: generate_integration_testbench() got an unexpected keyword
argument 'prior_failure'
\`\`\`

Confirmed on two end-to-end codespace runs in #31's branch (adder8 with Claude, mcu3 with Codex) -- frontend pipeline completed cleanly, then the first integration-DV retry crashed instantly with this signature mismatch.

## Fix

Add \`prior_failure: str = ""\` to both wrappers' signatures and forward to the agent's \`.generate()\` -- both \`IntegrationTestbenchGenerator.generate()\` and \`ValidationDVGenerator.generate()\` already accept this kwarg (they use it to inject retry context into the LLM prompt). 

## Test plan

- [x] \`pytest -k "integration_dv or validation_dv"\` -> 5 passed (verified in the cs-inverted codespace)
- [ ] Full CI green