### PR TITLE
arch: enforce contract FIFO depth on per-block RTL (close v9 deadlock class)

### DIFF
--- a/orchestrator/architecture/constraints.py
+++ b/orchestrator/architecture/constraints.py
@@ -527,6 +527,55 @@ _CONSTRAINT_CATALOG: list[dict] = [
             (ctx.get("interface_contracts") or {}).get("contracts")
         ),
     },
+    {
+        "id": "cross_spec_fifo_depth_adherence",
+        "category": "structural",
+        "severity": "error",
+        "description": (
+            "The Interface Definition stage's `flow_control_policy` "
+            "declares `min_buffer_depth_beats` for every edge with "
+            "`semantics == \"elastic_fifo\"`. Those depths were chosen "
+            "from the worst-case stall window of the feedback graph; "
+            "the RTL author MUST size the FIFO to at least the declared "
+            "depth. The v9 h264 codec_v3 chip_top deadlocked at 3.3% of "
+            "frame input because the frame_block_scheduler FIFO was "
+            "sized 256 against a contract that needed deeper buffering; "
+            "this constraint catches that class of bug before DV.\n\n"
+            "For EACH contract entry where "
+            "`flow_control_policy.semantics == \"elastic_fifo\"`:\n\n"
+            "1. **Locate the producer block's RTL.** Grep its `*.v` for "
+            "the FIFO that backs this edge. The depth is usually a "
+            "`localparam DEPTH = <N>;` or `localparam [W:0] FIFO_DEPTH "
+            "= <N>;` or a `parameter DEPTH = <N>;` near the top of the "
+            "module. The reg array (`reg [...] fifo_mem [0:N-1];`) "
+            "should match.\n"
+            "2. **Compare against the contract.** If the actual depth "
+            "`< min_buffer_depth_beats`, flag a violation citing the "
+            "specific filename:line of the localparam.\n"
+            "3. **Skip cleanly.** If RTL has not been generated yet "
+            "(no `rtl/*/*.v` files in the bundle), pass with a "
+            "one-line note that the check did not run yet. Same for "
+            "any block whose RTL is missing.\n"
+            "4. **Tolerate inline FIFOs.** Some blocks implement the "
+            "FIFO as inline ring buffer (no localparam, just a sized "
+            "reg array with hard-coded index). In that case the audit "
+            "should look at the `reg [...] <name>_mem [0:<size>-1]` "
+            "declaration and compare `<size>` to the contract depth.\n\n"
+            "Pass if every elastic_fifo contract has an RTL FIFO whose "
+            "depth meets or exceeds `min_buffer_depth_beats`. Fail with "
+            "specific file:line citations otherwise."
+        ),
+        "applies": lambda ctx: bool(
+            (ctx.get("interface_contracts") or {}).get("contracts")
+            and any(
+                (c.get("flow_control_policy") or {}).get("semantics")
+                == "elastic_fifo"
+                for c in (
+                    (ctx.get("interface_contracts") or {}).get("contracts") or []
+                )
+            )
+        ),
+    },
 ]
 
 
@@ -588,6 +637,37 @@ def _build_artifact_bundle(
             parts.append(
                 "## per-block uArch specs (arch/uarch_specs/)\n\n"
                 + "\n\n".join(spec_chunks)
+            )
+
+    # Per-block generated RTL (if any has been written yet). Needed by
+    # cross_spec_fifo_depth_adherence so the audit can grep for
+    # FIFO depth params. Constrain size per-file to keep the bundle
+    # below the LLM context limit -- the FIFO depth declaration always
+    # lives in the first ~50 lines of a Verilog module, so a shallow
+    # head is enough.
+    rtl_root = Path(project_root) / "rtl"
+    if rtl_root.is_dir():
+        rtl_chunks: list[str] = []
+        for verilog_path in sorted(rtl_root.glob("**/*.v")):
+            if "integration" in verilog_path.parts:
+                # chip_top is generated separately by Integration Lead;
+                # the per-block FIFOs are what we care about here.
+                continue
+            try:
+                head = "\n".join(
+                    verilog_path.read_text(encoding="utf-8").splitlines()[:120]
+                )
+                rel = verilog_path.relative_to(Path(project_root))
+                rtl_chunks.append(
+                    f"### {rel.as_posix()} (first 120 lines)\n"
+                    f"```verilog\n{head}\n```"
+                )
+            except OSError:
+                continue
+        if rtl_chunks:
+            parts.append(
+                "## per-block generated RTL (heads only)\n\n"
+                + "\n\n".join(rtl_chunks)
             )
 
     if memory_map and (memory_map.get("peripherals") or memory_map.get("result")):

--- a/orchestrator/langchain/agents/contract_lookup.py
+++ b/orchestrator/langchain/agents/contract_lookup.py
@@ -197,6 +197,41 @@ def format_block_contracts_prompt(block_name: str, view: dict[str, Any]) -> str:
             "reverse channel; producer must respond with exactly one packet "
             "per request. Producer MUST NOT push unsolicited."
         )
