### PR TITLE
fix(mem-characterize): time input->register paths and read real cycle time

### DIFF
--- a/orchestrator/langgraph/mem_characterize.py
+++ b/orchestrator/langgraph/mem_characterize.py
@@ -372,9 +372,17 @@ def _worst_path_delay_ns(netlist: str, top: str, liberty: str,
 
     The critical path for a flop memory is the combinational read mux
     (addr -> N:1 mux -> rdata), an input->output path; for a registered read it
-    is reg->reg / reg->out. To time BOTH path classes in one report we:
-      * define a slow real clock (so reg->reg never bounds the result), and
-      * ``set_max_delay`` on input->output paths (so the comb read mux IS timed).
+    is input->reg (addr -> N:1 mux -> output-flop D). To time ALL path classes
+    in one report we:
+      * define a slow real clock (so reg->reg never bounds the result),
+      * ``set_max_delay`` on input->output paths (so the comb read mux IS
+        timed), and
+      * ``set_input_delay`` on the data inputs, so input->REGISTER paths are
+        timed too. Without this the address decode of a *registered* read is
+        unconstrained and STA silently reports a reg->reg path that starts at a
+        memory-bit Q and skips the decode entirely -- which understates the
+        real delay by up to 6.4x (8x1024 registered: 2.62 ns reported vs
+        16.87 ns actual).
     ``report_checks -path_delay max`` then prints the single worst path's
     ``data arrival time`` = the worst delay through the design. Fmax = 1/delay.
 
@@ -390,9 +398,26 @@ def _worst_path_delay_ns(netlist: str, top: str, liberty: str,
         f"read_verilog {netlist}\n"
         f"link_design {top}\n"
         f"create_clock -name clk -period {big} [get_ports clk]\n"
+        # Constrain input->register paths too (a registered read mux ends at a
+        # flop D, not at a port). ``all_inputs -no_clocks`` excludes the clock;
+        # older OpenSTA lacks the flag, so fall back to the full input set -- a
+        # data delay on the clock port is inert there, since it drives only CLK
+        # pins and so starts no data path.
+        "if {[catch {set_input_delay 0 -clock clk "
+        "[all_inputs -no_clocks]}]} {\n"
+        "  set_input_delay 0 -clock clk [all_inputs]\n"
+        "}\n"
         f"set_max_delay {big} -from [all_inputs] -to [all_outputs]\n"
-        "report_checks -path_delay max -group_path_count 1 "
+        # -group_path_count is the modern spelling; older OpenSTA (e.g.
+        # OpenROAD v2.0-17598) only knows -group_count and errors with
+        # STA-0563, which would make this function return None for every
+        # geometry -- a silent total absence of timing data, not just an
+        # optimistic one.
+        "if {[catch {report_checks -path_delay max -group_path_count 1 "
+        "-fields {} -no_line_splits}]} {\n"
+        "  report_checks -path_delay max -group_count 1 "
         "-fields {} -no_line_splits\n"
+        "}\n"
         "exit\n"
     )
     with tempfile.NamedTemporaryFile("w", suffix=".tcl", delete=False) as fh:
@@ -442,27 +467,103 @@ def _lef_area_um2(lef_path: str) -> float | None:
     return float(m.group(1)) * float(m.group(2))
 
 
-def _lib_access_time_ns(lib_path: str) -> float | None:
-    """Worst clk->dout access time (ns) from the macro's .lib timing arcs.
+def _lib_time_scale_ns(text: str) -> float:
+    """Return the declared Liberty ``time_unit`` multiplier in nanoseconds."""
+    match = re.search(
+        r"\btime_unit\s*:\s*[\"']?([\d.]+)\s*(fs|ps|ns|us)[\"']?\s*;",
+        text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return 1.0
+    factors = {"fs": 1e-6, "ps": 1e-3, "ns": 1.0, "us": 1e3}
+    return float(match.group(1)) * factors[match.group(2).lower()]
 
-    Reads the largest ``cell_rise``/``cell_fall`` value among the data-out pin
-    arcs related to the clock (rising_edge/falling_edge). This is the real
-    registered-read access time the SRAM achieves -- typically ~0.3-0.6 ns,
-    vs the hundreds of ns a deep flop comb-read mux takes.
+
+def _lib_timing_blocks(text: str) -> list[str]:
+    """Extract balanced ``timing(...) { ... }`` blocks from Liberty text."""
+    blocks: list[str] = []
+    for match in re.finditer(r"\btiming\s*\([^)]*\)\s*\{", text):
+        start = match.start()
+        brace = text.find("{", match.start(), match.end())
+        depth = 0
+        for pos in range(brace, len(text)):
+            if text[pos] == "{":
+                depth += 1
+            elif text[pos] == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(text[start:pos + 1])
+                    break
+    return blocks
+
+
+def _lib_constraint_values(block: str, constraint: str = "") -> list[float]:
+    """Read numeric ``values(...)`` entries, optionally under one constraint."""
+    scope = block
+    if constraint:
+        match = re.search(
+            rf"\b{re.escape(constraint)}\s*\([^)]*\)\s*\{{(.*?)\}}",
+            block,
+            re.DOTALL | re.IGNORECASE,
+        )
+        if not match:
+            return []
+        scope = match.group(1)
+    values: list[float] = []
+    for match in re.finditer(r"\bvalues\s*\((.*?)\)", scope, re.DOTALL):
+        values.extend(float(token) for token in re.findall(
+            r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?",
+            match.group(1),
+        ))
+    return values
+
+
+def _lib_min_cycle_time_ns(lib_path: str) -> float | None:
+    """Return the limiting legal clock period (ns) from a macro Liberty.
+
+    Clock-to-output access latency is NOT a legal clock period. The previous
+    implementation took the file-wide max ``cell_rise``/``cell_fall`` and
+    treated it as one, which reported e.g. 1000/0.484 = 2066 MHz for
+    ``sky130_sram_1kbyte_1rw1r_32x256_8`` whose own ``minimum_period`` is
+    1.791 ns = 558 MHz -- a 3.70x over-claim, uniform across the family.
+
+    Use both the ``minimum_period`` constraint and the sum of the minimum
+    high/low pulse widths, scaled by the Liberty's declared ``time_unit``
+    (previously never parsed, so a lib in ps would have been off by 1000x).
+    Missing cycle evidence returns ``None`` so exact macros fail closed rather
+    than inheriting an invented frequency.
     """
     try:
         text = Path(lib_path).read_text(errors="ignore")
     except OSError:
         return None
-    # Pull all cell_rise/cell_fall value tuples in the file; the data-out arcs
-    # dominate the max. (Setup/hold are in separate constraint tables with
-    # rise_constraint/fall_constraint keys, so they don't pollute this.)
-    worst = 0.0
-    for m in re.finditer(r"cell_(?:rise|fall)\s*\([^)]*\)\s*\{\s*values\(([^)]*)\)",
-                         text, re.DOTALL):
-        for tok in re.findall(r"-?\d+\.\d+", m.group(1)):
-            worst = max(worst, abs(float(tok)))
-    return worst if worst > 0 else None
+
+    min_periods: list[float] = []
+    pulse_periods: list[float] = []
+    for block in _lib_timing_blocks(text):
+        timing_type = re.search(
+            r"\btiming_type\s*:\s*[\"']?([A-Za-z0-9_]+)",
+            block,
+            re.IGNORECASE,
+        )
+        if not timing_type:
+            continue
+        kind = timing_type.group(1).lower()
+        if kind == "minimum_period":
+            values = _lib_constraint_values(block)
+            if values:
+                min_periods.append(max(values))
+        elif kind == "min_pulse_width":
+            rise = _lib_constraint_values(block, "rise_constraint")
+            fall = _lib_constraint_values(block, "fall_constraint")
+            if rise and fall:
+                pulse_periods.append(max(rise) + max(fall))
+
+    candidates = min_periods + pulse_periods
+    if not candidates:
+        return None
+    return max(candidates) * _lib_time_scale_ns(text)
 
 
 def _resolve_macro(ports: str, width: int, depth: int) -> MemPoint:
@@ -503,24 +604,24 @@ def _resolve_macro(ports: str, width: int, depth: int) -> MemPoint:
         base = res.base
         tiles = res.tiles_wide * res.tiles_deep
         area = (_lef_area_um2(base.lef) or base.area_um2 or 0.0) * tiles
-        acc = _lib_access_time_ns(base.lib)
+        cyc = _lib_min_cycle_time_ns(base.lib)
         pt.macro_feasible = True
         pt.macro_impl = "compose"
         pt.area_um2 = area if area > 0 else None
-        if acc:
+        if cyc:
             # bank select mux adds ~one extra mux level; small penalty
-            pt.fmax_mhz = 1000.0 / (acc + 0.10)
+            pt.fmax_mhz = 1000.0 / (cyc + 0.10)
         pt.notes = res.describe()
         return pt
 
     if isinstance(res, MacroInfo):
         area = _lef_area_um2(res.lef) or res.area_um2 or None
-        acc = _lib_access_time_ns(res.lib)
+        cyc = _lib_min_cycle_time_ns(res.lib)
         pt.macro_feasible = True
         pt.macro_impl = "openram" if res.name.startswith("sram_") else "exact"
         pt.area_um2 = area
-        if acc:
-            pt.fmax_mhz = 1000.0 / acc
+        if cyc:
+            pt.fmax_mhz = 1000.0 / cyc
         pt.notes = f"macro {res.name} ({res.words}x{res.data_bits})"
         if pt.fmax_mhz is None:
             pt.error = "macro resolved but .lib access-time unreadable"

--- a/orchestrator/tests/test_mem_characterize.py
+++ b/orchestrator/tests/test_mem_characterize.py
@@ -61,16 +61,56 @@ class TestParsing:
         area = mc._lef_area_um2(str(lef))
         assert area and abs(area - 479.78 * 397.5) < 1e-3
 
-    def test_lib_access_time(self, tmp_path):
+    # A clk->dout access arc is NOT a legal clock period. These pin the
+    # replacement of _lib_access_time_ns (which returned 0.484 ns here, i.e.
+    # a claimed 2066 MHz) with the Liberty's own cycle-time constraints.
+
+    _MIN_PERIOD_LIB = (
+        'time_unit : "1ns" ;\n'
+        'pin(dout0){ timing(){ related_pin:"clk0";\n'
+        '  cell_rise(t){ values("0.339, 0.368, 0.484"); }\n'
+        '  cell_fall(t){ values("0.300, 0.300, 0.300"); } }\n'
+        '  timing(){ related_pin:"clk0"; timing_type :"minimum_period";\n'
+        '    rise_constraint(s){ values("1.791"); }\n'
+        '    fall_constraint(s){ values("1.791"); } } }\n'
+    )
+
+    def test_lib_min_cycle_time_prefers_minimum_period(self, tmp_path):
+        lib = tmp_path / "m.lib"
+        lib.write_text(self._MIN_PERIOD_LIB)
+        cyc = mc._lib_min_cycle_time_ns(str(lib))
+        # 1.791 ns => 558 MHz, NOT 1000/0.484 = 2066 MHz.
+        assert cyc and abs(cyc - 1.791) < 1e-6
+        assert 1000.0 / cyc < 600.0
+
+    def test_lib_min_cycle_time_falls_back_to_pulse_widths(self, tmp_path):
         lib = tmp_path / "m.lib"
         lib.write_text(
+            'time_unit : "1ns" ;\n'
             'pin(dout0){ timing(){ related_pin:"clk0";\n'
-            '  cell_rise(t){ values("0.339, 0.368, 0.484",\n'
-            '                       "0.339, 0.368, 0.484"); }\n'
-            '  cell_fall(t){ values("0.300, 0.300, 0.300"); } } }\n'
+            '  timing_type :"min_pulse_width";\n'
+            '    rise_constraint(s){ values("0.8955"); }\n'
+            '    fall_constraint(s){ values("0.8955"); } } }\n'
         )
-        acc = mc._lib_access_time_ns(str(lib))
-        assert acc and abs(acc - 0.484) < 1e-6
+        cyc = mc._lib_min_cycle_time_ns(str(lib))
+        assert cyc and abs(cyc - 1.791) < 1e-6
+
+    def test_lib_min_cycle_time_scales_by_time_unit(self, tmp_path):
+        """A lib declaring ps must not be read 1000x too fast."""
+        lib = tmp_path / "m.lib"
+        lib.write_text(self._MIN_PERIOD_LIB.replace('"1ns"', '"1ps"'))
+        cyc = mc._lib_min_cycle_time_ns(str(lib))
+        assert cyc and abs(cyc - 0.001791) < 1e-9
+
+    def test_lib_min_cycle_time_fails_closed(self, tmp_path):
+        """No cycle evidence -> None, never an invented frequency."""
+        lib = tmp_path / "m.lib"
+        lib.write_text(
+            'time_unit : "1ns" ;\n'
+            'pin(dout0){ timing(){ related_pin:"clk0";\n'
+            '  cell_rise(t){ values("0.484"); } } }\n'
+        )
+        assert mc._lib_min_cycle_time_ns(str(lib)) is None
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The memory characterization model reported frequencies the silicon cannot deliver. Those numbers feed forward to the uArch agent as evidence that memory is never the timing bottleneck, so designs were planned against a cycle budget that does not exist. This is a plausible contributor to designs systematically struggling to close at 50 MHz.

Three independent defects, all reproduced with real numbers on sky130.

### 1. `input -> register` paths were never timed

`_worst_path_delay_ns` built its SDC as:

```tcl
create_clock -name clk -period 100000 [get_ports clk]
set_max_delay 100000 -from [all_inputs] -to [all_outputs]
```

`set_max_delay ... -to [all_outputs]` constrains input->output only. For a **registered** read, the path is `addr -> decode fanout -> N:1 mux -> output-flop D` and ends at a register, so it was unconstrained. OpenSTA instead reported a reg->reg path starting at a memory-bit `Q`, skipping the address decode entirely.

Measured, same host, adding only `set_input_delay 0`:

| geometry (registered_flop) | before | after | optimism |
|---|---|---|---|
| 8x64   | 537.6 MHz | 495.3 MHz | 1.09x |
| 8x256  | 405.8 MHz | 223.6 MHz | 1.85x |
| 8x1024 | 381.8 MHz | **59.3 MHz** | **6.44x** |
| 32x256 | 405.8 MHz | **63.7 MHz** | **6.38x** |

The reported path for 8x256 was `_3238_/Q -> mux4_2 x4 -> mux2_1 -> _5286_/D` at 2.417 ns. The real worst path is `addr[1] (in) -> clkinv_1 (2.167 ns) -> ... -> _5291_/D` at 4.472 ns — that 2.167 ns inverter is the address net fanning out to 256 mux selects, exactly the depth-dependent term being dropped.

### 2. `-group_path_count` is rejected by older OpenSTA

OpenROAD v2.0-17598 errors with `[ERROR STA-0563]`, so `_worst_path_delay_ns` returned `None` for **every** point on affected hosts. Caches on such a host contained 0 of 14 flop rows with any Fmax at all — a silent total absence of data, not merely an optimistic one. Now retries with the older `-group_count` spelling.

### 3. A clock-to-Q access arc was treated as a legal clock period

`_lib_access_time_ns` took the file-wide max `cell_rise`/`cell_fall` and inverted it. For `sky130_sram_1kbyte_1rw1r_32x256_8` that is 0.484 ns, giving `1000/0.484` = **2066 MHz**. The same Liberty states its own `minimum_period` as 1.791 ns = **558 MHz** — a 3.70x over-claim, uniform across the macro family because `minimum_period = 2 x min_pulse_width`.

`minimum_period`, `min_pulse_width` and `time_unit` had **zero occurrences** anywhere in the engine. Replaced by `_lib_min_cycle_time_ns`, which reads the cycle-time constraints and scales by the declared `time_unit` — latent 1000x bug for any OpenRAM-generated Liberty in ps. Returns `None` when a lib carries no cycle evidence, so macros fail closed rather than inheriting an invented frequency.

## Result

Corrected sweep, 152 points:

| geometry | Fmax |
|---|---|
| 8x64 | 495.0 MHz |
| 8x256 | 223.7 MHz |
| 8x1024 | 59.3 MHz |
| 32x256 | 63.7 MHz |
| 8x2048 | 30.5 MHz |
| 8x4096 | 16.1 MHz |
| 32x1024 | 15.9 MHz |
| 64x1024 | 8.0 MHz |

Range 3.7-709.2 MHz. **43 of 76 registered-flop geometries cannot reach 50 MHz**, where the previous model reported 316-537 MHz across the entire space. The depth curve was effectively flat (538 -> 413 -> 382 MHz over depth 64/256/1024); it is actually steeply super-linear (495 -> 224 -> 59).

Practical consequence: past roughly 8x512, flop arrays are not viable at 50 MHz and storage must go to an SRAM macro. This gives the existing flop-vs-macro threshold real data behind it.

## Verification

- `orchestrator/tests/test_mem_characterize.py` — **38 passed**.
- The removed `test_lib_access_time` asserted the buggy behavior (0.484 ns). Replaced with four tests covering `minimum_period`, the pulse-width fallback, `time_unit` scaling, and fail-closed on missing evidence.
- `ruff check` clean on both files.

## Not included

Existing caches computed before this change are invalid and should be regenerated. Widening the sweep grid (currently 7 geometries, and `pdk_characterize.py` never extends an existing table) and replacing the out-of-grid constant clamp are left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)