### PR TITLE
fix: auto-set PYTHONHOME so cocotb 2.x sims find pygpi

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -54,7 +54,18 @@
 
     "containerEnv": {
         "CORESMITH_PROJECT_ROOT": "/workspaces/coresmith",
-        "PYTHONUNBUFFERED": "1"
+        "PYTHONUNBUFFERED": "1",
+        // cocotb 2.x requires PYTHONHOME so the Verilator-embedded Python
+        // interpreter can find pygpi (a separate package introduced in
+        // cocotb 2.0). Without it, every cocotb sim invocation fails with
+        // `ModuleNotFoundError: No module named 'pygpi'` even though the
+        // module is on disk at the same site-packages dir cocotb itself
+        // lives in. Setting it here means every process in the container
+        // -- daemon, IDE-launched sims, SSH non-login shells -- inherits
+        // the right value automatically, instead of relying on a
+        // /etc/profile.d hook that non-login shells don't source.
+        "PYTHONHOME": "/usr/local/python/3.11.15",
+        "PYTHONPATH": "/workspaces/coresmith:/usr/local/python/3.11.15/lib/python3.11/site-packages"
     },
 
     "remoteEnv": {

--- a/bin/coresmith
+++ b/bin/coresmith
@@ -177,6 +177,23 @@ def _daemon_start(args):
         env["PATH"] = f"{venv_bin}:{env.get('PATH', '')}"
         env["VIRTUAL_ENV"] = str(repo_root / "venv")
 
+    # cocotb 2.x requires PYTHONHOME so the Verilator-embedded Python
+    # interpreter can find pygpi (a separate package introduced in
+    # cocotb 2.0). Without it, every sim invocation fails with
+    # ``ModuleNotFoundError: No module named 'pygpi'`` even though the
+    # module is on disk next to cocotb itself. We auto-detect the
+    # required value from the current interpreter's sysconfig prefix
+    # and inject it -- the operator may override by setting
+    # PYTHONHOME explicitly in the environment or in .coresmith/env.
+    if "PYTHONHOME" not in env:
+        try:
+            import sysconfig
+            prefix = sysconfig.get_config_var("prefix")
+            if prefix:
+                env["PYTHONHOME"] = prefix
+        except Exception:
+            pass
+
     with open(log_path, "ab") as logf:
         proc = subprocess.Popen(
             [str(python), "-m", "orchestrator.daemon.server", "--port", str(args.port or 0)],


### PR DESCRIPTION
## Summary

cocotb 2.x's Verilator-embedded interpreter needs `PYTHONHOME` to import `pygpi` (a separate package introduced in cocotb 2.0). Without it, **every** sim invocation fails with `ModuleNotFoundError: No module named 'pygpi'` — even though pygpi is on disk in the same `site-packages` dir as cocotb itself.

The v9 h264 codec_v3 autopilot run was completely blocked at the SIM stage because of this — both tier-1 blocks (axi_pixel_ingress, serial_csr_controller) exhausted TB-fix retries with the same pygpi error before being able to run a single test case. Verified manually: with `PYTHONHOME=/usr/local/python/3.11.15` set, the same TB runs **6/6 PASS**.

## Why the existing /etc/profile.d hook doesn't help

The devcontainer already writes a `/etc/profile.d/codespaces-setup.sh` that sets `PYTHONPATH` for SSH login shells. But:
- Daemon launches via `gh codespace ssh -- 'bin/coresmith daemon start'` use **non-login** SSH shells, which don't source `/etc/profile.d/`.
- IDE-launched processes inherit the IDE's env, not /etc/profile.d.

## Fix

Belt-and-suspenders:

1. **`.devcontainer/devcontainer.json`** — declare `PYTHONHOME` (+ `PYTHONPATH`) in `containerEnv` so every process in the container inherits the right value automatically.
2. **`bin/coresmith daemon start`** — when `PYTHONHOME` is unset in the caller's env, derive it from `sysconfig.get_config_var("prefix")` of the current interpreter and inject it before spawning the coresmithd subprocess. This survives across project_roots and works on non-codespace hosts where the devcontainer is not in play.

Operator override paths remain: explicit `PYTHONHOME=...` in caller env, or `<project_root>/.coresmith/env` (sticky env file).

## Test plan
- [x] Verified manually on the v9 codespace: with `PYTHONHOME` set, axi_pixel_ingress sim is **6/6 PASS** (was failing with pygpi error on every retry before)
- [x] Daemon restart with sticky `.coresmith/env` propagates `PYTHONHOME` to subprocess env (confirmed via `/proc/<pid>/environ`)
- [ ] Live v9 run with this fix is in progress; will update if tier-1 sims now actually pass under the daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)