### PR TITLE
daemon: warn when /run/start skips the architecture phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,26 @@ export CORESMITH_ENABLE_MEMORY_MAP=0
 export CORESMITH_ENABLE_CLOCK_TREE=0
 export CORESMITH_ENABLE_REGISTER_SPEC=0
 
-# Start the daemon + a fresh pipeline run
+# Start the daemon
 bin/coresmith daemon start --project-root $RUN_DIR
+
+# (1) Architecture phase — generates PRD, ERS, FRD, block_diagram.json
+#     and the initial arch/uarch_specs/<block>.md files from a
+#     natural-language requirements doc. Parks at PRD review, block
+#     diagram review, constraint check, etc.; outer agent resumes
+#     each via `coresmith resume`.
+bin/coresmith architecture start --project-root $RUN_DIR \
+    --requirements $RUN_DIR/inputs/requirements.md
+
+# (2) Frontend pipeline — runs against the architecture artifacts from (1)
+#     OR against a hand-written examples/<design>/blocks.yaml if you are
+#     intentionally skipping the architecture phase. Skipping is supported
+#     but the daemon will print a warning at /run/start because
+#     `integration_review` then can't verify cross-block data_width and
+#     `validation_dv` soft-aborts on missing ERS. Set
+#     CORESMITH_SKIP_ARCH_WARN=1 to silence the warning for rapid
+#     iteration / PPABench-style runs where you only care about the
+#     per-block frontend loop.
 bin/coresmith run start --project-root $RUN_DIR \
     --blocks-file /home/ubuntu/coresmith/examples/<design>/blocks.yaml
 

--- a/bin/coresmith
+++ b/bin/coresmith
@@ -247,7 +247,10 @@ def _run_start(args):
         "target_clock_mhz": args.target_clock_mhz,
         "blocks_file": args.blocks_file or "",
     }
-    print(json.dumps(_post(project_root, "/run/start", body), indent=2))
+    response = _post(project_root, "/run/start", body)
+    for w in response.get("warnings", []) or []:
+        print(f"warning: {w}", file=sys.stderr)
+    print(json.dumps(response, indent=2))
 
 
 def _run_pause(args):

--- a/orchestrator/daemon/server.py
+++ b/orchestrator/daemon/server.py
@@ -151,6 +151,7 @@ async def run_start(req: StartRequest):
         )
 
     _preflight_or_400()
+    arch_warnings = _check_architecture_artifacts(_PROJECT_ROOT)
     await _pipeline.reset_for_new_run()
 
     events_path = Path(_PROJECT_ROOT) / ".coresmith" / "pipeline_events.jsonl"
@@ -172,7 +173,14 @@ async def run_start(req: StartRequest):
 
     graph_config = {"configurable": {"thread_id": _pipeline.thread_id}}
     await _pipeline.safe_start(initial_state, graph_config)
-    return {"started": True, "block_count": len(block_queue), "status": _pipeline.status}
+    response = {
+        "started": True,
+        "block_count": len(block_queue),
+        "status": _pipeline.status,
+    }
+    if arch_warnings:
+        response["warnings"] = arch_warnings
+    return response
 
 
 @app.post("/run/resume")
@@ -463,6 +471,48 @@ def _preflight_or_400():
             "details": check["errors"],
             "warnings": check.get("warnings", []),
         })
