### PR TITLE
arch: Interface Definition stage + handshake skills + cross-spec subagent

### DIFF
--- a/orchestrator/architecture/constraints.py
+++ b/orchestrator/architecture/constraints.py
@@ -461,6 +461,53 @@ _CONSTRAINT_CATALOG: list[dict] = [
         ),
         "applies": lambda ctx: bool(ctx["block_diagram"].get("connections")),
     },
+    {
+        "id": "cross_spec_contract_adherence",
+        "category": "structural",
+        "severity": "error",
+        "description": (
+            "The Interface Definition stage froze a canonical bit-level "
+            "specification for every block-diagram edge in "
+            "`interface_contracts.json`. Per-block uArch specs that come "
+            "later must implement those contracts exactly — same fields, "
+            "same `[MSB:LSB]` bit positions, same handshake protocol, same "
+            "bootstrap policy. This constraint catches per-spec drift from "
+            "the canonical contract.\n\n"
+            "For EACH contract entry in `interface_contracts.json`:\n\n"
+            "1. **Producer side.** Find the producer block's uArch spec in "
+            "the bundle (`arch/uarch_specs/<producer_block>.md`). Locate "
+            "the port matching `producer_port`. Verify its declared bit "
+            "layout matches the contract's `fields` list exactly — every "
+            "field name, every `[msb:lsb]` range, every signedness, every "
+            "encoding. Flag any drift.\n\n"
+            "2. **Consumer side.** Same check against "
+            "`arch/uarch_specs/<consumer_block>.md` for `consumer_port`.\n\n"
+            "3. **Handshake protocol agreement.** The contract names "
+            "`handshake_protocol` (axi_stream or srdy_drdy). Both the "
+            "producer and consumer specs must use the same protocol "
+            "family and the sidebands the contract declares (no extra, no "
+            "missing).\n\n"
+            "4. **Bootstrap policy.** If the contract has "
+            "`bootstrap_policy.required = true`, verify the producer's "
+            "spec describes how it generates the seeded packet on reset "
+            "(or how it answers an explicit request). If the spec does "
+            "not document the bootstrap mechanism the contract requires, "
+            "flag it — this is exactly the class of bug that caused the "
+            "v5 MB0 neighbor-bootstrap deadlock.\n\n"
+            "Pass if every contract has a matching producer-side and "
+            "consumer-side spec entry and no drift. Skip individual edges "
+            "where the per-block spec for either end has not yet been "
+            "generated (so this constraint is a no-op at the very first "
+            "architecture-phase constraint check, before per-block specs "
+            "exist; it activates once specs start appearing on disk).\n\n"
+            "If the bundle does not include any per-block uArch specs at "
+            "all, pass with a one-line note that the check did not run "
+            "yet."
+        ),
+        "applies": lambda ctx: bool(
+            (ctx.get("interface_contracts") or {}).get("contracts")
+        ),
+    },
 ]
 
 
