### PR TITLE
agents: inject canonical interface_contracts.json into per-block prompts

### DIFF
--- a/orchestrator/langchain/agents/contract_lookup.py
+++ b/orchestrator/langchain/agents/contract_lookup.py
@@ -1,0 +1,164 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Per-block lookup into the canonical `interface_contracts.json` produced
+by the Interface Definition architecture stage.
+
+Per-block generators (uArch spec + RTL) call `load_block_contracts(...)`
+to receive only the edge contracts where this block participates as the
+producer or consumer, plus the design-wide defaults. The result is
+formatted as a prompt fragment ready to drop into the user message.
+
+Why this exists: the v7 h264 autopilot run produced a correct
+`interface_contracts.json` (incl. `bootstrap_policy.reset_seed` for the
+neighbor edge), but the per-block RTL generator did not honor it because
+it never read the file. This helper bridges that gap by giving each
+generator the relevant slice of contracts directly in its prompt.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_interface_contracts(project_root: str) -> dict[str, Any]:
+    """Load the full interface_contracts.json from disk.
+
+    Returns an empty dict if the file does not exist or fails to parse —
+    so callers can treat "no contracts" as a no-op rather than an error.
+    """
+    if not project_root:
+        return {}
+    path = Path(project_root) / ".coresmith" / "interface_contracts.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def filter_contracts_for_block(
+    contracts: list[dict] | None,
+    block_name: str,
+) -> list[dict]:
+    """Return the subset of contracts where `block_name` is the producer
+    or the consumer. Tolerant of missing fields."""
+    if not contracts:
+        return []
+    out: list[dict] = []
+    for c in contracts:
+        producer = str(c.get("producer_block", "")).strip()
+        consumer = str(c.get("consumer_block", "")).strip()
+        if block_name == producer or block_name == consumer:
+            out.append(c)
+    return out
+
+
+def load_block_contracts(project_root: str, block_name: str) -> dict[str, Any]:
+    """Compose a per-block contract view suitable for prompt injection.
+
+    Returns a dict with two keys:
+      - `defaults`: top-level design conventions (default packing,
+        endianness rationale) from the canonical file. Empty when the
+        file is missing.
+      - `edges`: list of contract entries where `block_name` participates,
+        each tagged with `role` ("producer" or "consumer") so the generator
+        knows which side it has to implement.
+    """
+    full = load_interface_contracts(project_root)
+    if not full:
+        return {"defaults": {}, "edges": []}
+
+    contracts = full.get("contracts") or []
+    edges: list[dict] = []
+    for c in filter_contracts_for_block(contracts, block_name):
+        # Annotate role so the generator knows which port to expose.
+        producer = str(c.get("producer_block", "")).strip()
+        role = "producer" if producer == block_name else "consumer"
+        edge = dict(c)
+        edge["role"] = role
+        edges.append(edge)
+
+    defaults = {
+        k: full.get(k)
+        for k in (
+            "default_packing_convention",
+            "default_endianness_rationale",
+            "design_summary",
+        )
+        if full.get(k)
+    }
+    return {"defaults": defaults, "edges": edges}
+
+
+def format_block_contracts_prompt(block_name: str, view: dict[str, Any]) -> str:
+    """Render a `load_block_contracts(...)` result as a prompt fragment.
+
+    Returns the empty string when there are no relevant edges, so the
+    caller can `if fragment: parts.append(fragment)` and skip injection
+    cleanly when contracts aren't available (e.g., older runs).
+    """
+    edges = view.get("edges") or []
+    if not edges:
+        return ""
+
+    defaults = view.get("defaults") or {}
+    lines = [
+        "",
+        "## CANONICAL INTERFACE CONTRACTS for this block",
+        f"({len(edges)} edge contract(s) where `{block_name}` participates. "
+        "These are AUTHORITATIVE — the bit layouts, field positions, handshake "
+        "protocol, sideband signals, and bootstrap policy below MUST match in "
+        "your output exactly. Do not invent new fields, change widths, or "
+        "skip the bootstrap policy.)",
+        "",
+    ]
+
+    pack = defaults.get("default_packing_convention")
+    if pack:
+        rationale = defaults.get("default_endianness_rationale") or ""
+        lines.append(
+            f"**Design-wide convention:** `{pack}`"
+            + (f" ({rationale})" if rationale else "")
+        )
+        lines.append("")
+
+    lines.append("```json")
+    lines.append(json.dumps(edges, indent=2))
+    lines.append("```")
+
+    # Highlight bootstrap_policy explicitly because it's silently easy to miss.
+    bootstrap_edges = [
+        e for e in edges
+        if (e.get("bootstrap_policy") or {}).get("required")
+    ]
+    if bootstrap_edges:
+        lines.append("")
+        lines.append("**Bootstrap policy notice:**")
+        for e in bootstrap_edges:
+            bp = e.get("bootstrap_policy") or {}
+            lines.append(
+                f"- Edge `{e.get('edge_id', '?')}` (role={e.get('role')}) "
+                f"requires `{bp.get('policy_type', 'unspecified')}` bootstrap. "
+                f"{(bp.get('rationale') or '').strip()}"
+            )
+        lines.append(
+            "If you are the producer on a `reset_seed` edge, your RTL MUST "
+            "drive a valid output with the specified seed value on cycle 1 "
+            "after reset, holding until the consumer's first ready handshake. "
+            "If you are the consumer on a `request_driven` edge, your RTL "
+            "MUST emit the request before waiting for a response."
+        )
+
+    return "\n".join(lines)
+
+
+__all__ = [
+    "load_interface_contracts",
+    "filter_contracts_for_block",
+    "load_block_contracts",
+    "format_block_contracts_prompt",
+]

