### PR TITLE
fix(gen_ram): repair a CLI that could never generate, and stop overclaiming

### DIFF
--- a/bin/gen_ram
+++ b/bin/gen_ram
@@ -13,13 +13,24 @@ rediscover them.
 
 The pipeline is:
 
-    patch -> generate -> DRC -> LVS -> Liberty check -> emit
+    patch -> generate -> Liberty check -> emit
 
-and it **fails closed** at every stage: a missing artifact, an unparsed tool
-verdict, or a blank result is a FAILURE, never a pass. That posture is
-deliberate -- the defect that motivated this tool was a characterization run
-whose measurements silently went missing and were misread as "slow macro"
-rather than "no data".
+and it **fails closed**: a missing artifact, an unparsed verdict, or a blank
+result is a FAILURE, never a pass. That posture is deliberate -- the defect
+that motivated this tool was a characterization run whose measurements
+silently went missing and were misread as "slow macro" rather than "no data".
+
+**What this tool does NOT do.** ``openram_gen``'s generated config sets
+``check_lvs = False`` and never sets ``analytical_delay``, so OpenRAM reports
+"Characterization is disabled (using analytical delay models)" and "DRC/LVS/PEX
+is disabled". Therefore:
+
+* **No DRC and no LVS run during generation.** Those verdicts are reported as
+  ``not run`` (never as a pass) and must come from the backend flow.
+* **Liberty timing is an ANALYTICAL ESTIMATE, not a SPICE measurement.** This
+  is why generated macros report 600-700 MHz while the one macro that was
+  fully characterized end-to-end (``sram_1rw1r_16_128_8_sky130``) measures
+  227 MHz. Do not read a generated ``minimum_period`` as signoff timing.
 
 Usage
 -----
@@ -46,6 +57,8 @@ sys.path.insert(0, str(REPO_ROOT))
 # outside this window is not a plausible result -- it is a units or parse error.
 # Reference point: sram_1rw1r_16_128_8_sky130 characterizes at 4.4 ns (227 MHz),
 # while the stock 1kbyte/2kbyte macros sit at 1.79-1.96 ns (511-558 MHz).
+_SUPPORTED_PORTS = {"1rw", "1rw1r"}
+
 MIN_PLAUSIBLE_PERIOD_NS = 0.5
 MAX_PLAUSIBLE_PERIOD_NS = 200.0
 
@@ -119,19 +132,40 @@ def stage_patch(check_only: bool) -> tuple[bool, str]:
 
 def stage_generate(width: int, depth: int, ports: str, out: Path,
                    timeout: int) -> tuple[bool, str, dict]:
-    """Generate the macro through the engine's own OpenRAM path."""
+    """Generate the macro through the engine's own OpenRAM path.
+
+    ``ensure_macro``'s signature is ``(words, data_bits, *, ...)`` -- DEPTH
+    first, then WIDTH, and everything after them keyword-only. The original
+    call here passed ``(ports, width, depth)``: three positionals into a
+    two-positional function, in the wrong order, with a string where an int
+    belongs. It raised TypeError on every invocation, so this tool could never
+    generate anything.
+    """
     try:
         from orchestrator.langgraph.openram_gen import ensure_macro
     except ImportError as exc:
         return False, f"cannot import openram_gen: {exc}", {}
+    if ports not in _SUPPORTED_PORTS:
+        return False, (
+            f"unsupported --ports {ports!r}; ensure_macro generates "
+            f"{'/'.join(sorted(_SUPPORTED_PORTS))} geometries"
+        ), {}
     try:
-        res = ensure_macro(ports, width, depth)
+        res = ensure_macro(depth, width)  # (words, data_bits)
     except Exception as exc:  # noqa: BLE001
-        return False, f"ensure_macro raised: {exc}", {}
+        return False, f"ensure_macro raised: {type(exc).__name__}: {exc}", {}
     if res is None:
