### PR TITLE
fix(pipeline): a block's name is not always its Verilog module name

### DIFF
--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -1615,14 +1615,64 @@ async def generate_rtl(
     return result
 
 
+def rtl_module_name(rtl_path: str | Path, block_name: str) -> str:
+    """Resolve the Verilog module name to drive for ``block_name``.
+
+    **A block's architectural name is not always its RTL module name.** When a
+    module name is fixed by an external contract -- a Caravel
+    ``user_project_wrapper``, a vendor-locked top, a pad ring -- the
+    architecture keeps its own block identifier while ``rtl_target`` carries
+    the mandated name. Every ordinary block has
+    ``rtl_target == <...>/<block_name>.v``, so the two coincide and this
+    returns ``block_name`` unchanged.
+
+    Resolution is evidence-based: whichever candidate the file actually
+    declares wins. Preferring ``block_name`` keeps existing behaviour intact
+    for every normal block; falling back to the ``rtl_target`` stem is safe
+    because that path comes from the block spec, which the engine controls --
+    an agent cannot use it to smuggle in an arbitrarily-named module.
+
+    Conflating the two caused a correct, lint-clean block to fail twice in one
+    run: first the RTL-generation postcondition rejected it, then the cocotb
+    Makefile set ``TOPLEVEL`` to the block name and Verilator's
+    ``--top-module`` found no such module, so simulation never elaborated and
+    produced no VCD -- reported as a simulation failure rather than a
+    configuration error.
+    """
+    p = Path(rtl_path)
+    try:
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return block_name
+    if f"module {block_name}" in text:
+        return block_name
+    if p.stem != block_name and f"module {p.stem}" in text:
+        return p.stem
+    return block_name
+
+
 def _assert_rtl_materialized(rtl_path: Path, block_name: str) -> str | None:
-    """Return None if rtl_path contains a real `module <block_name>` Verilog
-    file; otherwise return a one-line diagnostic explaining what's wrong.
+    """Return None if rtl_path contains a real Verilog module; otherwise
+    return a one-line diagnostic explaining what's wrong.
 
     Three checks: file exists; file is non-trivially-sized (manylinux empty
     file is 0 bytes, an `include "<path>"` redirect stub is typically
-    < 200 bytes); file contains `module <block_name>` literal so we know
-    the LLM didn't write the wrong module or a placeholder.
+    < 200 bytes); and the file declares a module whose name is one we expect,
+    so we know the LLM didn't write the wrong block's RTL or a placeholder.
+
+    **An architectural block name is not always its Verilog module name.** A
+    block whose RTL module name is fixed by an external contract -- a Caravel
+    ``user_project_wrapper``, a vendor-locked top, a pad ring -- is declared in
+    the architecture with its own block name while ``rtl_target`` carries the
+    mandated file/module name. Requiring ``module <block_name>`` rejected such
+    a block even though its RTL was correct and lint-clean, stopping the flow
+    before testbench generation.
+
+    So the expected name is ``block_name`` OR the stem of ``rtl_target``. That
+    keeps the check strong: ``rtl_target`` comes from the block spec, which the
+    engine controls, not from the agent -- so this cannot be used to smuggle in
+    an arbitrarily-named module. Every ordinary block has
+    ``rtl_target == <...>/<block_name>.v``, making the two identical.
     """
     if not rtl_path.exists():
         return (
@@ -1641,12 +1691,16 @@ def _assert_rtl_materialized(rtl_path: Path, block_name: str) -> str | None:
         text = rtl_path.read_text(encoding="utf-8")
     except OSError as e:
         return f"{rtl_path}: read failed ({e})"
-    if f"module {block_name}" not in text:
+    expected = {block_name, rtl_path.stem}  # see rtl_module_name()
+    if not any(f"module {name}" in text for name in expected):
+        want = "` or `module ".join(sorted(expected))
         return (
-            f"{rtl_path} ({size} bytes) does not contain `module "
-            f"{block_name}`. The agent likely wrote the wrong module name "
-            f"or a different block's RTL. The module declaration must use "
-            f"exactly the block name."
+            f"{rtl_path} ({size} bytes) does not contain `module {want}`. "
+            f"The agent likely wrote the wrong module name or a different "
+            f"block's RTL. The module declaration must use either the block "
+            f"name ({block_name}) or the rtl_target file stem "
+            f"({rtl_path.stem}) when the module name is fixed by an external "
+            f"contract."
         )
     return None
 
@@ -1679,7 +1733,8 @@ def lint_rtl(rtl_path: str, block_name: str, attempt: int = 1) -> dict:
             wrapper_lib_path as _wrapper_lib_path,
         )
         if _uses_wrapper(rtl_text):
-            cmd += ["--top-module", block_name, _wrapper_lib_path()]
+            cmd += ["--top-module", rtl_module_name(rtl_path, block_name),
+                    _wrapper_lib_path()]
     except Exception:
         pass
     cmd.append(rtl_path)
@@ -2214,11 +2269,18 @@ def run_simulation(block: dict, rtl_path: str, tb_path: str, attempt: int = 1,
         if _an:
             _def_line += f"EXTRA_ARGS += {_an}\n"
 
+    # TOPLEVEL must be the module Verilator will find with --top-module, which
+    # is not always the architectural block name (locked Caravel/vendor tops).
+    _toplevel = rtl_module_name(rtl_path, block_name)
+    if _toplevel != block_name:
+        log(f"  [SIM] TOPLEVEL={_toplevel} (block {block_name} declares an "
+            f"externally-mandated module name)", CYAN)
+
     makefile_content = f"""
 SIM = verilator
 TOPLEVEL_LANG = verilog
 VERILOG_SOURCES = {_verilog_sources}
