### PR TITLE
integration_check: triage warning-severity mismatches via outer-agent interrupt

### DIFF
--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -2553,6 +2553,104 @@ async def integration_check_node(state: OrchestratorState) -> dict:
 
             return {"integration_result": integration_result}
 
+        if (
+            warnings
+            and not os.getenv("CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS")
+        ):
+            log(
+                f"  [INTEGRATION] {len(warnings)} warning(s) -- triaging "
+                "for outer-agent review",
+                YELLOW,
+            )
+
+            warning_payload = {
+                "type": "integration_warning_review",
+                "design_name": design_name,
+                "top_rtl_path": top_rtl_path,
+                "block_count": len(modules),
+                "error_count": 0,
+                "warning_count": len(warnings),
+                "lint_clean": True,
+                "warnings": warnings,
+                "mismatches": mismatches,
+                "block_rtl_paths": rtl_paths,
+                "skipped_connections": agent_result.get(
+                    "skipped_connections", []
+                ),
+                "supported_actions": [
+                    "accept",
+                    "retry",
+                    "fix_rtl",
+                    "abort",
+                ],
+                "outer_agent_guidance": (
+                    "Integration Lead agent flagged warnings but no hard "
+                    "errors. Architecture warnings have caused DV deadlocks "
+                    "in practice (closed AXI-Stream feedback loops without "
+                    "a bootstrap policy, etc.), so triage before letting "
+                    "the run reach DV:\n"
+                    "1. Read each warning's `description` and "
+                    "`suggested_fix`.\n"
+                    "2. If the warning is benign or compensated elsewhere, "
+                    "resume_pipeline(action='accept').\n"
+                    "3. If a block needs patching, edit it on disk, then "
+                    "resume_pipeline(action='fix_rtl', "
+                    "rtl_fix_description='...'). The run will END so you "
+                    "can issue restart_node for the affected stage.\n"
+                    "4. If the integration top should be regenerated, "
+                    "resume_pipeline(action='retry'). The run will END so "
+                    "you can restart_node('integration_check').\n"
+                    "5. If a uArch-level revision is needed (e.g. add a "
+                    "request-driven bootstrap path), "
+                    "resume_pipeline(action='abort') and escalate.\n"
+                    "Set CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS=1 to "
+                    "restore the old non-blocking behavior."
+                ),
+                "reference_files": {
+                    "top_rtl": top_rtl_path,
+                    "architecture": ".coresmith/architecture_state.json",
+                    "block_diagram": ".coresmith/block_diagram_viz.json",
+                },
+            }
+
+            response = interrupt(warning_payload)
+            action = (
+                response.get("action", "abort")
+                if isinstance(response, dict)
+                else "abort"
+            )
+            integration_result["warning_triage_action"] = action
+
+            write_graph_event(pr, "Integration Check", "graph_node_exit", {
+                "action": action,
+                "warning_count": len(warnings),
+                "via": "warning_triage",
+            })
+
+            if action == "accept":
+                integration_result["accepted_warnings"] = True
+                log(
+                    "  [INTEGRATION] Warnings accepted by outer agent",
+                    GREEN,
+                )
+            elif action in ("retry", "fix_rtl"):
+                fix_desc = response.get("rtl_fix_description", "")
+                integration_result["fix_applied"] = fix_desc
+                integration_result["aborted"] = True
+                log(
+                    f"  [INTEGRATION] {action} requested "
+                    f"(desc='{fix_desc}'); routing to END so outer agent "
+                    "can restart_node",
+                    YELLOW,
+                )
+            else:  # abort or unknown
+                integration_result["aborted"] = True
+                log(
+                    "  [INTEGRATION] Aborted on warning triage", RED
+                )
+
+            return {"integration_result": integration_result}
+
         log(f"\n{'='*60}", GREEN)
         log("  INTEGRATION CHECK PASSED", GREEN)
         log(f"  Top module: {module_name}", GREEN)

--- a/orchestrator/tests/test_integration_lead.py
+++ b/orchestrator/tests/test_integration_lead.py
@@ -993,6 +993,213 @@ class TestIntegrationCheckNode:
 
 
 # ---------------------------------------------------------------------------