-        return False, f"no macro resolved for {ports} {width}x{depth}", {}
-    info = {"resolved": type(res).__name__, "detail": str(res)[:400]}
-    return True, f"resolved {ports} {width}x{depth}", info
+        return False, (
+            f"no macro resolved for {ports} {width}x{depth} -- no exact "
+            "pre-built part and OpenRAM generation did not produce one"
+        ), {}
+    info = {
+        "resolved": type(res).__name__,
+        "name": getattr(res, "name", ""),
+        "lib": str(getattr(res, "lib", "") or ""),
+        "detail": str(res)[:400],
+    }
+    return True, f"resolved {ports} {width}x{depth} -> {info['name'] or res}", info
 
 
 # ---------------------------------------------------------------------------
@@ -255,6 +289,31 @@ def main(argv: list[str] | None = None) -> int:
                                       args.out, args.timeout)
     report["stages"]["generate"] = {"ok": ok, "detail": detail, **info}
     _log(f"[generate] {detail}")
+    if ok:
+        # Liberty check. This is the ONLY downstream gate gen_ram can honestly
+        # run today: openram_gen's config sets `check_lvs = False` and never
+        # sets `analytical_delay`, so OpenRAM logs "Characterization is
+        # disabled (using analytical delay models)" and "DRC/LVS/PEX is
+        # disabled". The minimum_period below is therefore an ANALYTICAL MODEL
+        # ESTIMATE, not a SPICE measurement -- which is why generated macros
+        # report 600-700 MHz while the one macro that WAS fully characterized
+        # (sram_1rw1r_16_128_8_sky130) measures 227 MHz. Do not read these as
+        # signoff timing.
+        lok, ldetail, cyc = check_liberty(Path(info.get("lib") or ""))
+        report["stages"]["liberty"] = {
+            "ok": lok, "detail": ldetail, "min_period_ns": cyc,
+            "characterized": False,
+            "note": "analytical delay model, NOT SPICE-characterized",
+        }
+        _log(f"[liberty] {ldetail} (analytical model, not characterized)")
+        if not lok:
+            ok, detail = False, f"liberty check failed: {ldetail}"
+        report["stages"]["drc"] = {"ok": None, "detail": "not run by OpenRAM "
+                                   "(check_lvs=False); use the backend DRC flow"}
+        report["stages"]["lvs"] = {"ok": None, "detail": "not run by OpenRAM "
+                                   "(check_lvs=False); use the backend LVS flow"}
+        _log("[drc] not run -- OpenRAM generation has DRC/LVS disabled")
+        _log("[lvs] not run -- OpenRAM generation has DRC/LVS disabled")
     if not ok:
         report["verdict"] = "FAIL"
         _emit(report, args.out)

