### PR TITLE
backend: EDA-step timeouts + graceful missing-testbench handling

### DIFF
--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -45,22 +45,6 @@ import re
 from pathlib import Path
 from typing import Annotated, Optional, TypedDict
 
-
-def _eda_timeout(env: str, default: int) -> int:
-    """Per-stage EDA-step timeout (seconds), overridable by env var.
-
-    Large designs (≳300K cells) routinely need longer than the historic
-    defaults for PnR and signoff: detailed routing alone can run well past
-    30 min. Gate the ceiling on an env var so big-design runs don't get
-    their OpenROAD child killed mid-route while small designs keep the
-    snappy default.
-    """
-    try:
-        v = int(os.environ.get(env, "").strip())
-        return v if v > 0 else default
-    except (ValueError, AttributeError):
-        return default
-
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import interrupt
 from opentelemetry import trace
@@ -76,6 +60,22 @@ from orchestrator.langgraph.pipeline_helpers import (
 )
 
 _tracer = trace.get_tracer("coresmith.langgraph.backend_graph")
+
+
+def _eda_timeout(env: str, default: int) -> int:
+    """Per-stage EDA-step timeout (seconds), overridable by env var.
+
+    Large designs (≳300K cells) routinely need longer than the historic
+    defaults for PnR and signoff: detailed routing alone can run well past
+    30 min. Gate the ceiling on an env var so big-design runs don't get
+    their OpenROAD child killed mid-route while small designs keep the
+    snappy default.
+    """
+    try:
+        v = int(os.environ.get(env, "").strip())
+        return v if v > 0 else default
+    except (ValueError, AttributeError):
+        return default
 
 
 def _last(a, b):

--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -40,9 +40,26 @@ from __future__ import annotations
 import asyncio
 import json
 import operator
+import os
 import re
 from pathlib import Path
 from typing import Annotated, Optional, TypedDict
+
+
+def _eda_timeout(env: str, default: int) -> int:
+    """Per-stage EDA-step timeout (seconds), overridable by env var.
+
+    Large designs (≳300K cells) routinely need longer than the historic
+    defaults for PnR and signoff: detailed routing alone can run well past
+    30 min. Gate the ceiling on an env var so big-design runs don't get
+    their OpenROAD child killed mid-route while small designs keep the
+    snappy default.
+    """
+    try:
+        v = int(os.environ.get(env, "").strip())
+        return v if v > 0 else default
+    except (ValueError, AttributeError):
+        return default
 
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import interrupt
@@ -622,7 +639,7 @@ async def run_pnr_node(state: BackendState) -> dict:
                 "tcl_path": tcl_path,
             },
             result_json_path=result_json_path,
-            timeout=1800,
+            timeout=_eda_timeout("CORESMITH_PNR_TIMEOUT", 1800),
         )
 
         pnr_ok = result.get("success", False)
@@ -1013,7 +1030,7 @@ async def generate_wrapper_node(state: BackendState) -> dict:
                 "result_json_path": result_json_path,
             },
             result_json_path=result_json_path,
-            timeout=600,
+            timeout=_eda_timeout("CORESMITH_WRAPPER_TIMEOUT", 600),
         )
 
         wrapper_ok = result.get("success", False)

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -717,6 +717,13 @@ async def generate_testbench_node(state: BlockState) -> dict:
     block = state["current_block"]
     block_name = block["name"]
     attempt = state["attempt"]
+    # A blocks.yaml entry that omits `testbench` must not crash the whole
+    # run -- it previously raised KeyError here and aborted every other
+    # in-flight block in the tier. Default to the conventional cocotb path
+    # and write it back so all downstream consumers (generate_testbench,
+    # the "reuse existing" log, etc.) see a value.
+    if not block.get("testbench"):
+        block["testbench"] = f"tb/cocotb/test_{block_name}.py"
     tb_path_obj = Path(state["project_root"]) / block["testbench"]
     rtl_path = state.get("rtl_path", "")
 

--- a/orchestrator/tests/test_backend_graph.py
+++ b/orchestrator/tests/test_backend_graph.py
@@ -406,3 +406,29 @@ class TestHappyPath:
         assert len(result["completed_blocks"]) == 1
         assert result["completed_blocks"][0]["name"] == "test_chip_top"
         assert result["completed_blocks"][0]["skipped"] is True