+        # Hard requirement on FIFO depth -- the v9 codec deadlock was
+        # exactly this: contract said depth=N but the RTL author picked
+        # a smaller convenient value and the loop wedged. The
+        # cross_spec_fifo_depth_adherence audit will reject any FIFO
+        # whose declared DEPTH is below the contract minimum, so failing
+        # this rule guarantees a downstream pipeline failure.
+        elastic_edges = [
+            e for e in fc_edges
+            if (e.get("flow_control_policy") or {}).get("semantics") == "elastic_fifo"
+        ]
+        if elastic_edges:
+            lines.append("")
+            lines.append("**FIFO depth requirement (HARD, enforced by audit):**")
+            for e in elastic_edges:
+                fc = e.get("flow_control_policy") or {}
+                depth = fc.get("min_buffer_depth_beats")
+                if depth is None:
+                    continue
+                lines.append(
+                    f"- Edge `{e.get('edge_id', '?')}` (role={e.get('role')}) "
+                    f"requires FIFO DEPTH >= {depth} beats. Declare it as "
+                    f"`localparam DEPTH = {depth};` (or larger) and size all "
+                    "depth-dependent registers + pointer widths accordingly."
+                )
+            lines.append(
+                "Do NOT downsize the FIFO below the contract minimum even "
+                "if synthesis or area pressure pushes back. The "
+                "min_buffer_depth_beats values were derived from the "
+                "worst-case stall window of the feedback graph; choosing a "
+                "smaller depth WILL deadlock the design. The "
+                "`cross_spec_fifo_depth_adherence` constraint subagent reads "
+                "the synthesized RTL after generation and fails the run if "
+                "any `localparam DEPTH` (or equivalent) is below the value "
+                "above."
+            )
 
     return "\n".join(lines)
 

--- a/orchestrator/tests/test_architecture.py
+++ b/orchestrator/tests/test_architecture.py
@@ -1216,3 +1216,81 @@ class TestCrossSpecContractAdherence:
                 # No interface_contracts and no file on disk
             )
         assert "cross_spec_contract_adherence" not in called
+
+
+# ---------------------------------------------------------------------------
+# cross_spec_fifo_depth_adherence subagent (PR #52)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSpecFifoDepthAdherence:
+    """Catches per-block RTL whose FIFO `localparam DEPTH` is below the
+    contract's `flow_control_policy.min_buffer_depth_beats`. The v9 codec
+    deadlock at 3.3% of frame input was exactly this class of bug."""
+
+    def test_constraint_registered(self):
+        from orchestrator.architecture.constraints import _CONSTRAINT_CATALOG
+        match = [
+            c for c in _CONSTRAINT_CATALOG
+            if c["id"] == "cross_spec_fifo_depth_adherence"
+        ]
+        assert len(match) == 1
+        assert match[0]["severity"] == "error"
+
+    def test_applies_only_when_elastic_fifo_edges_exist(self):
+        from orchestrator.architecture.constraints import _CONSTRAINT_CATALOG
+        c = next(
+            x for x in _CONSTRAINT_CATALOG
+            if x["id"] == "cross_spec_fifo_depth_adherence"
+        )
+        # No contracts at all -> skip
+        assert c["applies"]({"interface_contracts": {}}) is False
+        # Contracts but no elastic_fifo semantics -> skip
+        assert c["applies"]({
+            "interface_contracts": {
+                "contracts": [
+                    {"edge_id": "a", "flow_control_policy": {"semantics": "skid"}},
+                    {"edge_id": "b", "flow_control_policy": {"semantics": "free_running"}},
+                ],
+            }
+        }) is False
+        # At least one elastic_fifo -> apply
+        assert c["applies"]({
+            "interface_contracts": {
+                "contracts": [
+                    {"edge_id": "a", "flow_control_policy": {"semantics": "skid"}},
+                    {"edge_id": "b", "flow_control_policy": {"semantics": "elastic_fifo"}},
+                ],
+            }
+        }) is True
+
+    def test_artifact_bundle_includes_rtl_heads(self, tmp_project):
+        """The audit must see the per-block RTL heads in the bundle so it
+        can grep for `localparam DEPTH = N` declarations."""
+        from orchestrator.architecture.constraints import _build_artifact_bundle
+        from pathlib import Path
+
+        rtl_dir = Path(tmp_project) / "rtl" / "design"
+        rtl_dir.mkdir(parents=True)
+        sample = (
+            "/* Block alpha */\n"
+            "module alpha (input clk, input rst_n);\n"
+            "    localparam [8:0] FIFO_DEPTH = 9'd256;\n"
+            "    reg [31:0] block_fifo_mem [0:255];\n"
+            "endmodule\n"
+        )
+        (rtl_dir / "alpha.v").write_text(sample)
+
+        bundle = _build_artifact_bundle(
+            block_diagram={"blocks": [{"name": "alpha"}]},
+            memory_map={},
+            clock_tree={},
+            register_spec={},
+            benchmark_results=None,
+            pdk_config=None,
+            requirements="",
+            ers_spec=None,
+            project_root=tmp_project,
+        )
+        assert "rtl/design/alpha.v" in bundle
+        assert "FIFO_DEPTH = 9'd256" in bundle

