### PR TITLE
pipeline: WaveKit VCD audit skips gracefully when unavailable (no more spurious DV_PROCESS_ERROR)

### DIFF
--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -718,11 +718,21 @@ with VcdReader(str(vcd_path)) as reader:
             timeout=scaled(180),
         )
     except subprocess.CalledProcessError as exc:
+        # WaveKit could not be SET UP (no prebuilt wheel for this arch + missing
+        # native build deps like python3-dev/cmake, etc.). The WaveKit VCD audit
+        # is a *supplementary* analysis layered on top of the cocotb regression
+        # result -- a missing optional tool must NOT masquerade as a DV failure
+        # (that produced a spurious DV_PROCESS_ERROR on arm64 workers lacking
+        # build deps). Skip gracefully so DV is decided by the cocotb pass/fail.
         result = {
-            "ok": False,
-            "error": (
-                f"WaveKit setup failed: {(exc.stderr or exc.stdout or str(exc))[-2000:]}"
+            "ok": True,
+            "skipped": True,
+            "reason": (
+                "WaveKit unavailable; VCD audit skipped -- DV relies on cocotb "
+                "results. Install WaveKit (needs python3-dev + cmake to build "
+                "pylibfst from sdist on platforms without a prebuilt wheel)."
             ),
+            "detail": (exc.stderr or exc.stdout or str(exc))[-1000:],
             "vcd_path": str(vcd_path),
         }
         audit_path.write_text(json.dumps(result, indent=2), encoding="utf-8")

--- a/orchestrator/tests/test_wavekit_audit.py
+++ b/orchestrator/tests/test_wavekit_audit.py
@@ -1,0 +1,41 @@
+"""WaveKit VCD audit graceful-degradation.
+
+The WaveKit audit is supplementary on top of the cocotb regression result. If
+WaveKit can't be set up (no prebuilt wheel for the arch + missing build deps),
+the audit must SKIP gracefully rather than report ok=False -- otherwise a pure
+infrastructure problem masquerades as an integration_dv failure (DV_PROCESS_ERROR).
+"""
+import json
+import subprocess
+
+from orchestrator.langgraph import pipeline_helpers
+
+
+def test_wavekit_setup_failure_skips_not_fails(tmp_path, monkeypatch):
+    vcd = tmp_path / "dump.vcd"
+    vcd.write_text("$timescale 1ns $end\n")  # non-empty so we pass the size guard
+    audit = tmp_path / "wavekit_audit.json"
+
+    def boom(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0] if args else "cmd",
+                                            output="", stderr="Python.h: No such file")
+
+    # Force WaveKit setup to fail (no wheel, can't compile pylibfst).
+    monkeypatch.setattr(pipeline_helpers.subprocess, "run", boom)
+
+    result = pipeline_helpers.run_wavekit_vcd_audit(vcd, audit)
+
+    # Non-fatal: ok stays True (so callers don't fail DV), but clearly skipped.
+    assert result["ok"] is True
+    assert result["skipped"] is True
+    assert "WaveKit unavailable" in result["reason"]
+    # audit file is still written for forensics
+    assert json.loads(audit.read_text())["skipped"] is True
+
+
+def test_wavekit_missing_vcd_is_not_skipped(tmp_path):
+    # A genuinely missing/empty VCD is a real error (ok=False), not a skip.
+    audit = tmp_path / "wavekit_audit.json"
+    result = pipeline_helpers.run_wavekit_vcd_audit(tmp_path / "nope.vcd", audit)
+    assert result["ok"] is False
+    assert not result.get("skipped")


### PR DESCRIPTION
## Problem
The WaveKit VCD audit is a **supplementary** analysis layered on top of the cocotb regression result. But when WaveKit can't be set up, `run_wavekit_vcd_audit` returned `ok=False`, which the integration/validation DV nodes treated as a **failure** → a spurious **`DV_PROCESS_ERROR`** that masks the real verdict.

Seen on the 2026-05-31 nightly: a JPEG run's `integration_dv` reported `DV_PROCESS_ERROR` (conf 0.95) with *"No RTL-vs-golden divergence observed; the first failing event is the WaveKit venv cannot import pip"* — i.e. the chip's functional correctness was **never actually decided**, the audit infra just broke.

Root cause of the infra break: on **arm64** there's no prebuilt `pylibfst` wheel, so pip compiles from sdist, which needs `python3-dev` (Python.h) + `cmake` — missing on the OCI workers. (x86_64 Docker/Codespaces get a prebuilt wheel or have the dev headers, so they're unaffected — this was environment-specific, not systemic.)

## Fix
Make the WaveKit setup-failure path **skip gracefully**: return `{ok: True, skipped: True, reason: ...}` so DV is decided by the cocotb pass/fail, with the skip recorded in the audit JSON. The audit `subprocess.run` is not `check=True`, so this `except CalledProcessError` only ever catches WaveKit *setup* failures — never a genuine audit divergence — making the skip safe.

## Tests
`test_wavekit_audit.py`: (1) setup failure → `ok=True, skipped=True` (non-fatal); (2) a genuinely missing VCD is still a real `ok=False` error. Both pass.

Companion env note: to actually *run* WaveKit on a fresh non-x86_64 box, install `python3-dev` + `cmake` before `pip install wavekit` (done on the workers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)