--- a/orchestrator/langgraph/openram_gen.py
+++ b/orchestrator/langgraph/openram_gen.py
@@ -223,8 +223,17 @@ def openram_available() -> bool:
     the real invocation path (cached; OPENRAM_HOME's sram_compiler.py counts).
     """
     global _OPENRAM_RUNNABLE
-    if os.environ.get("OPENRAM_HOME"):
-        return bool(Path(os.environ["OPENRAM_HOME"], "sram_compiler.py").exists())
+    # OPENRAM_HOME means "a source checkout with sram_compiler.py at its root".
+    # It is NOT safe to trust the env var alone: importing the pip package
+    # EXPORTS ``OPENRAM_HOME=<site-packages>/openram/compiler`` into os.environ,
+    # which has no sram_compiler.py -- so once anything imported openram (the
+    # patcher does, on every gen_ram invocation) this probe returned a false
+    # NEGATIVE and generation became unreachable. Only honor the var when it
+    # actually looks like a checkout; otherwise fall through to the real
+    # `python -m openram` invocation check below.
+    _home = os.environ.get("OPENRAM_HOME")
+    if _home and Path(_home, "sram_compiler.py").exists():
+        return True
     if _OPENRAM_RUNNABLE is not None:
         return _OPENRAM_RUNNABLE
     try:

--- a/orchestrator/tests/test_gen_ram_cli.py
+++ b/orchestrator/tests/test_gen_ram_cli.py
@@ -1,0 +1,132 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression tests for ``bin/gen_ram``.
+
+The CLI shipped with a call that could never succeed:
+``ensure_macro(ports, width, depth)`` against a
+``ensure_macro(words, data_bits, *, ...)`` signature -- three positionals into
+a two-positional function, in the wrong order, with a string where an int
+belongs. It raised TypeError on every invocation and nothing caught it, because
+nothing imported the module under test. These tests exist so that cannot recur.
+"""
+from __future__ import annotations
+
+import importlib.util
+import inspect
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GEN_RAM = REPO_ROOT / "bin" / "gen_ram"
+
+
+def _load():
+    spec = importlib.util.spec_from_loader(
+        "gen_ram_cli",
+        importlib.machinery.SourceFileLoader("gen_ram_cli", str(GEN_RAM)),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def gen_ram():
+    return _load()
+
+
+class TestCallSignature:
+    def test_module_imports(self, gen_ram):
+        assert hasattr(gen_ram, "stage_generate")
+
+    def test_stage_generate_calls_ensure_macro_correctly(self, gen_ram, monkeypatch):
+        """(words, data_bits) positionally -- depth first, then width."""
+        seen = {}
+
+        def fake_ensure_macro(words, data_bits, **kw):
+            seen["words"] = words
+            seen["data_bits"] = data_bits
+            seen["kw"] = kw
+            return type("M", (), {"name": "fake_macro", "lib": "/tmp/fake.lib"})()
+
+        import orchestrator.langgraph.openram_gen as og
+        monkeypatch.setattr(og, "ensure_macro", fake_ensure_macro)
+
+        ok, detail, info = gen_ram.stage_generate(
+            width=16, depth=128, ports="1rw1r", out=Path("/tmp"), timeout=60
+        )
+        assert ok, detail
+        # depth -> words, width -> data_bits. Getting these backwards silently
+        # generates a transposed macro, which is worse than a crash.
+        assert seen["words"] == 128, "depth must map to words"
+        assert seen["data_bits"] == 16, "width must map to data_bits"
+        assert info["name"] == "fake_macro"
+
+    def test_signature_is_actually_two_positionals(self):
+        """Pin the contract this CLI depends on."""
+        from orchestrator.langgraph.openram_gen import ensure_macro
+
+        params = list(inspect.signature(ensure_macro).parameters.values())
+        positional = [
+            p for p in params
+            if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        ]
+        assert [p.name for p in positional] == ["words", "data_bits"]
+
+    def test_bad_ports_rejected_not_crashed(self, gen_ram):
+        ok, detail, _ = gen_ram.stage_generate(
+            width=16, depth=128, ports="7rw", out=Path("/tmp"), timeout=60
+        )
+        assert not ok and "unsupported" in detail.lower()
+
+    def test_ensure_macro_exception_is_reported_not_raised(self, gen_ram, monkeypatch):
+        import orchestrator.langgraph.openram_gen as og
+
+        def boom(*a, **k):
+            raise TypeError("simulated bad call")
+
+        monkeypatch.setattr(og, "ensure_macro", boom)
+        ok, detail, _ = gen_ram.stage_generate(
+            width=16, depth=128, ports="1rw1r", out=Path("/tmp"), timeout=60
+        )
+        assert not ok and "TypeError" in detail
+
+
+class TestHonestVerdicts:
+    def test_parse_drc_returns_none_when_no_verdict(self, gen_ram):
+        """None is NOT zero -- an unparsed DRC log must never read as clean."""
+        assert gen_ram.parse_drc("nothing useful here") is None
+        assert gen_ram.parse_drc("MAGIC_DRC_ERRORS = 0") == 0
+        assert gen_ram.parse_drc("Total DRC errors found: 7") == 7
+
+    def test_parse_lvs_returns_none_when_no_verdict(self, gen_ram):
+        assert gen_ram.parse_lvs("no verdict") is None
+        assert gen_ram.parse_lvs("Circuits match uniquely") is True
+        assert gen_ram.parse_lvs("Circuits do not match") is False
+
+    def test_liberty_missing_file_fails(self, gen_ram):
+        ok, detail, cyc = gen_ram.check_liberty(Path("/nonexistent/x.lib"))
+        assert not ok and cyc is None
+
+
+class TestOpenramAvailability:
+    def test_package_exported_openram_home_is_not_trusted(self, monkeypatch, tmp_path):
+        """Importing openram exports OPENRAM_HOME=<pkg>/compiler, which has no
+        sram_compiler.py. Treating that as a source checkout made the probe
+        return a false NEGATIVE and left generation unreachable."""
+        import orchestrator.langgraph.openram_gen as og
+
+        monkeypatch.setenv("OPENRAM_HOME", str(tmp_path))  # no sram_compiler.py
+        monkeypatch.setattr(og, "_OPENRAM_RUNNABLE", False)
+        # Must fall through to the real check rather than short-circuiting True.
+        assert og.openram_available() is False
+
+    def test_real_checkout_openram_home_is_honored(self, monkeypatch, tmp_path):
+        import orchestrator.langgraph.openram_gen as og
+
+        (tmp_path / "sram_compiler.py").write_text("# real checkout\n")
+        monkeypatch.setenv("OPENRAM_HOME", str(tmp_path))
+        assert og.openram_available() is True


### PR DESCRIPTION
Found by the first real attempt to *use* `bin/gen_ram` on a design — regenerating raster's two non-stock macros (`32x64`, `9x512`). All three defects are in merged `main` (#69).

## 1. The CLI could never generate anything

```python
res = ensure_macro(ports, width, depth)          # bin/gen_ram:128
def ensure_macro(words, data_bits, *, ...)       # the actual signature
```

Three positionals into a two-positional function, in the wrong order, with a string where an int belongs. **`TypeError` on every invocation.** Nothing caught it because no test imported the module.

Fixed to `ensure_macro(depth, width)` — depth→words, width→data_bits.

## 2. The fail-closed checks were dead code

`parse_drc`, `parse_lvs` and `check_liberty` were defined and never called. `main()` went generate → PASS. The fail-closed posture the docstring advertised did not exist at runtime.

`check_liberty` is now wired in, and DRC/LVS report `not run` — explicitly, never as a pass.

## 3. `openram_available()` returned a false negative

It short-circuited on any non-empty `OPENRAM_HOME`:

```python
if os.environ.get("OPENRAM_HOME"):
    return bool(Path(os.environ["OPENRAM_HOME"], "sram_compiler.py").exists())
```

But importing the pip package **exports** `OPENRAM_HOME=<site-packages>/openram/compiler`, which contains no `sram_compiler.py`. Verified:

```
before import: None
after  import: .../site-packages/openram/compiler
```

`gen_ram` imports openram (via the patcher) before probing, so the probe reported OpenRAM unavailable and generation became unreachable.

**This is the one that matters most right now.** With #70 (tiling disabled) this escalates *every* non-stock geometry — the tiling fallback previously masked it. The env var is now honored only when the path actually looks like a source checkout.

## And a correction to what the tool claims

`openram_gen._write_config` sets `check_lvs = False` and never sets `analytical_delay`. OpenRAM's own log says the consequence:

```
Characterization is disabled (using analytical delay models)
DRC/LVS/PEX is disabled (check_lvsdrc=True to enable)
```

So the advertised `patch -> generate -> DRC -> LVS -> Liberty` pipeline **never ran DRC or LVS**, and a generated `minimum_period` is an **analytical model estimate, not a SPICE measurement**.

That is the actual explanation for a discrepancy flagged earlier as suspect stale libraries: generated macros report 600–700 MHz because the number is modelled, while the one macro characterized end-to-end (`sram_1rw1r_16_128_8_sky130`) measures **227 MHz**. Not stale files — never measured.

The docstring now states both plainly, the Liberty stage is labelled `characterized: false`, and DRC/LVS are reported `not run`.

**Deliberately not changed here:** enabling `check_lvsdrc` / real characterization. That is a behaviour change with a large runtime cost and belongs in its own PR with its own measurements. This PR makes the tool honest about what it does; a follow-up can make it do more.

## Verification

- New `orchestrator/tests/test_gen_ram_cli.py`, **10 tests**: imports the CLI (which nothing previously did), pins the `ensure_macro` signature contract, and asserts depth→words / width→data_bits so a **transposed** macro cannot be generated silently — a subtler failure than the crash, since it would produce a real but wrong-shaped macro.
- Both `OPENRAM_HOME` directions covered: package-exported path rejected, real checkout honored.
- **77 passed** across `test_gen_ram_cli`, `test_patch_openram`, `test_macro_backend`, `test_macro_pin_short_guard`. `ruff` clean.

## Suggested merge order

Before or with #70. #70 removes the tiling fallback that was masking defect 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)