+
+
+def _check_architecture_artifacts(project_root: str) -> list[str]:
+    """Return a list of warnings if the frontend pipeline is about to run
+    without architecture-phase artifacts (PRD / ERS / block_diagram).
+
+    The frontend pipeline can run against just `blocks.yaml` + a
+    `generate_uarch_spec` per-block fallback, but the chip-level
+    `integration_review` and `validation_dv` nodes need the architecture
+    artifacts to do their job. When they're missing those nodes don't
+    hard-fail — they soft-fail / abort silently — so the user thinks the
+    run finished cleanly when it really skipped requirement validation.
+
+    Set CORESMITH_SKIP_ARCH_WARN=1 to suppress this warning (PPABench /
+    rapid-iteration flows that intentionally skip the architecture phase).
+    """
+    if os.environ.get("CORESMITH_SKIP_ARCH_WARN", "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }:
+        return []
+
+    root = Path(project_root)
+    expected = {
+        "PRD spec": root / ".coresmith" / "prd_spec.json",
+        "ERS spec": root / "arch" / "ers_spec.md",
+        "block diagram": root / ".coresmith" / "block_diagram.json",
+    }
+    missing = [label for label, path in expected.items() if not path.exists()]
+    if not missing:
+        return []
+
+    return [
+        (
+            f"Architecture-phase artifacts missing: {', '.join(missing)}. "
+            "The frontend pipeline will still run from blocks.yaml + uArch "
+            "spec generation, but `integration_review` cannot verify "
+            "cross-block data_width and `validation_dv` will soft-abort "
+            "with 'No ERS found'. To exercise the full pipeline run "
+            "`coresmith architecture start --requirements <spec>.md` first. "
+            "Set CORESMITH_SKIP_ARCH_WARN=1 to silence this warning."
+        )
+    ]
 
 
 def _shape_state(state_snapshot) -> dict:

--- a/orchestrator/tests/test_daemon_arch_warning.py
+++ b/orchestrator/tests/test_daemon_arch_warning.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the architecture-artifacts warning emitted by the daemon's
+`/run/start` endpoint when the frontend pipeline is launched without an
+upstream architecture phase run."""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.daemon.server import _check_architecture_artifacts
+
+
+class TestCheckArchitectureArtifacts:
+    def test_no_warnings_when_all_present(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CORESMITH_SKIP_ARCH_WARN", raising=False)
+        (tmp_path / ".coresmith").mkdir()
+        (tmp_path / "arch").mkdir()
+        (tmp_path / ".coresmith" / "prd_spec.json").write_text("{}")
+        (tmp_path / "arch" / "ers_spec.md").write_text("# ERS")
+        (tmp_path / ".coresmith" / "block_diagram.json").write_text("{}")
+
+        assert _check_architecture_artifacts(str(tmp_path)) == []
+
+    def test_warns_when_all_missing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CORESMITH_SKIP_ARCH_WARN", raising=False)
+        warnings = _check_architecture_artifacts(str(tmp_path))
+
+        assert len(warnings) == 1
+        w = warnings[0]
+        assert "PRD spec" in w
+        assert "ERS spec" in w
+        assert "block diagram" in w
+        assert "coresmith architecture start" in w
+        assert "CORESMITH_SKIP_ARCH_WARN" in w
+
+    def test_warns_when_only_ers_missing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CORESMITH_SKIP_ARCH_WARN", raising=False)
+        (tmp_path / ".coresmith").mkdir()
+        (tmp_path / ".coresmith" / "prd_spec.json").write_text("{}")
+        (tmp_path / ".coresmith" / "block_diagram.json").write_text("{}")
+
+        warnings = _check_architecture_artifacts(str(tmp_path))
+        assert len(warnings) == 1
+        assert "ERS spec" in warnings[0]
+        assert "PRD spec" not in warnings[0]
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "Yes"])
+    def test_skip_env_var_suppresses_warning(self, tmp_path, monkeypatch, value):
+        monkeypatch.setenv("CORESMITH_SKIP_ARCH_WARN", value)
+        # Even though all artifacts are missing, we suppress.
+        assert _check_architecture_artifacts(str(tmp_path)) == []
+
+    def test_skip_env_var_off_does_not_suppress(self, tmp_path, monkeypatch):
+        # Values other than the truthy set should NOT suppress.
+        monkeypatch.setenv("CORESMITH_SKIP_ARCH_WARN", "0")
+        warnings = _check_architecture_artifacts(str(tmp_path))
+        assert len(warnings) == 1
+
+        monkeypatch.setenv("CORESMITH_SKIP_ARCH_WARN", "")
+        warnings = _check_architecture_artifacts(str(tmp_path))
+        assert len(warnings) == 1


### PR DESCRIPTION
## Summary

Adds a warning to the daemon's `/run/start` response when the frontend pipeline is launched without architecture-phase artifacts (`prd_spec.json`, `arch/ers_spec.md`, `.coresmith/block_diagram.json`). Surfaces it via the CLI to stderr so it's visible at the moment the user makes the choice — they currently only find out by reading the deep-pipeline interrupt payloads many minutes later.

## Why

Today's PPABench runs in `cs-inverted-q64p449wp2xq54`:
- **mcu3**: 1/1 block + 8/8 integration-DV tests passed, then `validation_dv` silently aborted on missing ERS → daemon reported `status: done, pipeline_done: false` (a half-success the user has no immediate signal for).
- **h264**: 8/8 blocks + 2/3 integration-review mismatches fixed by the agent, 1 unresolvable ("block_diagram.json missing") → integration_review couldn't verify cross-block `data_width`.

Both runs used `coresmith run start --blocks-file` directly (the recipe in `CLAUDE.md`), which doesn't run the architecture phase. The frontend pipeline can run without those artifacts but the chip-level review nodes can't fully exercise their checks.

## What changed

**`orchestrator/daemon/server.py`** — new `_check_architecture_artifacts(project_root)` helper, called from `/run/start` after preflight. Returns a single, human-readable warning string when any of PRD/ERS/block_diagram is missing. Suppressed via `CORESMITH_SKIP_ARCH_WARN=1` (for rapid iteration / PPABench-style runs that intentionally skip).

**`bin/coresmith`** — `_run_start` prints `warning: ...` lines to stderr before the JSON body, so scripted JSON consumers aren't broken and interactive users see it.

**`CLAUDE.md`** — "How to run" recipe rewritten to show both phases in order (`architecture start` then `run start`), with explicit documentation that skipping is supported but trips the warning. This was the documentation gap that led to today's silent-skip runs.

## Test plan

- [x] `pytest orchestrator/tests/test_daemon_arch_warning.py` → 10/10 passed
- [x] `ruff check orchestrator/` → clean
- [ ] Restart the daemon in `cs-inverted-q64p449wp2xq54` and observe the warning on a fresh `run start` (verifying via CLI stderr + JSON `warnings` array)

🤖 Generated with [Claude Code](https://claude.com/claude-code)