### PR TITLE
integration_lead: postcondition asserts every block appears in chip_top

### DIFF
--- a/orchestrator/langchain/agents/integration_lead.py
+++ b/orchestrator/langchain/agents/integration_lead.py
@@ -275,3 +275,49 @@ class IntegrationLeadAgent:
             result["notes"] += " WARNING: verilog field does not contain a module declaration."
 
         return result
+
+
+def assert_blocks_instantiated(
+    chip_top_verilog: str, expected_block_names: set[str]
+) -> str | None:
+    """Postcondition: every expected block must appear as an instantiation
+    inside the Integration Lead's chip_top Verilog. Returns None on success
+    or a descriptive error string listing the missing blocks.
+
+    The Integration Lead has historically been observed to silently drop
+    blocks from block_diagram.json and substitute glue stubs (e.g.,
+    cavlc_enc -> rle_to_packer_token_bridge). Lint passes because the
+    substitute compiles, but the chip is structurally wrong.
+    """
+    if not chip_top_verilog or not expected_block_names:
+        return None
+
+    # Strip line and block comments to avoid matching block names that
+    # appear only in commentary.
+    code = re.sub(r"//[^\n]*", "", chip_top_verilog)
+    code = re.sub(r"/\*.*?\*/", "", code, flags=re.DOTALL)
+
+    missing: list[str] = []
+    for block_name in expected_block_names:
+        # An instantiation is either
+        #   <module> <inst_name> ( ... );           non-parameterized
+        # or
+        #   <module> #( <params> ) <inst_name> (    parameterized
+        # We accept either by allowing the next token after the module name
+        # to be `#` (parameter override) or an identifier followed by `(`.
+        pattern = (
+            rf"\b{re.escape(block_name)}\s+"
+            rf"(?:#|[a-zA-Z_]\w*\s*\()"
+        )
+        if not re.search(pattern, code):
+            missing.append(block_name)
+
+    if missing:
+        return (
+            f"Integration Lead postcondition failed: chip_top RTL does NOT "
+            f"instantiate {len(missing)} expected block(s): "
+            f"{sorted(missing)}. The Integration Lead may have silently "
+            f"dropped blocks or substituted glue stubs (the cavlc_enc -> "
+            f"rle_to_packer_token_bridge failure mode). Refusing to proceed."
+        )
+    return None

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -2414,6 +2414,35 @@ async def integration_check_node(state: OrchestratorState) -> dict:
         module_name = agent_result.get("module_name", design_name)
         top_rtl_path = agent_result.get("rtl_path", output_path)
 
+        chip_top_text = ""
+        if top_rtl_path and os.path.exists(top_rtl_path):
+            try:
+                chip_top_text = Path(top_rtl_path).read_text()
+            except OSError:
+                chip_top_text = ""
+        if not chip_top_text:
+            chip_top_text = agent_result.get("verilog", "")
+
+        from orchestrator.langchain.agents.integration_lead import (
+            assert_blocks_instantiated,
+        )
+        postcond = assert_blocks_instantiated(
+            chip_top_text, set(block_rtl_sources.keys())
+        )
+        if postcond:
+            log(f"  [INTEGRATION] Postcondition failed: {postcond}", RED)
+            write_graph_event(pr, "Integration Check", "graph_node_exit", {
+                "error": "block_instantiation_postcondition_failed",
+                "missing_summary": postcond,
+            })
+            return {"integration_result": {
+                "skipped": True,
+                "reason": postcond,
+                "postcondition_failed": True,
+                "agent_notes": agent_result.get("notes", ""),
+                "top_rtl_path": top_rtl_path,
+            }}
+
         log(f"  [INTEGRATION] Agent generated {module_name}: "
             f"{len(modules)} blocks, "
             f"{agent_result.get('wire_count', 0)} wires", GREEN)

--- a/orchestrator/tests/test_integration_lead.py
+++ b/orchestrator/tests/test_integration_lead.py
@@ -26,6 +26,7 @@ from orchestrator.langchain.agents.integration_lead import (
     IntegrationLeadAgent,
     SYSTEM_PROMPT,
     _PROMPT_FILE,
+    assert_blocks_instantiated,
 )
 
 
@@ -67,6 +68,26 @@ SAMPLE_CONNECTIONS = [
         "data_width": 8,
     },
 ]