-TOPLEVEL = {block_name}
+TOPLEVEL = {_toplevel}
 MODULE = test_{block_name}
 WAVES = 1
 EXTRA_ARGS += --trace --trace-structs

--- a/orchestrator/tests/test_rtl_postcondition.py
+++ b/orchestrator/tests/test_rtl_postcondition.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the RTL-generation postcondition.
+
+Regression: the check required a literal ``module <block_name>``, which
+rejected a correct, lint-clean block whose Verilog module name is fixed by an
+external contract. A Caravel harness mandates ``module user_project_wrapper``;
+the architecture names that block ``user_project_wrapper_io`` and encodes the
+mandated name in ``rtl_target``. The block was failed with "the agent likely
+wrote the wrong module name" and the flow stopped before testbench generation.
+"""
+from __future__ import annotations
+
+from orchestrator.langgraph.pipeline_helpers import _assert_rtl_materialized
+
+BODY = "\n".join(f"  wire w{i};" for i in range(60))  # push past the 200-byte floor
+
+
+def _write(tmp_path, filename: str, module: str):
+    p = tmp_path / filename
+    p.write_text(f"// generated\nmodule {module} (\n  input clk\n);\n{BODY}\nendmodule\n")
+    return p
+
+
+class TestModuleNameMatching:
+    def test_ordinary_block_matches_block_name(self, tmp_path):
+        p = _write(tmp_path, "qspi_cdc_frontend.v", "qspi_cdc_frontend")
+        assert _assert_rtl_materialized(p, "qspi_cdc_frontend") is None
+
+    def test_externally_mandated_module_name_is_accepted(self, tmp_path):
+        """The regression: block name != module name, and that is legitimate."""
+        p = _write(tmp_path, "user_project_wrapper.v", "user_project_wrapper")
+        assert _assert_rtl_materialized(p, "user_project_wrapper_io") is None
+
+    def test_wrong_block_rtl_still_rejected(self, tmp_path):
+        """The check must still catch a different block's RTL."""
+        p = _write(tmp_path, "zbuffer_sram.v", "framebuffer_sram")
+        err = _assert_rtl_materialized(p, "zbuffer_sram")
+        assert err is not None and "does not contain" in err
+
+    def test_error_names_both_acceptable_forms(self, tmp_path):
+        p = _write(tmp_path, "user_project_wrapper.v", "something_else")
+        err = _assert_rtl_materialized(p, "user_project_wrapper_io")
+        assert err is not None
+        assert "user_project_wrapper_io" in err and "user_project_wrapper" in err
+
+
+class TestOtherPostconditions:
+    def test_missing_file(self, tmp_path):
+        err = _assert_rtl_materialized(tmp_path / "nope.v", "nope")
+        assert err is not None and "did not write" in err
+
+    def test_stub_too_small(self, tmp_path):
+        p = tmp_path / "stub.v"
+        p.write_text('`include "elsewhere.v"\n')
+        err = _assert_rtl_materialized(p, "stub")
+        assert err is not None and "bytes" in err
+
+    def test_empty_file(self, tmp_path):
+        p = tmp_path / "empty.v"
+        p.write_text("")
+        err = _assert_rtl_materialized(p, "empty")
+        assert err is not None
+
+
+class TestRtlModuleNameResolver:
+    """The resolver behind TOPLEVEL, --top-module and the postcondition."""
+
+    def test_ordinary_block_returns_block_name(self, tmp_path):
+        from orchestrator.langgraph.pipeline_helpers import rtl_module_name
+        p = _write(tmp_path, "zbuffer_sram.v", "zbuffer_sram")
+        assert rtl_module_name(p, "zbuffer_sram") == "zbuffer_sram"
+
+    def test_locked_top_returns_file_stem(self, tmp_path):
+        """The regression: TOPLEVEL must be the module Verilator can find."""
+        from orchestrator.langgraph.pipeline_helpers import rtl_module_name
+        p = _write(tmp_path, "user_project_wrapper.v", "user_project_wrapper")
+        assert rtl_module_name(p, "user_project_wrapper_io") == "user_project_wrapper"
+
+    def test_block_name_wins_when_both_declared(self, tmp_path):
+        """Prefer the block name so normal blocks are unaffected."""
+        from orchestrator.langgraph.pipeline_helpers import rtl_module_name
+        p = tmp_path / "top.v"
+        p.write_text(f"module blk (input clk);\n{BODY}\nendmodule\n"
+                     f"module top (input clk);\n{BODY}\nendmodule\n")
+        assert rtl_module_name(p, "blk") == "blk"
+
+    def test_missing_file_falls_back_to_block_name(self, tmp_path):
+        from orchestrator.langgraph.pipeline_helpers import rtl_module_name
+        assert rtl_module_name(tmp_path / "nope.v", "blk") == "blk"
+
+    def test_neither_declared_falls_back(self, tmp_path):
+        """Postcondition is the gate for this case, not the resolver."""
+        from orchestrator.langgraph.pipeline_helpers import rtl_module_name
+        p = _write(tmp_path, "a.v", "totally_other")
+        assert rtl_module_name(p, "blk") == "blk"