+
+
+class TestEdaTimeout:
+    """`_eda_timeout` gates per-stage EDA-step ceilings on env vars so
+    large-design PnR/signoff runs don't get the OpenROAD child killed
+    mid-route, while small designs keep the snappy default."""
+
+    def test_default_when_unset(self, monkeypatch):
+        from orchestrator.langgraph.backend_graph import _eda_timeout
+        monkeypatch.delenv("CORESMITH_PNR_TIMEOUT", raising=False)
+        assert _eda_timeout("CORESMITH_PNR_TIMEOUT", 1800) == 1800
+
+    def test_override_when_set(self, monkeypatch):
+        from orchestrator.langgraph.backend_graph import _eda_timeout
+        monkeypatch.setenv("CORESMITH_PNR_TIMEOUT", "5400")
+        assert _eda_timeout("CORESMITH_PNR_TIMEOUT", 1800) == 5400
+
+    def test_garbage_falls_back_to_default(self, monkeypatch):
+        from orchestrator.langgraph.backend_graph import _eda_timeout
+        monkeypatch.setenv("CORESMITH_PNR_TIMEOUT", "not-an-int")
+        assert _eda_timeout("CORESMITH_PNR_TIMEOUT", 1800) == 1800
+
+    def test_nonpositive_falls_back_to_default(self, monkeypatch):
+        from orchestrator.langgraph.backend_graph import _eda_timeout
+        monkeypatch.setenv("CORESMITH_PNR_TIMEOUT", "0")
+        assert _eda_timeout("CORESMITH_PNR_TIMEOUT", 1800) == 1800

--- a/orchestrator/tests/test_pipeline_graph.py
+++ b/orchestrator/tests/test_pipeline_graph.py
@@ -1961,3 +1961,39 @@ class TestIntegrationReviewFiltering:
             {"name": "b", "tier": 1},
         ]
         assert filtered["connections"] == [{"from": "a.out", "to": "b.in"}]
+
+
+class TestTestbenchDefaultPath:
+    """A blocks.yaml entry without `testbench` must not KeyError and crash
+    the whole run; generate_testbench_node defaults to the cocotb path and
+    writes it back into the block dict for downstream consumers."""
+
+    async def test_missing_testbench_defaults_and_skips_cleanly(self, tmp_path):
+        from orchestrator.langgraph import pipeline_graph
+        block = {"name": "widget", "tier": 2, "rtl_target": "rtl/widget/widget.v"}
+        state = {
+            "current_block": block,
+            "attempt": 1,
+            "project_root": str(tmp_path),
+            "rtl_path": "",  # no RTL -> node returns early, before any LLM call
+            "step_log_paths": {},
+        }
+        # Must not raise KeyError('testbench'); returns sim_passed False (no RTL).
+        result = await pipeline_graph.generate_testbench_node(state)
+        assert result["sim_passed"] is False
+        assert block["testbench"] == "tb/cocotb/test_widget.py"
+        assert result["tb_path"].endswith("tb/cocotb/test_widget.py")
+
+    async def test_explicit_testbench_preserved(self, tmp_path):
+        from orchestrator.langgraph import pipeline_graph
+        block = {"name": "widget", "tier": 2, "testbench": "tb/custom/tb_widget.py"}
+        state = {
+            "current_block": block,
+            "attempt": 1,
+            "project_root": str(tmp_path),
+            "rtl_path": "",
+            "step_log_paths": {},
+        }
+        result = await pipeline_graph.generate_testbench_node(state)
+        assert block["testbench"] == "tb/custom/tb_widget.py"
+        assert result["tb_path"].endswith("tb/custom/tb_widget.py")


### PR DESCRIPTION
Two backend/pipeline robustness fixes surfaced during the 2026-05-27 night MCU runs (mcu3/mcu5 on OCI workers).

## Commits
- **796e860** `backend: env-gate PnR/wrapper EDA-step timeouts for large designs` — large designs were tripping fixed EDA-step timeouts during PnR/wrapper; gate the timeouts behind an env var so big runs (mcu*) don't get killed mid-step.
- **0fc65c7** `pipeline: default missing block testbench instead of crashing the run` — a block with no generated TB crashed the whole run; default it instead so the pipeline degrades gracefully.

## Test
Both behaviors are env-gated / additive. Existing fast tests should be unaffected; CI on this PR validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)