+
+# Chip-top stubs used by integration_check_node tests. The
+# assert_blocks_instantiated postcondition (introduced after the codec
+# stub-substitution incident) requires every expected block to appear as
+# an instantiation in the generated chip_top, so the mocked chip_top text
+# must contain those instances or the postcondition will (rightly) reject
+# the agent output mid-test.
+CHIP_TOP_AB = """\
+module chip_top (input clk, input rst_n);
+    a u_a (.clk(clk), .rst_n(rst_n));
+    b u_b (.clk(clk), .rst_n(rst_n));
+endmodule
+"""
+
+CHIP_TOP_BLOCK_A_B = """\
+module test_top (input clk, input rst_n);
+    block_a u_a (.clk(clk), .rst_n(rst_n));
+    block_b u_b (.clk(clk), .rst_n(rst_n));
+endmodule
+"""
 
 SAMPLE_PORT_SUMMARIES = [
     {
@@ -570,7 +591,7 @@ class TestIntegrationCheckNode:
             return mod_b
 
         mock_integrate = AsyncMock(return_value={
-            "verilog": "module test_top();\nendmodule\n",
+            "verilog": CHIP_TOP_BLOCK_A_B,
             "mismatches": [],
             "module_name": "test_top",
             "wire_count": 1,
@@ -600,7 +621,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langgraph.pipeline_graph.write_graph_event"
         ), patch(
             "pathlib.Path.read_text",
-            return_value=SAMPLE_VERILOG_A,
+            return_value=CHIP_TOP_BLOCK_A_B,
         ), patch(
             "pathlib.Path.mkdir",
         ), patch(
@@ -649,7 +670,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langgraph.pipeline_graph.write_graph_event"
         ), patch(
             "pathlib.Path.read_text",
-            return_value="module a(); endmodule",
+            return_value=CHIP_TOP_AB,
         ):
             result = await integration_check_node(state)
 
@@ -696,7 +717,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langgraph.pipeline_graph.write_graph_event"
         ), patch(
             "pathlib.Path.read_text",
-            return_value="module a(); endmodule",
+            return_value=CHIP_TOP_AB,
         ):
             result = await integration_check_node(state)
 
@@ -731,7 +752,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langchain.agents.integration_lead.IntegrationLeadAgent.integrate",
             new_callable=AsyncMock,
             return_value={
-                "verilog": "module test();\nendmodule\n",
+                "verilog": CHIP_TOP_AB,
                 "mismatches": [],
                 "module_name": "chip_top",
                 "wire_count": 0,
@@ -748,7 +769,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langgraph.pipeline_graph.write_graph_event"
         ), patch(
             "pathlib.Path.read_text",
-            return_value="module a(); endmodule",
+            return_value=CHIP_TOP_AB,
         ), patch(
             "pathlib.Path.mkdir",
         ), patch(
@@ -792,7 +813,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langchain.agents.integration_lead.IntegrationLeadAgent.integrate",
             new_callable=AsyncMock,
             return_value={
-                "verilog": "module chip_top();\nendmodule\n",
+                "verilog": CHIP_TOP_AB,
                 "mismatches": [
                     {
                         "from_block": "a",
@@ -818,7 +839,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langgraph.pipeline_graph.write_graph_event"
         ), patch(
             "pathlib.Path.read_text",
-            return_value="module a(); endmodule",
+            return_value=CHIP_TOP_AB,
         ), patch(
             "pathlib.Path.mkdir",
         ), patch(
@@ -860,7 +881,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langchain.agents.integration_lead.IntegrationLeadAgent.integrate",
             new_callable=AsyncMock,
             return_value={
-                "verilog": "module test_top();\nendmodule\n",
+                "verilog": CHIP_TOP_AB,
                 "mismatches": [],
                 "module_name": "test_top",
                 "wire_count": 3,
@@ -874,7 +895,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langgraph.pipeline_graph.write_graph_event"
         ), patch(
             "pathlib.Path.read_text",
-            return_value="module a(); endmodule",
+            return_value=CHIP_TOP_AB,
         ), patch(
             "pathlib.Path.mkdir",
         ), patch(
@@ -917,7 +938,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langchain.agents.integration_lead.IntegrationLeadAgent.integrate",
             new_callable=AsyncMock,
             return_value={
-                "verilog": "module chip_top();\nendmodule\n",
+                "verilog": CHIP_TOP_AB,
                 "mismatches": [],
                 "module_name": "chip_top",
                 "wire_count": 0,
@@ -937,7 +958,7 @@ class TestIntegrationCheckNode:
             "orchestrator.langgraph.pipeline_graph.write_graph_event"
         ), patch(
             "pathlib.Path.read_text",
-            return_value="module a(); endmodule",
+            return_value=CHIP_TOP_AB,
         ), patch(
             "pathlib.Path.mkdir",
         ), patch(
@@ -1039,3 +1060,84 @@ class TestIntegrationHelpers:
         connections, name = load_architecture_connections(str(tmp_path))
         assert connections == []
         assert name == "chip_top"
+
+
+# ---------------------------------------------------------------------------
+# assert_blocks_instantiated postcondition
+# ---------------------------------------------------------------------------
+
+class TestAssertBlocksInstantiated:
+    """Postcondition for Integration Lead's chip_top output.
+
+    Catches the silent-block-drop / glue-stub-substitution failure mode
+    that produced the codec stub (cavlc_enc -> rle_to_packer_token_bridge).
+    """
+
+    def test_all_blocks_present_passes(self):
+        chip_top = """\
+module chip_top (input clk, input rst_n);
+    block_a u_a (.clk(clk), .rst_n(rst_n));
+    block_b u_b (.clk(clk), .rst_n(rst_n));
+endmodule
+"""
+        assert assert_blocks_instantiated(
+            chip_top, {"block_a", "block_b"}
+        ) is None
+
+    def test_missing_block_fails(self):
+        chip_top = """\
+module chip_top (input clk);
+    block_a u_a (.clk(clk));
+endmodule
+"""
+        err = assert_blocks_instantiated(chip_top, {"block_a", "block_b"})
+        assert err is not None
+        assert "block_b" in err
+        assert "postcondition failed" in err.lower()
+
+    def test_codec_stub_substitution_caught(self):
+        chip_top = """\
+module chip_top (input clk);
+    // cavlc_enc replaced with a glue stub
+    rle_to_packer_token_bridge u_bridge (.clk(clk));
+    other_block u_other (.clk(clk));
+endmodule
+"""
+        err = assert_blocks_instantiated(
+            chip_top, {"cavlc_enc", "other_block"}
+        )
+        assert err is not None
+        assert "cavlc_enc" in err
+
+    def test_parameterized_instantiation_recognized(self):
+        chip_top = """\
+module chip_top;
+    block_a #(.WIDTH(8)) u_a (.clk(clk));
+endmodule
+"""
+        assert assert_blocks_instantiated(chip_top, {"block_a"}) is None
+
+    def test_empty_chip_top_with_no_blocks_passes(self):
+        assert assert_blocks_instantiated("", set()) is None
+
+    def test_block_name_appearing_only_as_substring_fails(self):
+        chip_top = """\
+module chip_top;
+    my_block_alpha u_alpha (.clk(clk));
+    block_a_alt   u_alt   (.clk(clk));
+endmodule
+"""
+        err = assert_blocks_instantiated(chip_top, {"block_a"})
+        assert err is not None
+        assert "block_a" in err
+
+    def test_block_name_in_comment_does_not_count(self):
+        chip_top = """\
+module chip_top;
+    // The block_a module would go here but was dropped
+    other_block u (.clk(clk));
+endmodule
+"""
+        err = assert_blocks_instantiated(chip_top, {"block_a"})
+        assert err is not None
+        assert "block_a" in err


### PR DESCRIPTION
## Summary

Catches the silent-block-drop / glue-stub-substitution failure mode that produced the codec_v2 chip_top stub on 2026-05-22 (where the Integration Lead replaced `cavlc_enc.v` with `rle_to_packer_token_bridge`, lint passed in isolation, and the chip shipped structurally broken).

This is friction #1 from the postmortem notes in `daemon.md`.

## What changed

**`orchestrator/langchain/agents/integration_lead.py`** — new module-level function `assert_blocks_instantiated(chip_top_verilog, expected_block_names)` that returns `None` on success or a descriptive error string listing the missing blocks. Recognizes both bare and parameterized instantiation forms, strips comments to avoid false positives, and word-anchors so `block_a` doesn't get satisfied by `block_a_alt` or `my_block_alpha`.

**`orchestrator/langgraph/pipeline_graph.py::integration_check_node`** — wires the postcondition between the agent parse-error guard and the lint step. On failure returns
```
{"skipped": True, "postcondition_failed": True, "reason": <human-readable details>}
```
so the pipeline router sees a structured failure rather than a falsely-clean `integration_result`.

**`orchestrator/tests/test_integration_lead.py`** — 7 new unit tests for the postcondition itself (including a direct reproducer of the codec-stub substitution) and mock-fixture updates for the 5 existing `integration_check_node` tests whose stubbed agent output didn't actually instantiate the test blocks.

## Test plan

- [x] `pytest orchestrator/tests/test_integration_lead.py` → 53 passed
- [x] `ruff check orchestrator/` → clean
- [ ] H264 pipeline run in codespace `cs-inverted-q64p449wp2xq54` reaching `integration_check_node` to confirm the postcondition fires (or doesn't) on real Codex output

🤖 Generated with [Claude Code](https://claude.com/claude-code)