--- a/orchestrator/tests/test_contract_lookup.py
+++ b/orchestrator/tests/test_contract_lookup.py
@@ -285,3 +285,30 @@ class TestFormatFlowControl:
         view = load_block_contracts(project_with_contracts, "alpha")
         out = format_block_contracts_prompt("alpha", view)
         assert "Flow control policy notice" not in out
+
+    def test_fifo_depth_requirement_emitted_for_elastic_edges(
+        self, project_with_flow_control
+    ):
+        # PR #52: elastic_fifo edges must surface a hard FIFO depth
+        # requirement in the per-block prompt, citing the contract's
+        # min_buffer_depth_beats value so the RTL author can't silently
+        # downsize. The audit subagent will reject it otherwise.
+        view = load_block_contracts(project_with_flow_control, "sched")
+        out = format_block_contracts_prompt("sched", view)
+        assert "FIFO depth requirement (HARD" in out
+        # The fixture sets min_buffer_depth_beats=16 on sched's edge.
+        assert "FIFO DEPTH >= 16 beats" in out
+        assert "localparam DEPTH = 16" in out
+        # The audit name must be referenced so the LLM knows what
+        # enforces it.
+        assert "cross_spec_fifo_depth_adherence" in out
+
+    def test_no_fifo_depth_section_when_no_elastic_edges(
+        self, project_with_contracts
+    ):
+        # The bootstrap fixture has no elastic_fifo semantics, so the
+        # FIFO depth requirement section must NOT appear (we don't want
+        # to confuse the LLM about request_response or skid edges).
+        view = load_block_contracts(project_with_contracts, "alpha")
+        out = format_block_contracts_prompt("alpha", view)
+        assert "FIFO depth requirement" not in out


### PR DESCRIPTION
## Summary

Closes the v8/v9 codec deadlock class structurally. The contract layer (PR #49) declared the right elasticity. The per-block prompt injection (PR #48) surfaced it. The RTL generator agreed in prose but picked a smaller convenient depth, and no audit caught the drift. **The v9 chip_top deadlocked at 7681/230400 input pixels — exactly this bug.**

## The fix: two layers

### 1. Prompt hardening (`contract_lookup.format_block_contracts_prompt`)
For every `elastic_fifo` edge, append an explicit **FIFO depth requirement (HARD, enforced by audit)** section listing each edge with its required `localparam DEPTH = <N>` value. Replaces the previous soft "at least the declared min_buffer_depth_beats" suggestion. The audit name (`cross_spec_fifo_depth_adherence`) is cited inline so the LLM knows enforcement exists.

### 2. `cross_spec_fifo_depth_adherence` audit subagent (`constraints.py`)
New entry in `_CONSTRAINT_CATALOG`. `applies` predicate fires only when at least one contract has `flow_control_policy.semantics == "elastic_fifo"`. The artifact bundle now includes the **first 120 lines of every per-block Verilog file** (enough to capture `localparam DEPTH = N`), so the subagent can grep + compare against `min_buffer_depth_beats`. No-op when RTL hasn't been generated yet (so the architecture-phase constraint check stays non-blocking on the first pass; it activates the moment RTL exists on disk).

## Test plan
- [x] 3 new `TestCrossSpecFifoDepthAdherence` tests (constraint registered, applies predicate, bundle includes RTL heads)
- [x] 2 new `TestFormatFlowControl` tests (depth requirement section emitted for elastic edges, suppressed otherwise)
- [x] Full suite: **70/70** pass
- [x] `ruff check orchestrator/` clean
- [ ] Live v10 run: confirm RTL generated under PR #52 honors contract depths and integration_dv runs end-to-end

## Why integration_lead didn't catch this (covered in the discussion)

Integration Lead's job is chip-level wiring: port/width compatibility and lint. It doesn't open per-block RTL and inspect `localparam DEPTH`, doesn't simulate, and can't tell whether `depth=256` is sufficient for the actual feedback latency. This PR puts the audit at the right layer (per-block, with both contract + RTL in scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)