### PR TITLE
integration_check: add accept action for lint-clean architectural drift

### DIFF
--- a/bin/coresmith
+++ b/bin/coresmith
@@ -418,7 +418,10 @@ def main():
     _add_project_root(rs)
     rs.add_argument(
         "--action", required=True,
-        help="approve | retry | skip | abort | feedback | fix_rtl | fix_tb | revise",
+        help=(
+            "approve | accept | retry | skip | abort | feedback | "
+            "fix_rtl | fix_tb | revise"
+        ),
     )
     rs.add_argument("--feedback", help="text feedback for the agent")
     rs.add_argument("--rtl-fix-description", help="describe the on-disk RTL/TB edit")

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -2504,12 +2504,17 @@ async def integration_check_node(state: OrchestratorState) -> dict:
                 "lint_log_path": lint_result.get("log_path", ""),
                 "block_rtl_paths": rtl_paths,
                 "skipped_connections": agent_result.get("skipped_connections", []),
-                "supported_actions": [
-                    "retry",
-                    "fix_rtl",
-                    "skip",
-                    "abort",
-                ],
+                "supported_actions": (
+                    # `accept` is only offered when the chip_top still
+                    # lint-passes despite the architectural mismatches --
+                    # the operator can then advance to DV without
+                    # regenerating, because the issues are naming /
+                    # design-intent drift rather than syntactic
+                    # violations.
+                    ["accept", "retry", "fix_rtl", "skip", "abort"]
+                    if lint_clean
+                    else ["retry", "fix_rtl", "skip", "abort"]
+                ),
                 "outer_agent_guidance": (
                     "Integration Lead agent found issues. As the outer-loop "
                     "diagnostic agent, diagnose and fix before escalating:\n"
@@ -2521,7 +2526,10 @@ async def integration_check_node(state: OrchestratorState) -> dict:
                     "4. LINT_ERRORS: Read the lint log and edit "
                     f"{top_rtl_path} directly.\n"
                     "5. After fixing, resume_pipeline(action='fix_rtl').\n"
-                    "6. Only escalate for architectural issues."
+                    "6. Only escalate for architectural issues.\n"
+                    "7. ACCEPT: chip_top already lint-passes and the "
+                    "mismatches are acceptable for this run -- proceed "
+                    "to DV without further regeneration."
                 ),
                 "reference_files": {
                     "top_rtl": top_rtl_path,
@@ -2543,6 +2551,18 @@ async def integration_check_node(state: OrchestratorState) -> dict:
             if action == "skip":
                 integration_result["skipped_by_user"] = True
                 log("  [INTEGRATION] Skipped by user/agent", YELLOW)
+            elif action == "accept":
+                # User/agent acknowledges the mismatch errors but the
+                # chip_top still lint-passes -- advance to DV with the
+                # existing top-level Verilog.  Mark the result so the
+                # router stops short-circuiting on error_count > 0.
+                integration_result["accepted_by_user"] = True
+                log(
+                    "  [INTEGRATION] Accepted despite "
+                    f"{len(errors)} error(s) (lint_clean=True); "
+                    "advancing to DV",
+                    YELLOW,
+                )
             elif action == "abort":
                 integration_result["aborted"] = True
                 log("  [INTEGRATION] Aborted", RED)
@@ -2680,6 +2700,11 @@ def route_after_integration(state: OrchestratorState) -> str:
         return END
     if result.get("lint_clean") is False:
         return END
+    # `accepted_by_user` overrides the error_count gate: the operator
+    # has acknowledged the architectural mismatches are acceptable for
+    # this run and chip_top still lint-passes, so DV is allowed to run.
+    if result.get("accepted_by_user"):
+        return "integration_dv"
     if int(result.get("error_count", 0) or 0) > 0:
         return END
     return "integration_dv"

--- a/orchestrator/tests/test_pipeline_graph.py
+++ b/orchestrator/tests/test_pipeline_graph.py
@@ -780,6 +780,30 @@ class TestRouteAfterIntegration:
             "integration_result": {"lint_clean": True, "error_count": 1}
         }) == "__end__"
 
+    def test_accepted_by_user_overrides_error_count(self):
+        # When the operator/agent explicitly accepts the integration
+        # failure (chip_top still lint-passes, mismatches are
+        # acceptable for this run), routing must advance to DV
+        # regardless of error_count.
+        assert pipeline_graph.route_after_integration({
+            "integration_result": {
+                "lint_clean": True,
+                "error_count": 2,
+                "accepted_by_user": True,
+            }
+        }) == "integration_dv"
+
+    def test_accepted_by_user_does_not_override_lint_failure(self):
+        # accept is only meaningful when chip_top still lint-passes;
+        # if lint failed, route to END even if accepted_by_user is set.
+        assert pipeline_graph.route_after_integration({
+            "integration_result": {
+                "lint_clean": False,
+                "error_count": 0,
+                "accepted_by_user": True,
+            }
+        }) == "__end__"
+
     @pytest.mark.asyncio
     async def test_partial_block_set_refuses_integration(self, tmp_path):
         result = await pipeline_graph.integration_check_node({


### PR DESCRIPTION
## Summary

Adds `accept` to the `integration_failure` interrupt's `supported_actions` when `lint_clean=True`. Previously the only options were `retry / fix_rtl / skip / abort`, none of which matched the common case where chip_top lint-passes but Integration Lead flagged naming or design-intent drift.

## Why

The v9 h264 codec_v3 autopilot run hit `integration_failure` with:
- `lint_clean=True` (chip_top synthesizes fine)
- 2 errors: `axis_pixel_ingress` vs `axi_pixel_ingress` block name drift, and `recon_history_store` opting to internally count block coords instead of accepting an `s_axis_block_coord` input port

Neither error blocks DV from running — they show up as failed/skipped tests, which is the information DV is meant to surface. But the only available actions were:
- `retry` → re-runs Integration Lead → reproduces the same drift (LLM-generated specs disagree the same way every regeneration)
- `skip` → bypasses DV + validation entirely (loses the chance to test the design)
- `fix_rtl` → requires hand-editing RTL on disk first

`accept` lands in the gap: chip_top stays as-is, `accepted_by_user` flag set, router advances to `integration_dv`.

## Changes
- `orchestrator/langgraph/pipeline_graph.py`: add `accept` to `supported_actions` only when `lint_clean=True`; new `accepted_by_user` flag on `integration_result`; `route_after_integration` honors the flag and routes to `integration_dv` even with `error_count > 0`.
- `bin/coresmith`: update `--action` help text.
- `orchestrator/tests/test_pipeline_graph.py`: 2 new tests covering the override path and the lint-failure exception.

## Test plan
- [x] 6/6 `TestRouteAfterIntegration` tests pass
- [x] `ruff check orchestrator/` clean
- [ ] End-to-end: re-run v9 integration_check, resume `accept`, verify integration_dv launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)