+# integration_check_node: warning-only triage (matches arch constraint flow)
+# ---------------------------------------------------------------------------
+
+class TestIntegrationCheckWarningTriage:
+    """integration_check_node must triage warning-only mismatches via an
+    outer-agent interrupt before letting the run advance to DV. The
+    closed-feedback warning from the h264 v4 run predicted the exact DV
+    deadlock that followed, so warnings are no longer silently dropped."""
+
+    def _state(self):
+        return {
+            "project_root": "/tmp/test",
+            "completed_blocks": [
+                {"name": "a", "success": True, "rtl_path": "/tmp/a.v"},
+                {"name": "b", "success": True, "rtl_path": "/tmp/b.v"},
+            ],
+            "pipeline_done": False,
+        }
+
+    def _common_patches(self, mismatches, interrupt_response):
+        from orchestrator.langgraph.integration_helpers import (
+            VerilogModule, VerilogPort,
+        )
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        mod = VerilogModule(name="a", ports=[VerilogPort("clk", "input")])
+
+        patches = [
+            patch(
+                "orchestrator.langgraph.pipeline_graph.load_architecture_connections",
+                return_value=(SAMPLE_CONNECTIONS, "chip_top"),
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.discover_block_rtl",
+                return_value={"a": "/tmp/a.v", "b": "/tmp/b.v"},
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.parse_verilog_ports",
+                return_value=mod,
+            ),
+            patch(
+                "orchestrator.langchain.agents.integration_lead."
+                "IntegrationLeadAgent.integrate",
+                new_callable=AsyncMock,
+                return_value={
+                    "verilog": CHIP_TOP_AB,
+                    "mismatches": mismatches,
+                    "module_name": "chip_top",
+                    "wire_count": 0,
+                    "skipped_connections": [],
+                    "notes": "",
+                },
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.lint_top_level",
+                return_value={"clean": True, "warnings": ""},
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.interrupt",
+                return_value=interrupt_response,
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.write_graph_event"
+            ),
+            patch("pathlib.Path.read_text", return_value=CHIP_TOP_AB),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+        ]
+        for p in patches:
+            stack.enter_context(p)
+        return stack
+
+    _WARNING = {
+        "from_block": "a",
+        "to_block": "b",
+        "issue_type": "prd_violation",
+        "severity": "warning",
+        "description": "Closed AXI-Stream feedback loop without bootstrap",
+        "suggested_fix": "Add request-driven neighbor lookup",
+    }
+
+    @pytest.mark.asyncio
+    async def test_warning_only_fires_triage_interrupt(self, monkeypatch):
+        monkeypatch.delenv(
+            "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", raising=False
+        )
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        captured = {}
+
+        def fake_interrupt(payload):
+            captured.update(payload)
+            return {"action": "accept"}
+
+        with self._common_patches([self._WARNING], {"action": "accept"}), \
+                patch(
+                    "orchestrator.langgraph.pipeline_graph.interrupt",
+                    side_effect=fake_interrupt,
+                ):
+            await integration_check_node(self._state())
+
+        assert captured["type"] == "integration_warning_review"
+        assert captured["warning_count"] == 1
+        assert captured["error_count"] == 0
+        assert captured["lint_clean"] is True
+        assert "accept" in captured["supported_actions"]
+        assert "retry" in captured["supported_actions"]
+        assert "fix_rtl" in captured["supported_actions"]
+        assert "abort" in captured["supported_actions"]
+        # Outer agent guidance must explicitly mention the bootstrap class of
+        # failure so the reviewer understands what they're triaging.
+        assert "bootstrap" in captured["outer_agent_guidance"].lower()
+
+    @pytest.mark.asyncio
+    async def test_warning_triage_accept_proceeds(self, monkeypatch):
+        monkeypatch.delenv(
+            "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", raising=False
+        )
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        with self._common_patches([self._WARNING], {"action": "accept"}):
+            result = await integration_check_node(self._state())
+
+        ir = result["integration_result"]
+        assert ir["accepted_warnings"] is True
+        assert ir["warning_triage_action"] == "accept"
+        assert ir.get("aborted") is None
+        assert ir["lint_clean"] is True
+        # route_after_integration will see lint_clean=True, error_count=0,
+        # no aborted -> routes to integration_dv.
+        from orchestrator.langgraph.pipeline_graph import route_after_integration
+        assert route_after_integration(result) == "integration_dv"
+
+    @pytest.mark.asyncio
+    async def test_warning_triage_abort_ends_pipeline(self, monkeypatch):
+        monkeypatch.delenv(
+            "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", raising=False
+        )
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        with self._common_patches([self._WARNING], {"action": "abort"}):
+            result = await integration_check_node(self._state())
+
+        ir = result["integration_result"]
+        assert ir["aborted"] is True
+        assert ir["warning_triage_action"] == "abort"
+        assert ir.get("accepted_warnings") is None
+
+    @pytest.mark.asyncio
+    async def test_warning_triage_retry_ends_with_fix_recorded(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv(
+            "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", raising=False
+        )
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        with self._common_patches(
+            [self._WARNING],
+            {
+                "action": "fix_rtl",
+                "rtl_fix_description": "added neighbor bootstrap port",
+            },
+        ):
+            result = await integration_check_node(self._state())
+
+        ir = result["integration_result"]
+        # retry / fix_rtl both route to END so the outer agent can issue
+        # restart_node via MCP for the right stage.
+        assert ir["aborted"] is True
+        assert ir["fix_applied"] == "added neighbor bootstrap port"
+        assert ir["warning_triage_action"] == "fix_rtl"
+
+    @pytest.mark.asyncio
+    async def test_nonblocking_env_var_restores_old_behaviour(self, monkeypatch):
+        """CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS=1 restores the
+        pre-change behaviour where warning-only integration results
+        silently proceed to integration_dv with no interrupt."""
+        monkeypatch.setenv("CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", "1")
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        # If the env var really suppresses the triage, this fake_interrupt
+        # must NOT be called by the warning-only path. (The error/lint path
+        # would still call interrupt, but we have no errors and lint is clean
+        # in this fixture, so any call here is a regression.)
+        fake_interrupt = patch(
+            "orchestrator.langgraph.pipeline_graph.interrupt",
+            side_effect=AssertionError(
+                "interrupt() should not fire when "
+                "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS=1"
+            ),
+        )
+
+        with self._common_patches([self._WARNING], {"action": "accept"}), \
+                fake_interrupt:
+            result = await integration_check_node(self._state())
+
+        ir = result["integration_result"]
+        assert ir["warning_count"] == 1
+        assert ir["lint_clean"] is True
+        assert ir.get("accepted_warnings") is None
+        assert ir.get("warning_triage_action") is None
+        assert ir.get("aborted") is None
+
+
+# ---------------------------------------------------------------------------
 # Graph construction still works
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- When the Integration Lead agent returns warning-only mismatches (no errors, lint clean), `integration_check_node` now raises an `integration_warning_review` interrupt for outer-agent triage instead of silently proceeding to integration DV.
- Mirrors the architecture-phase constraint-check escalation flow that already required outer-agent decisions on violations.
- Supported actions: `accept` (proceed to DV), `retry` / `fix_rtl` (END so outer agent can `restart_node` via MCP), `abort`.
- Gated for rollback via `CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS=1`.

## Motivation

In the h264 v4 PPABench run, the closed AXI-Stream feedback warning between `rd_mode_transform_quant_engine` and `recon_neighbor_store` predicted the exact deadlock that then made integration DV starve at macroblock 0 — but the warning was logged `(non-blocking)` and the run advanced straight to DV. The contract audit's post-DV diagnosis was `UARCH_INTERFACE_CONTRACT_ERROR` with `recommended_action=revise_uarch`, matching the original warning word-for-word.

Promoting these warnings to a triaged interrupt lets the outer agent stop the run before the wasted DV cycle, or accept the warning explicitly when it's compensated elsewhere.

## Test plan

- [x] `pytest orchestrator/tests/test_integration_lead.py::TestIntegrationCheckWarningTriage` — 5 new tests cover: triage interrupt fires with correct payload, `accept` proceeds, `abort` ends, `fix_rtl` ends with `fix_applied`, env var restores old behavior
- [x] `pytest orchestrator/tests/test_integration_lead.py::TestIntegrationCheckNode` — existing 12 tests still pass (no regression to error/lint paths)
- [x] `pytest orchestrator/tests/test_pipeline_graph.py::TestRouteAfterIntegration` — routing still correct (accept path goes to integration_dv; aborted goes to END)

🤖 Generated with [Claude Code](https://claude.com/claude-code)