### PR DESCRIPTION
Found by a live Raster run, where it failed the **same correct block twice** at two different stages.

## The assumption

A block whose RTL module name is fixed by an external contract — a Caravel `user_project_wrapper`, a vendor-locked top, a pad ring — is declared in the architecture under its own block identifier, while `rtl_target` carries the mandated name:

```
user_project_wrapper_io    rtl_target=rtl/user_project_wrapper.v     <-- differs
qspi_cdc_frontend          rtl_target=rtl/io_subsystem/qspi_cdc_frontend.v
triangle_store             rtl_target=rtl/memory_subsystem/triangle_store.v
...
```

Every ordinary block has `rtl_target == <...>/<block_name>.v`. Exactly one didn't, and three code paths assumed it always would.

## Failure 1 — RTL rejected as wrong

`_assert_rtl_materialized` required a literal `module <block_name>` and failed the block with *"The agent likely wrote the wrong module name."* The engine's own diagnosis disagreed, at confidence 0.99:

> line 34 correctly declares `module user_project_wrapper` … The uArch Sections 1 and 9, the ERS, and the block diagram all explicitly require the locked Caravel top name … **the orchestration code incorrectly assumes that every block identifier is also its Verilog module identifier.**

Verilator lint had returned 0. The flow stopped before testbench generation.

## Failure 2 — the same bug, one stage later

With the postcondition fixed the block reached simulation, where the generated cocotb Makefile set `TOPLEVEL = user_project_wrapper_io`. Verilator's `--top-module` found no such module, **elaboration never happened, and no VCD was produced**.

That surfaced as a **simulation failure** — with no divergent signal to point at, because time 0 was never reached. A configuration error wearing the costume of a hardware bug. The diagnosis again:

> No RTL signal diverged because simulation never elaborated and never reached time 0. … The same infrastructure category occurred in both prior attempts, showing that the flow still conflates block identity with executable RTL module identity.

Third site: Verilator lint passes `--top-module <block_name>` on the wrapper path.

## The fix

`rtl_module_name(rtl_path, block_name)`, used by all three sites. Resolution is **evidence-based** — whichever candidate the file actually declares wins:

1. `block_name` if the file declares it (every ordinary block, so behaviour is byte-identical)
2. else the `rtl_target` stem if the file declares that
3. else `block_name`, leaving the postcondition to report the real problem

Preferring `block_name` means no normal block changes. Falling back to the stem is safe because `rtl_target` comes from the **block spec, which the engine controls** — an agent cannot use it to smuggle in an arbitrarily-named module. The postcondition still rejects a stub, an empty file, and a different block's RTL.

The integration path already solved this the same way and documents it in a comment (*"A filename-derived TOPLEVEL always selects the first/file-stem wrapper"*). This brings the per-block path in line rather than inventing a new convention.

## Verification

**12 tests** in `orchestrator/tests/test_rtl_postcondition.py`, `ruff` clean:

- ordinary block resolves to its block name; the locked top resolves to the file stem
- **a different block's RTL is still rejected** — the check keeps its teeth
- block name wins when both are declared, so normal blocks are unaffected
- missing file / stub / empty postconditions unchanged
- the error message now names both acceptable forms instead of only the block name

Applied to the live run: the block cleared RTL generation and lint on the next attempt.

## Worth a look separately

While diagnosing this, `/run/state` reported `pending_interrupt_count: 0` and `interrupts: []` while the graph sat on `[HUMAN] Intervention needed` — and `POST /run/resume` then returned `{"resumed": true, "interrupts": 1}`. An outer agent polling state concludes nothing needs doing, and the run parks indefinitely. Not fixed here, but it is why this cost ~70 minutes to notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)