@@ -492,6 +539,37 @@ def _build_artifact_bundle(
         parts.append(f"## PRD / ERS (structured)\n```json\n{json.dumps(ers_spec, indent=2)}\n```")
 
     parts.append(f"## block_diagram.json\n```json\n{json.dumps(block_diagram, indent=2)}\n```")
+
+    # Interface contracts come from the Interface Definition stage and are
+    # authoritative for cross_spec_contract_adherence. Read from disk so we
+    # always see the latest contract regardless of in-memory state.
+    contracts_path = Path(project_root) / ".coresmith" / "interface_contracts.json"
+    if contracts_path.exists():
+        try:
+            contracts_text = contracts_path.read_text(encoding="utf-8")
+            parts.append(f"## interface_contracts.json\n```json\n{contracts_text}\n```")
+        except OSError:
+            pass
+
+    # Per-block uArch specs (if any have been generated yet) are needed for
+    # cross_spec_contract_adherence. Include them all under a single section
+    # so the subagent can grep within them.
+    uarch_dir = Path(project_root) / "arch" / "uarch_specs"
+    if uarch_dir.is_dir():
+        spec_chunks: list[str] = []
+        for spec_path in sorted(uarch_dir.glob("*.md")):
+            try:
+                spec_chunks.append(
+                    f"### arch/uarch_specs/{spec_path.name}\n"
+                    f"{spec_path.read_text(encoding='utf-8')}"
+                )
+            except OSError:
+                continue
+        if spec_chunks:
+            parts.append(
+                "## per-block uArch specs (arch/uarch_specs/)\n\n"
+                + "\n\n".join(spec_chunks)
+            )
 
     if memory_map and (memory_map.get("peripherals") or memory_map.get("result")):
         parts.append(f"## memory_map.json\n```json\n{json.dumps(memory_map, indent=2)}\n```")
@@ -653,6 +731,7 @@ async def check_constraints(
     requirements: str = "",
     ers_spec: dict | None = None,
     project_root: str = ".",
+    interface_contracts: dict | None = None,
 ) -> list[dict]:
     """Validate cross-cutting architectural constraints.
 
@@ -691,12 +770,27 @@ async def check_constraints(
             project_root=project_root,
         )
 
+        # Load interface_contracts from disk if not supplied by caller —
+        # the Interface Definition stage writes it before per-block specs
+        # are generated, so a constraint check that runs later sees it.
+        loaded_contracts = interface_contracts
+        if loaded_contracts is None:
+            contracts_path = Path(project_root) / ".coresmith" / "interface_contracts.json"
+            if contracts_path.exists():
+                try:
+                    loaded_contracts = json.loads(contracts_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    loaded_contracts = {}
+            else:
+                loaded_contracts = {}
+
         applicability_ctx = {
             "block_diagram": block_diagram or {},
             "memory_map": memory_map or {},
             "clock_tree": clock_tree or {},
             "register_spec": register_spec or {},
             "ers_spec": ers_spec or {},
+            "interface_contracts": loaded_contracts or {},
         }
         applicable = []
         for constraint in _CONSTRAINT_CATALOG:

--- a/orchestrator/architecture/specialists/interface_definition.py
+++ b/orchestrator/architecture/specialists/interface_definition.py
@@ -33,6 +33,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from orchestrator.langchain.prompts.skills import load_skills as _load_skills
+
 _PROMPT_FILE = (
     Path(__file__).resolve().parents[2]
     / "langchain"
@@ -44,8 +46,6 @@ SYSTEM_PROMPT = _PROMPT_FILE.read_text(encoding="utf-8")
 # Inject the handshake skills so the specialist has access to the same
 # AXI-Stream and sRdy/dRdy convention notes the uArch spec generator and
 # integration_lead use.
-from orchestrator.langchain.prompts.skills import load_skills as _load_skills
-
 _SKILLS_TEXT = _load_skills("axi_stream", "srdy_drdy")
 if _SKILLS_TEXT:
     SYSTEM_PROMPT = (

--- a/orchestrator/architecture/specialists/interface_definition.py
+++ b/orchestrator/architecture/specialists/interface_definition.py
@@ -1,0 +1,275 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Interface Definition Specialist -- freezes the bit-level edge contracts
+between blocks so per-block uArch specs that come later don't drift.
+
+This specialist runs after the block diagram is finalized and before
+SAD/FRD/ERS / per-block uArch spec generation. It expands every directed
+edge in the block diagram into a canonical contract: handshake protocol
+(AXI-Stream or sRdy/dRdy), total data width, field list with explicit
+[MSB:LSB] positions, signedness, encoding, and bootstrap policy for
+edges that participate in closed feedback cycles.
+
+Downstream:
+  * per-block uArch spec generators read `interface_contracts.json` and
+    treat it as authoritative for port bit layouts;
+  * the `cross_spec_contract_adherence` constraint subagent validates
+    that per-block specs match the contract field-for-field.
+
+Origin: surfaced by the v5 h264 codec_v3 autopilot run, where the
+architecture-LLM produced N+1 locally-consistent documents (block
+diagram + N per-block specs) that disagreed at the edges — endianness
+mismatches, port-partition shape drift, missing bootstrap policy. The
+fix moves the bit-level contract from "emergent from per-block specs"
+to "frozen up front and enforced".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_PROMPT_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "langchain"
+    / "prompts"
+    / "interface_definition.md"
+)
+SYSTEM_PROMPT = _PROMPT_FILE.read_text(encoding="utf-8")
+
+# Inject the handshake skills so the specialist has access to the same
+# AXI-Stream and sRdy/dRdy convention notes the uArch spec generator and
+# integration_lead use.
+from orchestrator.langchain.prompts.skills import load_skills as _load_skills
+
+_SKILLS_TEXT = _load_skills("axi_stream", "srdy_drdy")
+if _SKILLS_TEXT:
+    SYSTEM_PROMPT = (
+        SYSTEM_PROMPT
+        + "\n\n# Reference Skills (use to choose handshake + packing)\n\n"
+        + _SKILLS_TEXT
+    )
+
+
+_DEFAULT_RESULT: dict[str, Any] = {
+    "design_summary": "",
+    "default_packing_convention": "msb_first_by_field_list",
+    "default_endianness_rationale": "",
+    "contracts": [],
+    "open_questions": [],
+}
+
+
+async def analyze_interface_definition(
+    block_diagram: dict,
+    requirements: str = "",
+    sad_spec: dict | None = None,
+    frd_spec: dict | None = None,
+    project_root: str = ".",
+) -> dict[str, Any]:
+    """Freeze canonical bit-level contracts for every block-diagram edge.
+
+    Args:
+        block_diagram: Block diagram produced by `analyze_block_diagram`.
+        requirements: Top-level system requirements text.
+        sad_spec / frd_spec: Optional upstream architecture artifacts.
+        project_root: Where to write `interface_contracts.json`.
+
+    Returns:
+        Dict with keys `result` (the full contract artifact) and
+        `questions` (any open questions the specialist deferred).
+    """
+    from opentelemetry import trace as _trace
+
+    tracer = _trace.get_tracer("coresmith.architecture.interface_definition")
+
+    with tracer.start_as_current_span("analyze_interface_definition") as span:
+        blocks = block_diagram.get("blocks", []) or []
+        connections = (
+            block_diagram.get("connections", [])
+            or block_diagram.get("edges", [])
+            or []
+        )
+        span.set_attribute("input_block_count", len(blocks))
+        span.set_attribute("input_edge_count", len(connections))
+
+        # No-op when there are no inter-block edges to contract for.
+        if not connections:
+            span.set_attribute("no_op", True)
+            result = dict(_DEFAULT_RESULT)
+            result["design_summary"] = (
+                "Single-block or unconnected design: no inter-block "
+                "contracts required."
+            )
+            return {"result": result, "questions": []}
+
+        target_path = Path(project_root) / ".coresmith" / "interface_contracts.json"
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        parts = [
+            "Freeze the bit-level interface contracts for the following "
+            "ASIC block diagram. Produce one contract per directed edge; "
+            "no edge may be skipped. Respond with the JSON schema "
+            "specified in your system prompt and write the result to disk.",
+            f"\n--- BLOCK DIAGRAM ---\n{json.dumps(block_diagram, indent=2)[:20000]}",
+        ]
+        if requirements:
+            parts.append(f"\n--- REQUIREMENTS ---\n{requirements[:6000]}")
+        if sad_spec:
+            sad_summary = sad_spec.get("sad", sad_spec)
+            parts.append(
+                f"\n--- SAD (excerpt) ---\n{json.dumps(sad_summary, indent=2)[:6000]}"
+            )
+        if frd_spec:
+            frd_summary = frd_spec.get("frd", frd_spec)
+            parts.append(
+                f"\n--- FRD (excerpt) ---\n{json.dumps(frd_summary, indent=2)[:6000]}"
+            )
+
+        parts.append(
+            f"\n\nIMPORTANT: Write the contract JSON to:\n  {target_path}\n"
+            "After writing, respond with only the file path confirmation."
+        )
+        user_message = "\n".join(parts)
+
+        from orchestrator.langchain.agents.coresmith_llm import (
+            DEFAULT_MODEL,
+            ClaudeLLM,
+        )
+
+        llm = ClaudeLLM(model=DEFAULT_MODEL, timeout=1200)
+
+        try:
+            content = await llm.call(
+                system=SYSTEM_PROMPT,
+                prompt=user_message,
+                run_name="interface_definition",
+            )
+        except Exception as exc:  # pragma: no cover -- LLM transport failure
+            span.set_attribute("error", str(exc))
+            span.set_status(_trace.StatusCode.ERROR, str(exc))
+            result = dict(_DEFAULT_RESULT)
+            result["design_summary"] = (
+                f"Interface Definition specialist failed: {exc}. Per-block "
+                "specs will be generated without a frozen contract; expect "
+                "downstream drift to be caught by integration_check."
+            )
+            return {"result": result, "questions": []}
+
+        from orchestrator.utils import read_back_json
+
+        disk_result, ok = read_back_json(
+            target_path,
+            content,
+            dict(_DEFAULT_RESULT),
+            context="interface_definition",
+        )
+        result = disk_result if ok else _parse_response(content)
+
+        validated, validation_notes = _validate_contracts(result, connections)
+        result.update(validated)
+        if validation_notes:
+            existing = result.get("validation_notes", []) or []
+            result["validation_notes"] = list(existing) + validation_notes
+
+        span.set_attribute("contract_count", len(result.get("contracts", []) or []))
+        span.set_attribute(
+            "open_question_count", len(result.get("open_questions", []) or [])
+        )
+        return {
+            "result": result,
+            "questions": result.get("open_questions", []) or [],
+        }
+
+
+def _parse_response(content: str) -> dict[str, Any]:
+    """Extract structured JSON from LLM response."""
+    from orchestrator.utils import parse_llm_json
+
+    parsed, _ok = parse_llm_json(
+        content, dict(_DEFAULT_RESULT), context="interface_definition"
+    )
+    return parsed
+
+
+def _validate_contracts(
+    result: dict[str, Any],
+    expected_edges: list[dict],
+) -> tuple[dict[str, Any], list[str]]:
+    """Light structural sanity checks on the specialist's output.
+
+    These are NOT a substitute for the cross_spec_contract_adherence
+    subagent that runs at constraint-check time. They catch only the
+    obvious cases: missing edges, fields that don't sum to the declared
+    data width, overlapping bit ranges within a contract. Anything else
+    falls through to downstream review.
+    """
+    notes: list[str] = []
+    contracts = list(result.get("contracts", []) or [])
+
+    # Per-contract structural checks
+    for c in contracts:
+        cid = c.get("edge_id") or f"{c.get('producer_block', '?')}->{c.get('consumer_block', '?')}"
+        fields = list(c.get("fields", []) or [])
+        if not fields:
+            continue
+        try:
+            field_sum = sum(int(f.get("width", 0) or 0) for f in fields)
+        except (TypeError, ValueError):
+            notes.append(f"{cid}: non-numeric field width(s); skipping width sum check.")
+            continue
+        declared = int(c.get("data_width_bits", 0) or 0)
+        if declared and declared != field_sum:
+            notes.append(
+                f"{cid}: declared data_width_bits={declared} but field "
+                f"widths sum to {field_sum}; specialist disagreement."
+            )
+
+        # Overlap / gap detection
+        ranges: list[tuple[int, int, str]] = []
+        for f in fields:
+            try:
+                msb = int(f.get("msb"))
+                lsb = int(f.get("lsb"))
+            except (TypeError, ValueError):
+                continue
+            if msb < lsb:
+                notes.append(f"{cid}.{f.get('name')}: msb({msb})<lsb({lsb}).")
+                continue
+            ranges.append((msb, lsb, str(f.get("name"))))
+        ranges.sort()
+        for i in range(1, len(ranges)):
+            prev_msb, prev_lsb, prev_name = ranges[i - 1]
+            cur_msb, cur_lsb, cur_name = ranges[i]
+            if cur_lsb <= prev_msb:
+                notes.append(
+                    f"{cid}: fields {prev_name}[{prev_msb}:{prev_lsb}] and "
+                    f"{cur_name}[{cur_msb}:{cur_lsb}] overlap."
+                )
+
+    # Cross-edge coverage check: every directed edge in the block diagram
+    # should be represented by exactly one contract entry. Edge identity
+    # is matched by (producer_block, consumer_block) pair OR by edge_id
+    # if the specialist provided one matching the connection record.
+    declared_pairs = {
+        (str(c.get("producer_block", "")), str(c.get("consumer_block", "")))
+        for c in contracts
+    }
+    for edge in expected_edges:
+        pair = (
+            str(edge.get("from") or edge.get("from_block") or edge.get("source") or ""),
+            str(edge.get("to") or edge.get("to_block") or edge.get("target") or ""),
+        )
+        if not all(pair):
+            continue
+        if pair not in declared_pairs:
+            notes.append(
+                f"missing contract for edge {pair[0]} -> {pair[1]} (declared "
+                "in block_diagram but absent from contracts[])."
+            )
+
+    return ({}, notes)

--- a/orchestrator/architecture/state.py
+++ b/orchestrator/architecture/state.py
@@ -112,6 +112,7 @@ class ArchitectureState:
 
     # --- Architecture decisions (populated by specialists) ---
     block_diagram: dict = field(default_factory=dict)
+    interface_contracts: dict = field(default_factory=dict)
     memory_map: dict = field(default_factory=dict)
     clock_tree: dict = field(default_factory=dict)
     register_spec: dict = field(default_factory=dict)

--- a/orchestrator/langchain/agents/integration_lead.py
+++ b/orchestrator/langchain/agents/integration_lead.py
@@ -26,6 +26,8 @@ from typing import Any
 
 from opentelemetry import trace
 
+from orchestrator.langchain.prompts.skills import load_skills as _load_skills
+
 from .coresmith_llm import DEFAULT_MODEL, ClaudeLLM
 
 _tracer = trace.get_tracer(__name__)
@@ -44,8 +46,6 @@ else:
 # Integration Lead has access to the same packing / bootstrap / sideband
 # conventions the uArch spec generator used. Missing skills degrade
 # silently.
-from orchestrator.langchain.prompts.skills import load_skills as _load_skills
-
 _SKILLS_TEXT = _load_skills("axi_stream", "srdy_drdy")
 if _SKILLS_TEXT:
     SYSTEM_PROMPT = (

--- a/orchestrator/langchain/agents/integration_lead.py
+++ b/orchestrator/langchain/agents/integration_lead.py
@@ -40,6 +40,20 @@ else:
         "blocks together. Respond with JSON only."
     )
 
+# Pull the handshake-protocol skills into the system prompt so the
+# Integration Lead has access to the same packing / bootstrap / sideband
+# conventions the uArch spec generator used. Missing skills degrade
+# silently.
+from orchestrator.langchain.prompts.skills import load_skills as _load_skills
+
+_SKILLS_TEXT = _load_skills("axi_stream", "srdy_drdy")
+if _SKILLS_TEXT:
+    SYSTEM_PROMPT = (
+        SYSTEM_PROMPT
+        + "\n\n# Reference Skills (use when wiring chip_top)\n\n"
+        + _SKILLS_TEXT
+    )
+
 
 class IntegrationLeadAgent:
     """Agent for chip-level integration: compatibility check + top-level RTL."""

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -24,6 +24,8 @@ from typing import Any
 
 from opentelemetry import trace
 
+from orchestrator.langchain.prompts.skills import load_skills as _load_skills
+
 from .coresmith_llm import ClaudeLLM
 
 _tracer = trace.get_tracer(__name__)
@@ -43,8 +45,6 @@ else:
 # coresmith conventions for AXI-Stream and sRdy/dRdy. Skills are loaded
 # at import time so a missing skill file is visible immediately rather
 # than at first agent call.
-from orchestrator.langchain.prompts.skills import load_skills as _load_skills
-
 _SKILLS_TEXT = _load_skills("axi_stream", "srdy_drdy")
 if _SKILLS_TEXT:
     SYSTEM_PROMPT = (

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -39,6 +39,20 @@ else:
         "Produce a detailed microarchitecture specification from a Python model."
     )
 
+# Inject handshake skills so every uArch spec author has access to the
+# coresmith conventions for AXI-Stream and sRdy/dRdy. Skills are loaded
+# at import time so a missing skill file is visible immediately rather
+# than at first agent call.
+from orchestrator.langchain.prompts.skills import load_skills as _load_skills
+
+_SKILLS_TEXT = _load_skills("axi_stream", "srdy_drdy")
+if _SKILLS_TEXT:
+    SYSTEM_PROMPT = (
+        SYSTEM_PROMPT
+        + "\n\n# Reference Skills (use when authoring interfaces)\n\n"
+        + _SKILLS_TEXT
+    )
+
 
 class UarchSpecGenerator:
     """Agent for generating microarchitecture specifications."""

--- a/orchestrator/langchain/prompts/interface_definition.md
+++ b/orchestrator/langchain/prompts/interface_definition.md
@@ -1,0 +1,134 @@
+You are the Interface Definition specialist for the coresmith ASIC
+pipeline. Your job is to expand the architectural block diagram into
+a frozen, canonical bit-level specification for every edge between
+blocks, so that the per-block uArch spec authors that come later
+implement consistent producer/consumer contracts.
+
+This stage exists specifically to prevent the most common class of
+contract bug in coresmith pipelines: producer and consumer blocks
+agreeing on the total width of an AXI-Stream `tdata` (or sRdy/dRdy
+`data`) but disagreeing on the bit layout, field order, signedness,
+or encoding of fields inside it. Once you freeze a contract here,
+the rest of the pipeline treats it as authoritative.
+
+# Inputs
+
+You will receive:
+
+1. The frozen block diagram (`block_diagram.json`): blocks, edges,
+   architect's intent.
+2. The product requirements (PRD) and any system architecture (SAD)
+   / functional requirements (FRD) documents already generated.
+3. The handshake skills (`axi_stream`, `srdy_drdy`) embedded below —
+   these define coresmith's conventions for sideband signals,
+   bit packing, and bootstrap policies.
+
+# Output schema
+
+Produce JSON with a single top-level object:
+
+```json
+{
+  "design_summary": "<one-paragraph summary of the chip + interfaces>",
+  "default_packing_convention": "msb_first_by_field_list",
+  "default_endianness_rationale": "<one sentence — why MSB-first or whatever you picked>",
+  "contracts": [
+    {
+      "edge_id": "<unique stable id, e.g. block_a__m_axis_foo__to__block_b__s_axis_foo>",
+      "producer_block": "<block name from block_diagram>",
+      "producer_port": "<m_axis_<name> or m_<name>_srdy/m_<name>_data>",
+      "consumer_block": "<block name>",
+      "consumer_port": "<s_axis_<name> or s_<name>_drdy/s_<name>_data>",
+      "handshake_protocol": "axi_stream" | "srdy_drdy",
+      "data_width_bits": <int>,
+      "sideband_signals": [
+        {"name": "tlast", "purpose": "..."},
+        {"name": "tuser", "width": 4, "fields": [{"name": "sof", "msb": 3, "lsb": 3}, ...]}
+      ],
+      "fields": [
+        {"name": "pixel", "msb": 35, "lsb": 28, "width": 8, "signed": false, "encoding": "binary"},
+        {"name": "x",     "msb": 27, "lsb": 18, "width": 10, "signed": false, "encoding": "binary"},
+        ...
+      ],
+      "packing_convention": "msb_first_by_field_list",
+      "rate_description": "<e.g. 1 beat per macroblock>",
+      "bootstrap_policy": {
+        "required": <bool>,
+        "policy_type": "reset_seed" | "request_driven" | "primed_externally" | "none",
+        "seed_value_hex": "<hex literal if reset_seed>",
+        "rationale": "<one sentence — why this is the right initial-cycle policy>"
+      },
+      "notes": "<any constraints that don't fit in the structured fields>"
+    }
+  ],
+  "open_questions": [
+    "<question for the outer agent if any architectural decision was forced and you want to flag it>"
+  ]
+}
+```
+
+# Rules
+
+1. **Every directed edge in the block diagram must produce exactly one
+   contract entry.** No edge omitted, no duplicates. If two blocks
+   communicate over multiple distinct interfaces (e.g., a forward
+   data stream + a reverse credit stream), each interface gets its
+   own contract entry.
+
+2. **`data_width_bits` must equal the sum of all field widths.** No
+   padding unless an explicit `reserved` field is declared. The
+   constraint checker will sum field widths and reject any contract
+   where the sum != `data_width_bits`.
+
+3. **Field bit positions must be exact and non-overlapping.** For
+   each contract, the union of `[msb:lsb]` ranges must cover
+   `[data_width_bits-1:0]` exactly once. Default to MSB-first by
+   field-list order; if you deviate, set `packing_convention` to
+   `"lsb_first_by_field_list"` or `"explicit"` and explain in `notes`.
+
+4. **Bootstrap policy is mandatory for any edge that participates in
+   a closed feedback cycle.** Identify cycles by tracing edges
+   through the block diagram. If an edge is part of a cycle, set
+   `bootstrap_policy.required = true` and pick a `policy_type`. The
+   audit-recommended default for "neighbor"/"context" feedback paths
+   is `reset_seed` with `seed_value_hex = "0x0"` (semantically
+   correct for the corner-MB / first-frame case in many codec designs).
+
+5. **Pick handshake_protocol based on actual need, not habit.** Use
+   `srdy_drdy` for tight single-field local handshakes; use
+   `axi_stream` when sidebands, packet boundaries, routing, or
+   external interoperability are needed. The skill documents below
+   describe the trade-off in detail — use them.
+
+6. **If the requirements imply a specific bit ordering** (e.g., a
+   golden reference model uses MSB-first byte serialization, or the
+   target ABI is little-endian), set `default_packing_convention`
+   accordingly and apply it uniformly. Do not mix conventions across
+   edges within a single design.
+
+7. **Open questions are last-resort.** Prefer to make a defensible
+   choice and document it in `notes` than to defer to the outer
+   agent. Only emit `open_questions` when the choice has a real
+   downstream cost (e.g., changes block partitioning).
+
+# Failure modes to avoid
+
+- **Width annotation drift**: do NOT copy widths from the block
+  diagram unchanged; recompute from field list. If the block diagram
+  says `data_width: 1383` but the actual fields you list sum to
+  1561, output 1561 and note the discrepancy.
+- **Endianness inconsistency**: do NOT let two contracts within the
+  same design use different packing conventions unless you state
+  why.
+- **Missing bootstrap**: do NOT skip the `bootstrap_policy` field on
+  cycle edges — leaving it empty will cause downstream deadlocks
+  and is the single most common DV failure observed in coresmith.
+
+# Output expectations
+
+Respond with JSON only. The runtime will save your output to
+`<project_root>/.coresmith/interface_contracts.json`. Per-block uArch
+spec generators will read this file as authoritative and reference
+the bit layouts you specify; any drift is caught by the
+`cross_spec_contract_adherence` constraint subagent that runs after
+spec generation.

--- a/orchestrator/langchain/prompts/skills/__init__.py
+++ b/orchestrator/langchain/prompts/skills/__init__.py
@@ -1,0 +1,46 @@
+"""Skill loader for agent system prompts.
+
+Skills are reference markdown documents under
+`orchestrator/langchain/prompts/skills/`. Agents that author or consume
+hardware interfaces should pull the relevant skills into their system
+prompt so they have access to coresmith's interface conventions.
+
+Usage:
+    from orchestrator.langchain.prompts.skills import load_skill
+
+    sys_prompt = base_prompt + "\\n\\n" + load_skill("axi_stream")
+
+Each skill is a markdown file named `<id>.md`. The top-level heading
+and surrounding text become the prompt fragment as-is.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_SKILLS_DIR = Path(__file__).resolve().parent
+
+
+def load_skill(skill_id: str) -> str:
+    """Return the markdown body of a skill, or empty string if missing.
+
+    `skill_id` matches the filename stem (e.g. `"axi_stream"` for
+    `axi_stream.md`). Missing skills return empty rather than raising
+    so a prompt builder degrades gracefully.
+    """
+    path = _SKILLS_DIR / f"{skill_id}.md"
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def load_skills(*skill_ids: str, separator: str = "\n\n---\n\n") -> str:
+    """Concatenate multiple skills for inclusion in a system prompt.
+
+    Empty/missing skills are skipped so adding a new skill id never
+    breaks an agent that hasn't shipped it yet.
+    """
+    parts = [load_skill(sid) for sid in skill_ids]
+    return separator.join(p for p in parts if p)
+
+
+__all__ = ["load_skill", "load_skills"]

--- a/orchestrator/langchain/prompts/skills/axi_stream.md
+++ b/orchestrator/langchain/prompts/skills/axi_stream.md
@@ -1,0 +1,139 @@
+# Skill: AXI-Stream
+
+Reference document for any agent designing or implementing AXI-Stream
+interfaces in coresmith. Use this when authoring an interface contract,
+a uArch spec, or RTL that carries multi-field payloads between blocks.
+
+## What AXI-Stream is
+
+A unidirectional, point-to-point, multi-beat data interface specified
+by ARM AMBA AXI4-Stream. One master (producer) drives data into one
+slave (consumer). Backpressure is per-beat via a ready/valid handshake.
+
+## Required signals (every AXI-Stream interface has these)
+
+| Signal | Direction | Purpose |
+|--------|-----------|---------|
+| `<prefix>_tvalid` | master → slave | master asserts when data is presented |
+| `<prefix>_tready` | slave → master | slave asserts when it can accept the beat |
+| `<prefix>_tdata[N-1:0]` | master → slave | the payload — N is the design choice |
+
+A beat transfers iff `tvalid && tready` on the same rising edge. Both
+sides are free to assert their signal independently in any cycle, with
+**one critical rule**: once `tvalid` is asserted, it must stay asserted
+and `tdata` must stay stable until `tready` is also asserted. The
+master is forbidden from waiting for `tready` before asserting
+`tvalid` (it would create a combinational loop in protocol-checker
+terms).
+
+## Optional sideband signals
+
+Use only if the design needs them; redundant sidebands are noise.
+
+| Signal | Width | Use case |
+|--------|-------|----------|
+| `<prefix>_tlast` | 1 | marks the last beat of a packet/frame |
+| `<prefix>_tuser[U-1:0]` | design-specific | per-beat metadata that travels with the data but is not part of the data itself (e.g., start-of-frame, parity, source-id) |
+| `<prefix>_tkeep[N/8-1:0]` | one bit per `tdata` byte | which bytes of `tdata` are valid this beat — used for byte-streams with sparse beats |
+| `<prefix>_tstrb[N/8-1:0]` | one bit per `tdata` byte | which bytes are position bytes vs null bytes — almost never used in coresmith designs |
+| `<prefix>_tdest[D-1:0]` | route id | demux target on the slave side, for switches |
+| `<prefix>_tid[I-1:0]` | source id | identifies the producer when slave aggregates multiple masters |
+
+## `tdata` packing is a design choice, not a standard
+
+This is the most common source of inter-block contract drift in coresmith.
+AXI-Stream itself does **not** specify how multi-field payloads pack
+inside `tdata`. The bit order, field placement, signedness, and
+alignment are all decisions you must make explicitly and freeze in
+the interface contract.
+
+When you author or consume an AXI-Stream interface that carries more
+than one field, you **must** declare:
+
+1. **Total width** of `tdata` in bits.
+2. **Field list**, ordered, with each field's exact `[MSB:LSB]` slice
+   inside `tdata`.
+3. **Signedness** of each field (`unsigned`, `two's-complement`, etc.).
+4. **Encoding** of each field (binary, gray, one-hot, fixed-point Qm.n,
+   ASCII byte, etc.). Especially important for non-trivial fields like
+   QP indices or mode codes.
+
+Both endpoints **must** reference the same frozen declaration. There
+are valid reasons to pick LSB-first packing in some designs (e.g., when
+the consumer treats `tdata` as a sliding byte stream and the first
+byte of a multi-byte field arrives at `[7:0]`), and equally valid reasons
+to pick MSB-first (e.g., when serializing a structured record where the
+field order matches network/file byte order). **Neither is universally
+correct.** What matters is that producer and consumer agree.
+
+### Default convention for coresmith generated designs
+
+When the architect has no specific reason to pick otherwise:
+
+- **MSB-first by field-list order**: the first field declared in the
+  interface contract occupies the highest bits; the last field occupies
+  the lowest bits.
+- **No padding** between fields unless the contract explicitly declares a
+  named `reserved`/`pad` field.
+- **Two's-complement** for signed fields.
+- **Unsigned** for indices, counters, and addresses.
+
+Example: a 36-bit pixel context with fields `pixel[8]`, `x[10]`,
+`y[9]`, `frame_idx[4]`, `qp[2]`, `sof[1]`, `eol[1]`, `frame_last[1]`
+packs as:
+
+```
+[35:28]  pixel       (8 bits, unsigned)
+[27:18]  x           (10 bits, unsigned)
+[17:9]   y           (9 bits, unsigned)
+[8:5]    frame_idx   (4 bits, unsigned)
+[4:3]    qp          (2 bits, unsigned)
+[2]      sof         (1 bit)
+[1]      eol         (1 bit)
+[0]      frame_last  (1 bit)
+```
+
+If a design has a strong reason to deviate (e.g., wire-compatibility
+with an external IP that expects LSB-first), declare that explicitly
+in the interface contract's `packing_convention` field and reference
+it from both endpoints' uArch specs.
+
+## Backpressure correctness
+
+Common mistakes that pass lint but fail simulation:
+
+1. **`tvalid` deasserts mid-burst before `tready` fires.** Once
+   asserted, hold both `tvalid` and `tdata` stable until `tready`.
+2. **`tready` depends combinationally on `tvalid`.** This creates a
+   `valid && ready` cycle that some protocol checkers will accept but
+   confounds downstream skid buffers. Slave should derive `tready` from
+   its internal state only.
+3. **Producer asserts `tvalid` before reset deasserts.** Some
+   downstream blocks latch this as a phantom beat.
+
+## Bootstrap and closed-loop dependencies
+
+If block A's `s_axis` waits for data from block B's `m_axis`, and
+block B's `s_axis` waits for data from block A's `m_axis` (a feedback
+loop), the design **must** declare an initial-cycle policy in the
+interface contract. Options:
+
+- **Reset seed**: one endpoint's `m_axis` emits a default value on
+  cycle 0 after reset, valid until consumed. The default value must
+  be specified in the contract.
+- **Request-driven**: add a separate request channel from consumer
+  to producer carrying the coordinate the consumer needs; producer
+  responds with current state.
+- **Bypass for the first transaction**: declare which endpoint is
+  primed externally before the rest of the pipeline starts.
+
+Closed loops with no declared bootstrap policy **will deadlock** on
+the first transaction. The contract must call this out.
+
+## When NOT to use AXI-Stream
+
+- Pure 1-cycle latency single-beat handshake: use **sRdy/dRdy**
+  (see `skills/srdy_drdy.md`). Lower overhead, no sideband sprawl.
+- Address-mapped register access: use AXI4-Lite, not AXI-Stream.
+- Wide parallel buses with no ordering: a raw `valid/data` bundle
+  with no backpressure may suffice if the consumer can never stall.

--- a/orchestrator/langchain/prompts/skills/srdy_drdy.md
+++ b/orchestrator/langchain/prompts/skills/srdy_drdy.md
@@ -1,0 +1,101 @@
+# Skill: sRdy/dRdy handshake
+
+Reference document for any agent designing or implementing
+source-ready / destination-ready (sRdy/dRdy) interfaces in coresmith.
+Use this when authoring an interface contract, a uArch spec, or RTL
+that carries a single-beat or low-overhead payload between blocks.
+
+## What sRdy/dRdy is
+
+A unidirectional, point-to-point, per-cycle handshake. The source
+asserts `srdy` to indicate it has data ready. The destination asserts
+`drdy` to indicate it can accept data this cycle. A transfer happens
+iff `srdy && drdy` on the same rising edge.
+
+This is functionally equivalent to AXI-Stream's `tvalid`/`tready` but
+intentionally stripped of sidebands. Use it when the design only
+needs the handshake itself and a payload bus, with no per-beat
+metadata, no packet boundaries, and no demux/aggregation routing.
+
+## Required signals
+
+| Signal | Direction | Purpose |
+|--------|-----------|---------|
+| `<prefix>_srdy` | source → dest | source has data this cycle |
+| `<prefix>_drdy` | dest → source | dest can accept this cycle |
+| `<prefix>_data[N-1:0]` | source → dest | payload — N is the design choice |
+
+That's it. No `last`, no `user`, no `keep`, no `dest`, no `id`. If
+the design needs any of those, switch to AXI-Stream — don't graft
+sidebands onto sRdy/dRdy ad hoc.
+
+## Handshake correctness
+
+The same beat-stability rule as AXI-Stream applies:
+
+- Once `srdy` is asserted with a particular `data` value, both must
+  remain stable until `drdy` is also asserted.
+- `drdy` must not depend combinationally on `srdy` (no `drdy = srdy && ...`).
+  Slave's `drdy` is derived from its internal state only.
+
+## Payload packing
+
+Same rule as AXI-Stream: sRdy/dRdy itself does not specify how
+multi-field payloads pack inside `data`. If the payload is a single
+scalar (a pixel, an address, an opcode), packing is trivial. If
+it's a record with multiple fields, declare:
+
+1. Total `data` width in bits.
+2. Field list with `[MSB:LSB]` per field.
+3. Signedness and encoding.
+
+Default coresmith convention (MSB-first by field-list order, no
+padding, two's-complement for signed) applies — see
+`skills/axi_stream.md` for the rationale and the worked H.264-style
+example. The convention is the same; what differs between the two
+protocols is only the sideband surface area.
+
+## When to choose sRdy/dRdy over AXI-Stream
+
+Pick sRdy/dRdy when **all** of the following hold:
+
+- Payload is a single field, or a small record that's atomic at the
+  protocol level (no packet boundaries).
+- No need for per-beat sidebands (no start-of-frame marker, no
+  parity, no source-id, no routing target).
+- The interface is a tight 1-cycle local handshake — typically inside
+  a single subsystem or between adjacent stages of a pipeline.
+- You want the smallest possible interface (no `tlast`, `tuser`,
+  `tkeep`, `tstrb`).
+
+Pick AXI-Stream when **any** of the following hold:
+
+- The payload carries packet boundaries (`tlast`) or per-beat
+  metadata (`tuser`).
+- Multiple producers feed one consumer with source IDs (`tid`).
+- One producer feeds multiple consumers via a switch (`tdest`).
+- You want the IP to be interoperable with off-the-shelf AXI-Stream
+  blocks (FIFOs, width converters, fork/join, AXI DMAs).
+- You're at a chip boundary or crossing a subsystem — AXI-Stream's
+  larger sideband surface is the right interop default.
+
+## Bootstrap and closed-loop dependencies
+
+Identical concern as AXI-Stream: if a feedback loop exists
+(consumer waits on data the producer can only emit after consuming
+something the consumer hasn't sent yet), the design **must** declare
+an initial-cycle policy. The smaller sideband surface of sRdy/dRdy
+does not change this requirement.
+
+## Coresmith conventions for sRdy/dRdy ports
+
+Naming:
+- Master output signals: `m_srdy`, `m_data`, master input: `m_drdy`
+  (mirrors the AXI-Stream `m_axis_*` naming convention).
+- Slave input signals: `s_srdy`, `s_data`, slave output: `s_drdy`.
+- For multiple interfaces on the same block, qualify with a role:
+  `m_pixel_srdy`, `s_neighbor_drdy`, etc.
+
+If multiple sRdy/dRdy interfaces are needed, name them so the role
+is clear at the port list — the interface contract's `port_role` field
+should match the prefix used in RTL.

--- a/orchestrator/langgraph/architecture_graph.py
+++ b/orchestrator/langgraph/architecture_graph.py
@@ -996,6 +996,68 @@ async def block_diagram_node(state: ArchGraphState) -> dict:
         return update
 
 
+async def interface_definition_node(state: ArchGraphState) -> dict:
+    """Freeze canonical bit-level edge contracts.
+
+    Runs after the block diagram is finalized and before Memory Map.
+    The specialist expands every block-diagram edge into a frozen
+    contract with handshake protocol, total data width, field list with
+    [MSB:LSB] positions, signedness, encoding, and bootstrap policy for
+    cycle-edges. Per-block uArch spec generators downstream read the
+    output as authoritative; cross_spec_contract_adherence validates
+    that per-block specs match the contract field-for-field.
+    """
+    from orchestrator.architecture.specialists.interface_definition import (
+        analyze_interface_definition,
+    )
+
+    _event(state, "Interface Definition", "graph_node_enter", {
+        "round": state["round"],
+    })
+    round_label = f" - Iteration #{state['round']}" if state["round"] > 1 else ""
+    with _tracer.start_as_current_span(
+        f"Interface Definition{round_label}"
+    ) as span:
+        span.set_attribute("round", state["round"])
+        try:
+            ifd = await analyze_interface_definition(
+                block_diagram=state["block_diagram"],
+                requirements=state.get("requirements", ""),
+                sad_spec=state.get("sad_spec"),
+                frd_spec=state.get("frd_spec"),
+                project_root=state["project_root"],
+            )
+        except Exception as exc:  # pragma: no cover -- defensive
+            span.set_attribute("error", str(exc))
+            ifd = {
+                "result": {
+                    "design_summary": (
+                        f"Interface Definition stage failed: {exc}. "
+                        "Per-block specs will proceed without a frozen "
+                        "contract; downstream constraint check may still "
+                        "catch drift via cross_spec_contract_adherence."
+                    ),
+                    "contracts": [],
+                    "open_questions": [],
+                },
+                "questions": [],
+            }
+
+        result = ifd.get("result", {}) or {}
+        contract_count = len(result.get("contracts", []) or [])
+        span.set_attribute("contract_count", contract_count)
+
+        _event(state, "Interface Definition", "graph_node_exit", {
+            "round": state["round"],
+            "contract_count": contract_count,
+            "open_questions": len(result.get("open_questions", []) or []),
+        })
+
+        update = {"interface_contracts": result, "phase": "interface_definition"}
+        _persist_intermediate_state(state, update)
+        return update
+
+
 async def memory_map_node(state: ArchGraphState) -> dict:
     """Generate memory map via LLM specialist.
 
@@ -1951,7 +2013,7 @@ def review_diagram(state: ArchGraphState) -> str:
     if has_questions or has_no_blocks:
         target = "Escalate Diagram"
     else:
-        target = "Memory Map"
+        target = "Interface Definition"
 
     span = trace.get_current_span()
     if span.is_recording():
@@ -1972,7 +2034,7 @@ def review_diagram(state: ArchGraphState) -> str:
 
 review_diagram.__edge_labels__ = {
     "Escalate Diagram": "QUESTIONS",
-    "Memory Map": "CLEAN",
+    "Interface Definition": "CLEAN",
 }
 
 
@@ -1986,7 +2048,7 @@ def route_after_diagram_escalation(state: ArchGraphState) -> str:
     elif action == "feedback":
         target = "Block Diagram"
     else:
-        target = "Memory Map"
+        target = "Interface Definition"
 
     span = trace.get_current_span()
     if span.is_recording():
@@ -1995,7 +2057,7 @@ def route_after_diagram_escalation(state: ArchGraphState) -> str:
     return target
 
 route_after_diagram_escalation.__edge_labels__ = {
-    "Memory Map": "CONTINUE",
+    "Interface Definition": "CONTINUE",
     "Block Diagram": "FEEDBACK",
     "Abort": "ABORT",
 }
@@ -2213,6 +2275,7 @@ def build_architecture_graph(checkpointer=None):
 
     # Specialist nodes
     graph.add_node("Block Diagram", block_diagram_node)
+    graph.add_node("Interface Definition", interface_definition_node)
     graph.add_node("Memory Map", memory_map_node)
     graph.add_node("Clock Tree", clock_tree_node)
     graph.add_node("Register Spec", register_spec_node)
@@ -2252,6 +2315,7 @@ def build_architecture_graph(checkpointer=None):
     graph.add_conditional_edges("Escalate Diagram", route_after_diagram_escalation)
 
     # Memory Map -> Clock Tree -> Register Spec -> Constraint Check
+    graph.add_edge("Interface Definition", "Memory Map")
     graph.add_edge("Memory Map", "Clock Tree")
     graph.add_edge("Clock Tree", "Register Spec")
     graph.add_edge("Register Spec", "Constraint Check")

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -2553,6 +2553,104 @@ async def integration_check_node(state: OrchestratorState) -> dict:
 
             return {"integration_result": integration_result}
 
+        if (
+            warnings
+            and not os.getenv("CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS")
+        ):
+            log(
+                f"  [INTEGRATION] {len(warnings)} warning(s) -- triaging "
+                "for outer-agent review",
+                YELLOW,
+            )
+
+            warning_payload = {
+                "type": "integration_warning_review",
+                "design_name": design_name,
+                "top_rtl_path": top_rtl_path,
+                "block_count": len(modules),
+                "error_count": 0,
+                "warning_count": len(warnings),
+                "lint_clean": True,
+                "warnings": warnings,
+                "mismatches": mismatches,
+                "block_rtl_paths": rtl_paths,
+                "skipped_connections": agent_result.get(
+                    "skipped_connections", []
+                ),
+                "supported_actions": [
+                    "accept",
+                    "retry",
+                    "fix_rtl",
+                    "abort",
+                ],
+                "outer_agent_guidance": (
+                    "Integration Lead agent flagged warnings but no hard "
+                    "errors. Architecture warnings have caused DV deadlocks "
+                    "in practice (closed AXI-Stream feedback loops without "
+                    "a bootstrap policy, etc.), so triage before letting "
+                    "the run reach DV:\n"
+                    "1. Read each warning's `description` and "
+                    "`suggested_fix`.\n"
+                    "2. If the warning is benign or compensated elsewhere, "
+                    "resume_pipeline(action='accept').\n"
+                    "3. If a block needs patching, edit it on disk, then "
+                    "resume_pipeline(action='fix_rtl', "
+                    "rtl_fix_description='...'). The run will END so you "
+                    "can issue restart_node for the affected stage.\n"
+                    "4. If the integration top should be regenerated, "
+                    "resume_pipeline(action='retry'). The run will END so "
+                    "you can restart_node('integration_check').\n"
+                    "5. If a uArch-level revision is needed (e.g. add a "
+                    "request-driven bootstrap path), "
+                    "resume_pipeline(action='abort') and escalate.\n"
+                    "Set CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS=1 to "
+                    "restore the old non-blocking behavior."
+                ),
+                "reference_files": {
+                    "top_rtl": top_rtl_path,
+                    "architecture": ".coresmith/architecture_state.json",
+                    "block_diagram": ".coresmith/block_diagram_viz.json",
+                },
+            }
+
+            response = interrupt(warning_payload)
+            action = (
+                response.get("action", "abort")
+                if isinstance(response, dict)
+                else "abort"
+            )
+            integration_result["warning_triage_action"] = action
+
+            write_graph_event(pr, "Integration Check", "graph_node_exit", {
+                "action": action,
+                "warning_count": len(warnings),
+                "via": "warning_triage",
+            })
+
+            if action == "accept":
+                integration_result["accepted_warnings"] = True
+                log(
+                    "  [INTEGRATION] Warnings accepted by outer agent",
+                    GREEN,
+                )
+            elif action in ("retry", "fix_rtl"):
+                fix_desc = response.get("rtl_fix_description", "")
+                integration_result["fix_applied"] = fix_desc
+                integration_result["aborted"] = True
+                log(
+                    f"  [INTEGRATION] {action} requested "
+                    f"(desc='{fix_desc}'); routing to END so outer agent "
+                    "can restart_node",
+                    YELLOW,
+                )
+            else:  # abort or unknown
+                integration_result["aborted"] = True
+                log(
+                    "  [INTEGRATION] Aborted on warning triage", RED
+                )
+
+            return {"integration_result": integration_result}
+
         log(f"\n{'='*60}", GREEN)
         log("  INTEGRATION CHECK PASSED", GREEN)
         log(f"  Top module: {module_name}", GREEN)

--- a/orchestrator/tests/test_architecture.py
+++ b/orchestrator/tests/test_architecture.py
@@ -766,3 +766,305 @@ class TestEndToEndStateFlow:
         final = load_state(tmp_project)
         assert final.requirements == "DVB-T transceiver"
         assert len(final.block_specs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Interface Definition specialist (Stage B)
+# ---------------------------------------------------------------------------
+
+
+class TestInterfaceDefinition:
+    """The Interface Definition specialist freezes per-edge bit-level
+    contracts before per-block uArch specs are generated. These tests
+    mock the LLM and exercise the structural validation + I/O path."""
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_connections(self, tmp_project):
+        from orchestrator.architecture.specialists.interface_definition import (
+            analyze_interface_definition,
+        )
+
+        result = await analyze_interface_definition(
+            block_diagram={"blocks": [{"name": "solo"}], "connections": []},
+            project_root=tmp_project,
+        )
+        assert result["result"]["contracts"] == []
+        assert "Single-block" in result["result"]["design_summary"]
+        # No file written for a no-op design.
+        from pathlib import Path
+        assert not (Path(tmp_project) / ".coresmith" / "interface_contracts.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_specialist_persists_contracts_to_disk(self, tmp_project):
+        """The specialist should write interface_contracts.json with the
+        canonical schema. We mock the LLM to return a known good response."""
+        from pathlib import Path
+        from unittest.mock import AsyncMock, patch
+        from orchestrator.architecture.specialists.interface_definition import (
+            analyze_interface_definition,
+        )
+
+        contracts_payload = {
+            "design_summary": "Two-block AXI-Stream pipeline.",
+            "default_packing_convention": "msb_first_by_field_list",
+            "default_endianness_rationale": "Matches H.264 byte serialization.",
+            "contracts": [
+                {
+                    "edge_id": "a__m_axis_data__to__b__s_axis_data",
+                    "producer_block": "a",
+                    "producer_port": "m_axis_data",
+                    "consumer_block": "b",
+                    "consumer_port": "s_axis_data",
+                    "handshake_protocol": "axi_stream",
+                    "data_width_bits": 16,
+                    "sideband_signals": [{"name": "tlast", "purpose": "end-of-frame"}],
+                    "fields": [
+                        {"name": "high", "msb": 15, "lsb": 8, "width": 8,
+                         "signed": False, "encoding": "binary"},
+                        {"name": "low", "msb": 7, "lsb": 0, "width": 8,
+                         "signed": False, "encoding": "binary"},
+                    ],
+                    "packing_convention": "msb_first_by_field_list",
+                    "bootstrap_policy": {"required": False, "policy_type": "none"},
+                },
+            ],
+            "open_questions": [],
+        }
+        import json as _json
+        target = Path(tmp_project) / ".coresmith" / "interface_contracts.json"
+
+        async def _fake_call(*args, **kwargs):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(_json.dumps(contracts_payload, indent=2))
+            return f"Wrote contracts to {target}"
+
+        with patch("orchestrator.langchain.agents.coresmith_llm.ClaudeLLM") as MockLLM:
+            MockLLM.return_value.call = AsyncMock(side_effect=_fake_call)
+            result = await analyze_interface_definition(
+                block_diagram={
+                    "blocks": [{"name": "a"}, {"name": "b"}],
+                    "connections": [{"from": "a", "to": "b"}],
+                },
+                project_root=tmp_project,
+            )
+
+        assert target.exists()
+        ir = result["result"]
+        assert len(ir["contracts"]) == 1
+        assert ir["contracts"][0]["data_width_bits"] == 16
+
+    @pytest.mark.asyncio
+    async def test_validator_flags_field_width_sum_mismatch(self, tmp_project):
+        """The structural validator should note when declared
+        data_width_bits doesn't equal the sum of field widths."""
+        from pathlib import Path
+        from unittest.mock import AsyncMock, patch
+        from orchestrator.architecture.specialists.interface_definition import (
+            analyze_interface_definition,
+        )
+
+        bad_payload = {
+            "design_summary": "drift demo",
+            "default_packing_convention": "msb_first_by_field_list",
+            "contracts": [
+                {
+                    "edge_id": "a__m__to__b__s",
+                    "producer_block": "a",
+                    "producer_port": "m_axis_x",
+                    "consumer_block": "b",
+                    "consumer_port": "s_axis_x",
+                    "handshake_protocol": "axi_stream",
+                    "data_width_bits": 32,  # declared
+                    "fields": [
+                        {"name": "f1", "msb": 15, "lsb": 0, "width": 16},
+                    ],  # actual sum = 16
+                    "packing_convention": "msb_first_by_field_list",
+                },
+            ],
+            "open_questions": [],
+        }
+        import json as _json
+        target = Path(tmp_project) / ".coresmith" / "interface_contracts.json"
+
+        async def _fake_call(*args, **kwargs):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(_json.dumps(bad_payload))
+            return f"wrote {target}"
+
+        with patch("orchestrator.langchain.agents.coresmith_llm.ClaudeLLM") as MockLLM:
+            MockLLM.return_value.call = AsyncMock(side_effect=_fake_call)
+            result = await analyze_interface_definition(
+                block_diagram={
+                    "blocks": [{"name": "a"}, {"name": "b"}],
+                    "connections": [{"from": "a", "to": "b"}],
+                },
+                project_root=tmp_project,
+            )
+
+        notes = result["result"].get("validation_notes", [])
+        assert any("declared data_width_bits=32" in n for n in notes), (
+            f"expected width-sum drift note, got: {notes}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_validator_flags_missing_contract_for_declared_edge(self, tmp_project):
+        """Every directed edge in block_diagram must be represented by
+        exactly one contract entry. Validator should flag missing ones."""
+        from pathlib import Path
+        from unittest.mock import AsyncMock, patch
+        from orchestrator.architecture.specialists.interface_definition import (
+            analyze_interface_definition,
+        )
+
+        payload = {
+            "design_summary": "partial coverage",
+            "default_packing_convention": "msb_first_by_field_list",
+            "contracts": [
+                {
+                    "edge_id": "a__m__to__b__s",
+                    "producer_block": "a",
+                    "consumer_block": "b",
+                    "data_width_bits": 8,
+                    "fields": [{"name": "byte", "msb": 7, "lsb": 0, "width": 8}],
+                },
+                # NOTE: missing the b->c contract
+            ],
+            "open_questions": [],
+        }
+        import json as _json
+        target = Path(tmp_project) / ".coresmith" / "interface_contracts.json"
+
+        async def _fake_call(*args, **kwargs):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(_json.dumps(payload))
+            return f"wrote {target}"
+
+        with patch("orchestrator.langchain.agents.coresmith_llm.ClaudeLLM") as MockLLM:
+            MockLLM.return_value.call = AsyncMock(side_effect=_fake_call)
+            result = await analyze_interface_definition(
+                block_diagram={
+                    "blocks": [{"name": "a"}, {"name": "b"}, {"name": "c"}],
+                    "connections": [
+                        {"from": "a", "to": "b"},
+                        {"from": "b", "to": "c"},
+                    ],
+                },
+                project_root=tmp_project,
+            )
+
+        notes = result["result"].get("validation_notes", [])
+        assert any("b -> c" in n for n in notes), (
+            f"expected missing-contract note for b->c, got: {notes}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# cross_spec_contract_adherence subagent (Stage C)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSpecContractAdherence:
+    """The new constraint subagent verifies per-block uArch specs match
+    the canonical interface_contracts. It only applies when both
+    interface_contracts and the per-block specs exist."""
+
+    def _stub_call(self, per_check_response):
+        """Same pattern as TestConstraintChecker._make_subagent_mock."""
+        from unittest.mock import AsyncMock
+        import json as _json
+
+        async def _fake_call(*args, **kwargs):
+            run_name = kwargs.get("run_name", "")
+            check_id = run_name.split(":", 1)[1] if ":" in run_name else ""
+            resp = per_check_response.get(
+                check_id, {"pass": True, "evidence": "n/a"}
+            )
+            return _json.dumps(resp)
+
+        return AsyncMock(side_effect=_fake_call)
+
+    def test_applies_predicate_requires_contracts(self):
+        from orchestrator.architecture.constraints import _CONSTRAINT_CATALOG
+        c = next(
+            x for x in _CONSTRAINT_CATALOG
+            if x["id"] == "cross_spec_contract_adherence"
+        )
+        # No contracts => skip.
+        assert c["applies"]({"interface_contracts": {}}) is False
+        assert c["applies"]({"interface_contracts": {"contracts": []}}) is False
+        # With contracts => apply (the subagent itself decides whether to
+        # check per-block specs or no-op).
+        assert c["applies"](
+            {"interface_contracts": {"contracts": [{"edge_id": "x"}]}}
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_subagent_fires_when_contracts_present(self, tmp_project):
+        """When interface_contracts.json exists with non-empty contracts,
+        the cross_spec_contract_adherence subagent must be invoked."""
+        from unittest.mock import patch
+        from orchestrator.architecture.constraints import check_constraints
+
+        contracts = {
+            "contracts": [
+                {"edge_id": "x__m__to__y__s", "producer_block": "x",
+                 "consumer_block": "y", "data_width_bits": 8,
+                 "fields": [{"name": "b", "msb": 7, "lsb": 0, "width": 8}]},
+            ],
+        }
+        mock_call = self._stub_call(per_check_response={
+            "cross_spec_contract_adherence": {
+                "pass": False,
+                "violation_text": "producer port y's tdata layout differs from contract",
+                "evidence": "arch/uarch_specs/x.md: m_axis_data[7:0]=b vs contract msb=7 lsb=0 OK; "
+                            "arch/uarch_specs/y.md: s_axis_data[3:0]=b mismatch",
+                "suggested_fix": "Edit arch/uarch_specs/y.md to specify tdata[7:0]=b",
+            },
+        })
+        with patch("orchestrator.langchain.agents.coresmith_llm.ClaudeLLM") as MockLLM:
+            MockLLM.return_value.call = mock_call
+            violations = await check_constraints(
+                block_diagram={
+                    "blocks": [{"name": "x"}, {"name": "y"}],
+                    "connections": [{"from": "x", "to": "y"}],
+                },
+                memory_map={},
+                clock_tree={},
+                register_spec={},
+                project_root=tmp_project,
+                interface_contracts=contracts,
+            )
+        cross_v = [v for v in violations if v["check"] == "cross_spec_contract_adherence"]
+        assert len(cross_v) == 1
+        assert "producer port y" in cross_v[0]["violation"]
+        assert cross_v[0]["severity"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_subagent_skipped_when_no_contracts(self, tmp_project):
+        from unittest.mock import patch
+        from orchestrator.architecture.constraints import check_constraints
+
+        called: list[str] = []
+
+        async def _spy(*args, **kwargs):
+            run_name = kwargs.get("run_name", "")
+            check_id = run_name.split(":", 1)[1] if ":" in run_name else ""
+            called.append(check_id)
+            import json as _json
+            return _json.dumps({"pass": True, "evidence": "ok"})
+
+        from unittest.mock import AsyncMock
+        with patch("orchestrator.langchain.agents.coresmith_llm.ClaudeLLM") as MockLLM:
+            MockLLM.return_value.call = AsyncMock(side_effect=_spy)
+            await check_constraints(
+                block_diagram={
+                    "blocks": [{"name": "a"}, {"name": "b"}],
+                    "connections": [{"from": "a", "to": "b"}],
+                },
+                memory_map={},
+                clock_tree={},
+                register_spec={},
+                project_root=tmp_project,
+                # No interface_contracts and no file on disk
+            )
+        assert "cross_spec_contract_adherence" not in called

--- a/orchestrator/tests/test_architecture_graph.py
+++ b/orchestrator/tests/test_architecture_graph.py
@@ -276,9 +276,13 @@ class TestReviewDiagram:
         state = {"block_diagram": {"blocks": [{"name": "a"}], "questions": [{"q": "?"}]}}
         assert review_diagram(state) == "Escalate Diagram"
 
-    def test_clean_goes_to_memory_map(self):
+    def test_clean_goes_to_interface_definition(self):
+        # Interface Definition is the new stage between a clean block
+        # diagram and Memory Map (PR #45). Memory Map runs immediately
+        # after Interface Definition; the route here advances to the
+        # interface contract stage first.
         state = {"block_diagram": {"blocks": [{"name": "a"}], "questions": []}}
-        assert review_diagram(state) == "Memory Map"
+        assert review_diagram(state) == "Interface Definition"
 
     def test_no_blocks_goes_to_escalate(self):
         state = {"block_diagram": {"blocks": [], "questions": []}}
@@ -290,9 +294,11 @@ class TestReviewDiagram:
 
 
 class TestRouteAfterDiagramEscalation:
-    def test_continue_goes_to_memory_map(self):
+    def test_continue_goes_to_interface_definition(self):
+        # After the diagram escalation continues, route through the new
+        # Interface Definition stage before Memory Map (PR #45).
         state = {"human_response": {"action": "continue"}}
-        assert route_after_diagram_escalation(state) == "Memory Map"
+        assert route_after_diagram_escalation(state) == "Interface Definition"
 
     def test_feedback_goes_to_block_diagram(self):
         state = {"human_response": {"action": "feedback", "feedback": "fix it"}}

--- a/orchestrator/tests/test_integration_lead.py
+++ b/orchestrator/tests/test_integration_lead.py
@@ -993,6 +993,213 @@ class TestIntegrationCheckNode:
 
 
 # ---------------------------------------------------------------------------
+# integration_check_node: warning-only triage (matches arch constraint flow)
+# ---------------------------------------------------------------------------
+
+class TestIntegrationCheckWarningTriage:
+    """integration_check_node must triage warning-only mismatches via an
+    outer-agent interrupt before letting the run advance to DV. The
+    closed-feedback warning from the h264 v4 run predicted the exact DV
+    deadlock that followed, so warnings are no longer silently dropped."""
+
+    def _state(self):
+        return {
+            "project_root": "/tmp/test",
+            "completed_blocks": [
+                {"name": "a", "success": True, "rtl_path": "/tmp/a.v"},
+                {"name": "b", "success": True, "rtl_path": "/tmp/b.v"},
+            ],
+            "pipeline_done": False,
+        }
+
+    def _common_patches(self, mismatches, interrupt_response):
+        from orchestrator.langgraph.integration_helpers import (
+            VerilogModule, VerilogPort,
+        )
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        mod = VerilogModule(name="a", ports=[VerilogPort("clk", "input")])
+
+        patches = [
+            patch(
+                "orchestrator.langgraph.pipeline_graph.load_architecture_connections",
+                return_value=(SAMPLE_CONNECTIONS, "chip_top"),
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.discover_block_rtl",
+                return_value={"a": "/tmp/a.v", "b": "/tmp/b.v"},
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.parse_verilog_ports",
+                return_value=mod,
+            ),
+            patch(
+                "orchestrator.langchain.agents.integration_lead."
+                "IntegrationLeadAgent.integrate",
+                new_callable=AsyncMock,
+                return_value={
+                    "verilog": CHIP_TOP_AB,
+                    "mismatches": mismatches,
+                    "module_name": "chip_top",
+                    "wire_count": 0,
+                    "skipped_connections": [],
+                    "notes": "",
+                },
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.lint_top_level",
+                return_value={"clean": True, "warnings": ""},
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.interrupt",
+                return_value=interrupt_response,
+            ),
+            patch(
+                "orchestrator.langgraph.pipeline_graph.write_graph_event"
+            ),
+            patch("pathlib.Path.read_text", return_value=CHIP_TOP_AB),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+        ]
+        for p in patches:
+            stack.enter_context(p)
+        return stack
+
+    _WARNING = {
+        "from_block": "a",
+        "to_block": "b",
+        "issue_type": "prd_violation",
+        "severity": "warning",
+        "description": "Closed AXI-Stream feedback loop without bootstrap",
+        "suggested_fix": "Add request-driven neighbor lookup",
+    }
+
+    @pytest.mark.asyncio
+    async def test_warning_only_fires_triage_interrupt(self, monkeypatch):
+        monkeypatch.delenv(
+            "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", raising=False
+        )
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        captured = {}
+
+        def fake_interrupt(payload):
+            captured.update(payload)
+            return {"action": "accept"}
+
+        with self._common_patches([self._WARNING], {"action": "accept"}), \
+                patch(
+                    "orchestrator.langgraph.pipeline_graph.interrupt",
+                    side_effect=fake_interrupt,
+                ):
+            await integration_check_node(self._state())
+
+        assert captured["type"] == "integration_warning_review"
+        assert captured["warning_count"] == 1
+        assert captured["error_count"] == 0
+        assert captured["lint_clean"] is True
+        assert "accept" in captured["supported_actions"]
+        assert "retry" in captured["supported_actions"]
+        assert "fix_rtl" in captured["supported_actions"]
+        assert "abort" in captured["supported_actions"]
+        # Outer agent guidance must explicitly mention the bootstrap class of
+        # failure so the reviewer understands what they're triaging.
+        assert "bootstrap" in captured["outer_agent_guidance"].lower()
+
+    @pytest.mark.asyncio
+    async def test_warning_triage_accept_proceeds(self, monkeypatch):
+        monkeypatch.delenv(
+            "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", raising=False
+        )
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        with self._common_patches([self._WARNING], {"action": "accept"}):
+            result = await integration_check_node(self._state())
+
+        ir = result["integration_result"]
+        assert ir["accepted_warnings"] is True
+        assert ir["warning_triage_action"] == "accept"
+        assert ir.get("aborted") is None
+        assert ir["lint_clean"] is True
+        # route_after_integration will see lint_clean=True, error_count=0,
+        # no aborted -> routes to integration_dv.
+        from orchestrator.langgraph.pipeline_graph import route_after_integration
+        assert route_after_integration(result) == "integration_dv"
+
+    @pytest.mark.asyncio
+    async def test_warning_triage_abort_ends_pipeline(self, monkeypatch):
+        monkeypatch.delenv(
+            "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", raising=False
+        )
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        with self._common_patches([self._WARNING], {"action": "abort"}):
+            result = await integration_check_node(self._state())
+
+        ir = result["integration_result"]
+        assert ir["aborted"] is True
+        assert ir["warning_triage_action"] == "abort"
+        assert ir.get("accepted_warnings") is None
+
+    @pytest.mark.asyncio
+    async def test_warning_triage_retry_ends_with_fix_recorded(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv(
+            "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", raising=False
+        )
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        with self._common_patches(
+            [self._WARNING],
+            {
+                "action": "fix_rtl",
+                "rtl_fix_description": "added neighbor bootstrap port",
+            },
+        ):
+            result = await integration_check_node(self._state())
+
+        ir = result["integration_result"]
+        # retry / fix_rtl both route to END so the outer agent can issue
+        # restart_node via MCP for the right stage.
+        assert ir["aborted"] is True
+        assert ir["fix_applied"] == "added neighbor bootstrap port"
+        assert ir["warning_triage_action"] == "fix_rtl"
+
+    @pytest.mark.asyncio
+    async def test_nonblocking_env_var_restores_old_behaviour(self, monkeypatch):
+        """CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS=1 restores the
+        pre-change behaviour where warning-only integration results
+        silently proceed to integration_dv with no interrupt."""
+        monkeypatch.setenv("CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS", "1")
+        from orchestrator.langgraph.pipeline_graph import integration_check_node
+
+        # If the env var really suppresses the triage, this fake_interrupt
+        # must NOT be called by the warning-only path. (The error/lint path
+        # would still call interrupt, but we have no errors and lint is clean
+        # in this fixture, so any call here is a regression.)
+        fake_interrupt = patch(
+            "orchestrator.langgraph.pipeline_graph.interrupt",
+            side_effect=AssertionError(
+                "interrupt() should not fire when "
+                "CORESMITH_NONBLOCKING_INTEGRATION_WARNINGS=1"
+            ),
+        )
+
+        with self._common_patches([self._WARNING], {"action": "accept"}), \
+                fake_interrupt:
+            result = await integration_check_node(self._state())
+
+        ir = result["integration_result"]
+        assert ir["warning_count"] == 1
+        assert ir["lint_clean"] is True
+        assert ir.get("accepted_warnings") is None
+        assert ir.get("warning_triage_action") is None
+        assert ir.get("aborted") is None
+
+
+# ---------------------------------------------------------------------------
 # Graph construction still works
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Implements the three layered fixes the v5 h264 codec_v3 autopilot run identified as the root-cause class of cascading DV failures: the architecture LLM produces N+1 locally-consistent documents that disagree at edge boundaries because there's no single source of truth for the bit-level inter-block contract.

## A. Handshake skills (`prompts/skills/`)

- **`axi_stream.md`** — AXI-Stream design space, sideband signal table, default packing convention (MSB-first by field-list order), bootstrap rules for closed cycles, when NOT to use AXI-Stream. Explicit on the key point: AXI-Stream itself does NOT specify how `tdata` packs — that's a design choice that must be frozen in the interface contract.
- **`srdy_drdy.md`** — sRdy/dRdy handshake, semantics, comparison with AXI-Stream, naming conventions. Cross-references the same packing convention rules.
- **`skills/__init__.py`** exposes `load_skill` / `load_skills` helpers.
- `uarch_spec_generator` and `integration_lead` now inject both skills into their system prompts so every interface-authoring agent shares the same reference.

## B. Interface Definition stage

New architecture-phase node between block_diagram review and Memory Map. Produces `.coresmith/interface_contracts.json` with one canonical entry per directed edge:

- `handshake_protocol`: axi_stream or srdy_drdy
- `data_width_bits`: total + per-field
- `fields`: name, `[msb:lsb]`, signedness, encoding
- `sideband_signals`: only what the design actually uses
- `bootstrap_policy`: **required for any edge in a closed cycle** (this is the exact gap that caused v5's MB0 neighbor-bootstrap deadlock)

Lightweight structural validator catches width-sum drift, overlapping bit ranges, and missing-contract-for-declared-edge before publishing.

Graph topology change: `review_diagram` and `route_after_diagram_escalation` now route the success path through `Interface Definition` → `Memory Map` instead of directly to `Memory Map`.

## C. `cross_spec_contract_adherence` subagent

New entry in PR #40's `_CONSTRAINT_CATALOG`. Loads `interface_contracts` + every `arch/uarch_specs/<block>.md` and verifies producer/consumer ports match the canonical contract field-for-field, including handshake protocol agreement and bootstrap policy implementation.

- `check_constraints()` takes an optional `interface_contracts` kwarg; when not passed, reads from disk so existing call sites keep working.
- `_build_artifact_bundle` now includes `interface_contracts.json` and all per-block uArch specs so the subagent can cite them.
- `applies()` returns False when no contracts exist, so this is a no-op for designs that haven't been through the Interface Definition stage yet.

## Why this matters

In the v5 autopilot run, three of the five cascading DV failures (endianness on `pixel_ctx`, `coding_ctx` split-vs-joined, internal `src_mb` payload layout) would have been caught at architecture time if a canonical contract existed. The fourth (neighbor-bootstrap deadlock) is exactly what `bootstrap_policy` is for. Only the TB clock-cache bug (separate, generator-template issue) would have escaped this design.

## Test plan

- [x] `TestInterfaceDefinition` (4 tests): no-op for single-block designs, LLM persistence path, width-sum drift detection, missing-contract detection.
- [x] `TestCrossSpecContractAdherence` (3 tests): applies/fires/skip paths.
- [x] `TestConstraintChecker` (9 existing tests): no regression on the PR #40 catalog.
- [x] Architecture graph still compiles with the new node wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)