### PR TITLE
pipeline: don't silently finish without DV (CORESMITH_REQUIRE_DV)

### DIFF
--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -2698,14 +2698,46 @@ async def integration_check_node(state: OrchestratorState) -> dict:
         return {"integration_result": integration_result}
 
 
+def _require_dv() -> bool:
+    """CORESMITH_REQUIRE_DV makes integration DV mandatory: the review-gate
+    bail-outs (skip / unaccepted errors) then route into DV instead of END."""
+    return (os.getenv("CORESMITH_REQUIRE_DV") or "").strip().lower() not in (
+        "", "0", "false", "no", "off",
+    )
+
+
 def route_after_integration(state: OrchestratorState) -> str:
-    """Route after integration check: proceed to DV or END."""
+    """Route after integration check: proceed to DV or END.
+
+    A clean integration check proceeds to integration DV. The review-gate
+    "bail" outcomes (operator skipping the review, or unresolved/unaccepted
+    integration errors) route to END by default -- but ending there means the
+    assembled chip is **never verified by DV**, so a non-functional design can
+    still report a clean ``done``. That silent bypass is the bug.
+
+    Behaviour:
+      - ``aborted`` (deliberate abort, or fix_rtl/retry that ENDs so the outer
+        agent can ``restart_node``) and a hard lint failure always END -- those
+        are genuine stops, not "skip verification".
+      - ``skipped`` / unaccepted ``error_count > 0`` END by default, but are
+        logged loudly as "ENDing WITHOUT DV -- chip UNVERIFIED" rather than
+        finishing silently. Set ``CORESMITH_REQUIRE_DV=1`` to make DV mandatory:
+        those cases then run integration DV instead of finishing unverified.
+    """
     result = state.get("integration_result") or {}
+    require_dv = _require_dv()
+
     if result.get("aborted"):
         return END
-    if result.get("skipped") or result.get("skipped_by_user"):
-        return END
     if result.get("lint_clean") is False:
+        return END
+    if result.get("skipped") or result.get("skipped_by_user"):
+        if require_dv:
+            log("  [INTEGRATION] review skipped, but CORESMITH_REQUIRE_DV set "
+                "-> running integration DV anyway", YELLOW)
+            return "integration_dv"
+        log("  [INTEGRATION] review skipped -> ENDing WITHOUT DV; chip is "
+            "UNVERIFIED (set CORESMITH_REQUIRE_DV=1 to force DV)", YELLOW)
         return END
     # `accepted_by_user` overrides the error_count gate: the operator
     # has acknowledged the architectural mismatches are acceptable for
@@ -2713,6 +2745,14 @@ def route_after_integration(state: OrchestratorState) -> str:
     if result.get("accepted_by_user"):
         return "integration_dv"
     if int(result.get("error_count", 0) or 0) > 0:
+        if require_dv:
+            log("  [INTEGRATION] unresolved integration errors, but "
+                "CORESMITH_REQUIRE_DV set -> running integration DV anyway",
+                YELLOW)
+            return "integration_dv"
+        log("  [INTEGRATION] ENDing WITHOUT DV due to unresolved integration "
+            "errors; chip is UNVERIFIED (set CORESMITH_REQUIRE_DV=1 to force "
+            "DV)", YELLOW)
         return END
     return "integration_dv"
 

--- a/orchestrator/tests/test_pipeline_graph.py
+++ b/orchestrator/tests/test_pipeline_graph.py
@@ -804,6 +804,45 @@ class TestRouteAfterIntegration:
             }
         }) == "__end__"
 
+    # --- CORESMITH_REQUIRE_DV: DV must not be silently skippable ---
+
+    def test_skipped_review_ends_without_dv_by_default(self, monkeypatch):
+        monkeypatch.delenv("CORESMITH_REQUIRE_DV", raising=False)
+        assert pipeline_graph.route_after_integration({
+            "integration_result": {
+                "lint_clean": True, "error_count": 0, "skipped_by_user": True,
+            }
+        }) == "__end__"
+
+    def test_skipped_review_runs_dv_when_require_dv(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_REQUIRE_DV", "1")
+        assert pipeline_graph.route_after_integration({
+            "integration_result": {
+                "lint_clean": True, "error_count": 0, "skipped_by_user": True,
+            }
+        }) == "integration_dv"
+
+    def test_unaccepted_errors_run_dv_when_require_dv(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_REQUIRE_DV", "1")
+        assert pipeline_graph.route_after_integration({
+            "integration_result": {"lint_clean": True, "error_count": 3}
+        }) == "integration_dv"
+
+    def test_require_dv_does_not_override_abort(self, monkeypatch):
+        # A deliberate abort (or fix_rtl/retry that ENDs for restart_node)
+        # must still END even when DV is required.
+        monkeypatch.setenv("CORESMITH_REQUIRE_DV", "1")
+        assert pipeline_graph.route_after_integration({
+            "integration_result": {"aborted": True, "lint_clean": True}
+        }) == "__end__"
+
+    def test_require_dv_does_not_override_lint_failure(self, monkeypatch):
+        # A hard lint failure can't be DV'd (chip_top won't build), so END.
+        monkeypatch.setenv("CORESMITH_REQUIRE_DV", "1")
+        assert pipeline_graph.route_after_integration({
+            "integration_result": {"lint_clean": False, "error_count": 0}
+        }) == "__end__"
+
     @pytest.mark.asyncio
     async def test_partial_block_set_refuses_integration(self, tmp_path):
         result = await pipeline_graph.integration_check_node({


### PR DESCRIPTION
## The bug
`route_after_integration` routes to `END` whenever the integration review is **skipped** or has **unaccepted errors**. Ending there means the assembled chip is **never exercised by integration DV**, yet the run still reports a clean `done` — so a non-functional design looks identical to one that passed DV.

**Observed on the 2026-05-29 nightly:** a from-scratch JPEG compressor reached `done` having skipped DV. Driving a real 8×8 image through the generated `jpeg_compressor_top` showed it **deadlocks after 2 of 64 pixels and emits 0 bytes** — completely non-functional, but greenlit. Forcing integration_dv to run afterward immediately caught it (5/6 chip-level tests fail, end-to-end test hangs). The only thing standing between "broken chip" and "caught" was that DV was skippable.

## The fix
- **Always log the bypass loudly** — `ENDing WITHOUT DV; chip is UNVERIFIED` — instead of finishing silently.
- **`CORESMITH_REQUIRE_DV=1`** (env-gated, default off per repo convention): a skipped review or unaccepted errors then route into `integration_dv` instead of `END`, making DV mandatory. `aborted` (deliberate abort, or `fix_rtl`/`retry` that ENDs so the outer agent can `restart_node`) and hard **lint failures** still `END` regardless — those are genuine stops, not "skip verification."

## Tests
Extends `TestRouteAfterIntegration` with both-branch coverage (env unset → `END` as before; `CORESMITH_REQUIRE_DV=1` → `integration_dv`), plus that REQUIRE_DV does **not** override `aborted` or lint failure. The 5 new + 5 existing route tests pass locally.

Note: this addresses the coresmith-side half of the nightly false-positive. The other half (the autopilot answering the review gate with `retry`/`skip` instead of `approve`) was a bug in my nightly harness, not in coresmith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)