--- a/orchestrator/langchain/agents/rtl_generator.py
+++ b/orchestrator/langchain/agents/rtl_generator.py
@@ -203,7 +203,26 @@ class RTLGeneratorAgent:
                 f"- Constraints: .coresmith/blocks/{block_name}/constraints.json",
                 f"- Golden Model: {python_source_path}",
                 "- Block Diagram: .coresmith/block_diagram.json (for interface context)",
+                "- Interface Contracts: .coresmith/interface_contracts.json "
+                "(canonical bit-level edge contracts — see inline excerpt below)",
             ]
+
+            # Inject the canonical contract slice for this block directly
+            # into the prompt. The v7 autopilot run proved that telling the
+            # agent "go read interface_contracts.json" is not enough — the
+            # RTL generator routinely ignored the file's bootstrap_policy.
+            # Inlining the relevant edges forces the contract into the
+            # generator's context window.
+            from .contract_lookup import (
+                load_block_contracts,
+                format_block_contracts_prompt,
+            )
+            _contracts_view = load_block_contracts(project_root, block_name)
+            _contracts_fragment = format_block_contracts_prompt(
+                block_name, _contracts_view
+            )
+            if _contracts_fragment:
+                parts.append(_contracts_fragment)
 
             if attempt > 1:
                 parts.extend([

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -177,6 +177,22 @@ class UarchSpecGenerator:
                     except (OSError, _json.JSONDecodeError):
                         pass
 
+                # Inject canonical interface_contracts.json slice for this
+                # block. The Interface Definition arch stage produces this
+                # as the authoritative source for bit-level edge contracts
+                # (handshake protocol, field positions, bootstrap policy).
+                # Inlining prevents the spec author from drifting from it.
+                from .contract_lookup import (
+                    load_block_contracts,
+                    format_block_contracts_prompt,
+                )
+                _contracts_view = load_block_contracts(project_root, block_name)
+                _contracts_fragment = format_block_contracts_prompt(
+                    block_name, _contracts_view
+                )
+                if _contracts_fragment:
+                    parts.append(_contracts_fragment)
+
                 # FRD for testable requirements context
                 frd_path = _root / "arch" / "frd_spec.md"
                 if frd_path.exists():

--- a/orchestrator/tests/test_contract_lookup.py
+++ b/orchestrator/tests/test_contract_lookup.py
@@ -1,0 +1,194 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for `orchestrator.langchain.agents.contract_lookup`.
+
+The helper bridges the Interface Definition arch stage's
+`.coresmith/interface_contracts.json` into per-block generator prompts
+(uArch spec gen + RTL gen). These tests cover the loader, the per-block
+filter (with producer/consumer role tagging), and the prompt-fragment
+formatter that gets dropped into agent user messages.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orchestrator.langchain.agents.contract_lookup import (
+    filter_contracts_for_block,
+    format_block_contracts_prompt,
+    load_block_contracts,
+    load_interface_contracts,
+)
+
+
+@pytest.fixture
+def sample_contracts():
+    return {
+        "design_summary": "two-edge codec test design",
+        "default_packing_convention": "msb_first_by_field_list",
+        "default_endianness_rationale": "matches H.264 byte serialization",
+        "contracts": [
+            {
+                "edge_id": "alpha__m_axis_pix__to__beta__s_axis_pix",
+                "producer_block": "alpha",
+                "consumer_block": "beta",
+                "handshake_protocol": "axi_stream",
+                "data_width_bits": 8,
+                "fields": [
+                    {"name": "pixel", "msb": 7, "lsb": 0, "width": 8,
+                     "signed": False, "encoding": "binary"},
+                ],
+                "bootstrap_policy": {
+                    "required": True,
+                    "policy_type": "reset_seed",
+                    "seed_value_hex": "0x0",
+                    "rationale": "corner-MB boundary; H.264 intra has zero neighbors",
+                },
+            },
+            {
+                "edge_id": "beta__m_axis_mb__to__gamma__s_axis_mb",
+                "producer_block": "beta",
+                "consumer_block": "gamma",
+                "handshake_protocol": "axi_stream",
+                "data_width_bits": 16,
+                "fields": [
+                    {"name": "mb", "msb": 15, "lsb": 0, "width": 16,
+                     "signed": False, "encoding": "binary"},
+                ],
+                "bootstrap_policy": {"required": False, "policy_type": "none"},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def project_with_contracts(tmp_path, sample_contracts):
+    coresmith_dir = tmp_path / ".coresmith"
+    coresmith_dir.mkdir()
+    (coresmith_dir / "interface_contracts.json").write_text(
+        json.dumps(sample_contracts), encoding="utf-8"
+    )
+    return str(tmp_path)
+
+
+class TestLoadInterfaceContracts:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_interface_contracts(str(tmp_path)) == {}
+
+    def test_empty_project_root_returns_empty(self):
+        assert load_interface_contracts("") == {}
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        coresmith = tmp_path / ".coresmith"
+        coresmith.mkdir()
+        (coresmith / "interface_contracts.json").write_text("not json{", encoding="utf-8")
+        # Tolerant: returns empty rather than raising.
+        assert load_interface_contracts(str(tmp_path)) == {}
+
+    def test_well_formed_returns_full_dict(self, project_with_contracts, sample_contracts):
+        loaded = load_interface_contracts(project_with_contracts)
+        assert loaded == sample_contracts
+
+
+class TestFilterContractsForBlock:
+    def test_block_appears_in_no_edge(self, sample_contracts):
+        out = filter_contracts_for_block(sample_contracts["contracts"], "nonexistent")
+        assert out == []
+
+    def test_producer_match(self, sample_contracts):
+        out = filter_contracts_for_block(sample_contracts["contracts"], "alpha")
+        assert len(out) == 1
+        assert out[0]["edge_id"] == "alpha__m_axis_pix__to__beta__s_axis_pix"
+
+    def test_consumer_match(self, sample_contracts):
+        out = filter_contracts_for_block(sample_contracts["contracts"], "gamma")
+        assert len(out) == 1
+        assert out[0]["edge_id"] == "beta__m_axis_mb__to__gamma__s_axis_mb"
+
+    def test_block_on_both_sides(self, sample_contracts):
+        # `beta` is consumer of edge 1 and producer of edge 2 — both must
+        # surface so the spec author knows about its full port surface.
+        out = filter_contracts_for_block(sample_contracts["contracts"], "beta")
+        assert len(out) == 2
+        edge_ids = {e["edge_id"] for e in out}
+        assert "alpha__m_axis_pix__to__beta__s_axis_pix" in edge_ids
+        assert "beta__m_axis_mb__to__gamma__s_axis_mb" in edge_ids
+
+    def test_empty_input(self):
+        assert filter_contracts_for_block([], "alpha") == []
+        assert filter_contracts_for_block(None, "alpha") == []
+
+
+class TestLoadBlockContracts:
+    def test_role_tagging(self, project_with_contracts):
+        view = load_block_contracts(project_with_contracts, "beta")
+        roles = {e["edge_id"]: e["role"] for e in view["edges"]}
+        assert roles["alpha__m_axis_pix__to__beta__s_axis_pix"] == "consumer"
+        assert roles["beta__m_axis_mb__to__gamma__s_axis_mb"] == "producer"
+
+    def test_defaults_included(self, project_with_contracts):
+        view = load_block_contracts(project_with_contracts, "alpha")
+        assert view["defaults"]["default_packing_convention"] == "msb_first_by_field_list"
+        assert view["defaults"]["design_summary"] == "two-edge codec test design"
+
+    def test_block_with_no_edges(self, project_with_contracts):
+        view = load_block_contracts(project_with_contracts, "unconnected_block")
+        assert view["edges"] == []
+        # Defaults are still returned; the prompt formatter will treat the
+        # empty edges list as a no-op.
+        assert view["defaults"]["default_packing_convention"]
+
+    def test_missing_contracts_file(self, tmp_path):
+        view = load_block_contracts(str(tmp_path), "anything")
+        assert view == {"defaults": {}, "edges": []}
+
+
+class TestFormatBlockContractsPrompt:
+    def test_empty_edges_returns_empty_string(self):
+        # When the block has no contracts, the caller can skip injection
+        # without an `if`.
+        out = format_block_contracts_prompt(
+            "any_block", {"defaults": {}, "edges": []}
+        )
+        assert out == ""
+
+    def test_contains_canonical_marker(self, project_with_contracts):
+        view = load_block_contracts(project_with_contracts, "alpha")
+        out = format_block_contracts_prompt("alpha", view)
+        assert "CANONICAL INTERFACE CONTRACTS" in out
+        assert "alpha__m_axis_pix__to__beta__s_axis_pix" in out
+        # Authoritative-language marker for the agent to take seriously.
+        assert "AUTHORITATIVE" in out
+
+    def test_design_wide_convention_surfaces(self, project_with_contracts):
+        view = load_block_contracts(project_with_contracts, "alpha")
+        out = format_block_contracts_prompt("alpha", view)
+        assert "msb_first_by_field_list" in out
+
+    def test_bootstrap_policy_explicitly_called_out(self, project_with_contracts):
+        # The autopilot v7 finding: bootstrap_policy was specified but the
+        # RTL generator ignored it. The formatter must explicitly flag it
+        # so the agent can't miss it inside the JSON blob.
+        view = load_block_contracts(project_with_contracts, "alpha")
+        out = format_block_contracts_prompt("alpha", view)
+        assert "Bootstrap policy notice" in out
+        assert "reset_seed" in out
+        assert "corner-MB boundary" in out
+        # The instruction to drive seed on cycle 1 must be present.
+        assert "reset" in out.lower() and "seed" in out.lower()
+
+    def test_no_bootstrap_notice_when_not_required(self, project_with_contracts):
+        # `gamma` only consumes the second edge, which has
+        # bootstrap.required=False; the notice should NOT appear.
+        view = load_block_contracts(project_with_contracts, "gamma")
+        out = format_block_contracts_prompt("gamma", view)
+        assert "Bootstrap policy notice" not in out
+
+    def test_role_visible_in_bootstrap_notice(self, project_with_contracts):
+        view = load_block_contracts(project_with_contracts, "alpha")
+        out = format_block_contracts_prompt("alpha", view)
+        # `alpha` is the producer on the reset_seed edge.
+        assert "role=producer" in out


### PR DESCRIPTION
Re-opens #47 (auto-closed when its base branch was merged + deleted).

## Summary
- New helper `orchestrator/langchain/agents/contract_lookup.py` filters the canonical `.coresmith/interface_contracts.json` for a given block (producer + consumer roles), and renders a prompt fragment ready to drop into the per-block uArch spec generator + RTL generator user messages.
- Highlights `bootstrap_policy.required` edges explicitly so the RTL author cannot miss the seed/request/primed-externally requirement inside a large JSON blob.
- Wired into `uarch_spec_generator.py` and `rtl_generator.py`; the user message now contains a `## CANONICAL INTERFACE CONTRACTS for this block` section when contracts are present.

## Motivation (v7 h264 autopilot)
The Interface Definition stage (#45) was producing a correct `interface_contracts.json` (including `bootstrap_policy.reset_seed` for the neighbor edge), but the per-block RTL generator routinely ignored it because it never actually read the file. This PR forces the contract slice into each generator's context window.

## Test plan
- [x] `pytest orchestrator/tests/test_contract_lookup.py` — 19/19 pass
- [x] `ruff check orchestrator/` — clean
- [x] Verified in v8 h264 run: `recon_history_store.v` reset path now drives the documented zero-seed bootstrap (was missing in v5/v7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)