### PR TITLE
integration_testbench: explicit warning against module-level _clock_task cache

### DIFF
--- a/orchestrator/langchain/prompts/integration_testbench.md
+++ b/orchestrator/langchain/prompts/integration_testbench.md
@@ -134,9 +134,29 @@ COCOTB RULES (same as per-block):
 - Use cocotb with Python 3.11+ syntax.
 - Use `cocotb.clock.Clock` for clock generation (match PRD target clock).
 - Use active-low reset (`rst_n`): assert low for 5 cycles, then release.
-- Each DUT clock signal must have exactly one live cocotb Clock driver. Reuse a
-  module-level clock task across tests or explicitly stop the previous task;
-  never start a new free-running clock in every test without cleanup.
+- Each DUT clock signal must have exactly one live cocotb Clock driver, started
+  fresh per `@cocotb.test()` invocation. DO NOT cache the clock task handle
+  in a module-level global with an "if cache is None" guard:
+
+      # ❌ WRONG -- breaks tests 2+ when scheduler invalidates the task but
+      # the Python global persists, causing SimFailure: Simulator shut down
+      # prematurely (observed 3+ times in real coresmith runs).
+      _clock_task = None
+      async def start_clock(dut):
+          global _clock_task
+          if _clock_task is None:
+              _clock_task = cocotb.start_soon(Clock(...).start())
+
+  Each `@cocotb.test()` runs in a fresh scheduling scope; coroutines from
+  the previous test are cancelled, but module-level globals are not reset.
+  A cached handle from test 1 will be non-None during test 2, the guard
+  short-circuits, no new clock starts, and the simulator finishes with no
+  events.
+
+      # ✅ CORRECT -- start a fresh clock every test, no module-level cache.
+      async def start_clock(dut):
+          cocotb.start_soon(Clock(dut.clk, CLOCK_PERIOD_NS, units="ns").start())
+          await RisingEdge(dut.clk)
 - ALWAYS drive `m_tready = 1` BEFORE sending data on any input interface.
 - Use `cocotb.start_soon()` for concurrent sender/receiver coroutines.
   NEVER use `cocotb.start_fork()` (removed in cocotb 2.0).


### PR DESCRIPTION
The integration TB generator's system prompt previously suggested *\"Reuse a module-level clock task across tests or explicitly stop the previous task\"*. LLMs interpreted that as \"cache the task handle in a module-level None-guard\" — the exact broken pattern observed in **3 consecutive coresmith runs** (v4 h264, v5b h264, v7 h264):

\`\`\`
_clock_task = None
async def start_clock(dut):
    global _clock_task
    if _clock_task is None:               # ← short-circuits in test 2+ even though cocotb cancelled the task
        _clock_task = cocotb.start_soon(Clock(...).start())
\`\`\`

Symptom every time: \`SimFailure: Simulator shut down prematurely\` after test 1 passes, all subsequent tests fail with 0 sim time because no clock starts.

This commit replaces the ambiguous guidance with an explicit ❌ WRONG / ✅ CORRECT pair showing the bug pattern and the fix (always start a fresh \`Clock\` per \`@cocotb.test()\` invocation; never cache the handle in a module-level global with a None-guard). The example references the \`SimFailure\` symptom by name so future failure-mode reviews can grep for it.

## Why now

Autopilot has been hand-patching this generator output three runs in a row. Saves ~10 min of autopilot churn per integration run that fires \`integration_dv_failure\` → contract_audit → \`fix_tb\` → re-sim.

## Test plan

- [ ] Pure prompt change; no functional tests apply (the change is to the system prompt of an LLM generator).
- [x] Linting / parsing: markdown file renders correctly.
- [ ] Manual verification on next v7+ run: integration TB should ship without the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)