### PR TITLE
feat(gate-sim): judge the FLAT CHIP NETLIST, not a per-block one

### DIFF
--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -104,6 +104,11 @@ class BackendState(TypedDict):
     glue_blocks: list[dict]              # detected glue block needs
     integration_top_path: str            # rtl/integration/<design>_top.v
     flat_netlist_path: str               # syn/output/<design>/<design>_netlist.v
+    # chip_top gate-sim: the flat netlist replayed against the integration-DV
+    # vectors. None = did not apply (recorded with a reason, never silent).
+    chip_gate_sim_ok: bool | None
+    chip_gate_sim_status: str
+    chip_gate_sim_reason: str
     flat_sdc_path: str                   # syn/output/<design>/<design>.sdc
     synth_gate_count: int
     synth_area_um2: float
@@ -529,6 +534,76 @@ def _format_constraints(state: BackendState) -> str:
 # Node: flat_top_synthesis  (LLM-driven Yosys synthesis)
 # ---------------------------------------------------------------------------
 
+def _run_chip_top_gate_sim(state: "BackendState", netlist: str) -> tuple:
+    """Replay the integration-DV vectors through the FLAT CHIP NETLIST.
+
+    This is the artifact that becomes silicon. Every functional gate upstream
+    reads RTL; every PPA gate reads a netlist; until now nothing simulated the
+    flat top. A per-block gate-sim cannot close that: a block netlist is an
+    intermediate, and its stimulus is that block's own testbench rather than
+    real chip traffic.
+
+    Runs here -- after ``flat_top_synthesis``, before ``run_pnr`` -- because
+    this is the first point a flat chip netlist exists, and there is no reason
+    to spend P&R on a netlist that does not reproduce the verified RTL.
+
+    Returns ``(ok, status, reason)``. ``None`` ok means the gate did not apply
+    (disabled, no integration testbench, toolchain absent) and is ALWAYS
+    recorded with a reason, so absence never reads as success. Never raises:
+    gate plumbing must not crash the backend.
+    """
+    from orchestrator.harness import gate_sim as _gs
+
+    design = state.get("design_name", "chip_top")
+    root = Path(state.get("project_root", "."))
+
+    if not _gs.gate_sim_enabled():
+        log(f"  [CHIP-GATE-SIM] not run -- {_gs.GATE_SIM_ENV}=0. The FLAT CHIP "
+            f"NETLIST is never simulated; a synthesis-side divergence in the "
+            f"assembled design cannot be caught.", YELLOW)
+        return (None, _gs.STATUS_DISABLED, f"{_gs.GATE_SIM_ENV}=0")
+
+    # Integration DV is the reference stimulus: real traffic through the
+    # assembled chip, and the run that already matched the golden.
+    tb = ""
+    for cand in (root / "sim_build" / "integration" / f"test_{design}.py",
+                 root / "tb" / "integration" / f"test_{design}.py"):
+        if cand.is_file():
+            tb = str(cand)
+            break
+    if not tb:
+        reason = ("no integration-DV testbench found -- chip_top gate-sim needs "
+                  "the integration vectors as its reference stimulus")
+        log(f"  [CHIP-GATE-SIM] not run -- {reason}", YELLOW)
+        return (None, _gs.STATUS_NOT_RUN, reason)
+
+    top_rtl = state.get("top_rtl_path", "") or ""
+    log("  [CHIP-GATE-SIM] Replaying integration-DV vectors through the FLAT "
+        "chip netlist...", YELLOW)
+    try:
+        res = _gs.check_gate_sim(
+            block={"name": design, "is_chip_top": True},
+            netlist_path=netlist,
+            rtl_path=top_rtl,
+            tb_path=tb,
+        )
+    except Exception as exc:  # noqa: BLE001 - never crash the backend
+        reason = f"chip_top gate-sim plumbing error: {type(exc).__name__}: {exc}"
+        log(f"  [CHIP-GATE-SIM] {reason}", RED)
+        return (None, _gs.STATUS_NOT_RUN, reason)
+
+    if res.status == _gs.STATUS_PASS:
+        log(f"  [CHIP-GATE-SIM] PASS -- flat netlist reproduced the verified "
+            f"chip RTL ({res.cycles_compared} cycles, "
+            f"{res.output_bits_compared} output bits)", GREEN)
+        return (True, res.status, res.reason)
+    if res.status == _gs.STATUS_FAIL:
+        log(f"  [CHIP-GATE-SIM] FAIL -- {res.reason}", RED)
+        return (False, res.status, res.reason)
+    log(f"  [CHIP-GATE-SIM] not run -- {res.reason}", YELLOW)
+    return (None, res.status, res.reason)
+
+
 async def flat_top_synthesis_node(state: BackendState) -> dict:
     """Run Yosys synthesis entirely within the inner Claude LLM.
 
@@ -686,6 +761,7 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
                 "flat_netlist_path": "",
                 "flat_sdc_path": "",
             }
+        _gs_ok, _gs_status, _gs_reason = _run_chip_top_gate_sim(state, _netlist)
         return {
             "phase": "synth",
             "flat_netlist_path": _netlist,
@@ -693,6 +769,9 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
             "synth_gate_count": result.get("gate_count", 0),
             "synth_area_um2": result.get("area_um2", 0.0),
             "macro_bindings": _bindings,
+            "chip_gate_sim_ok": _gs_ok,
+            "chip_gate_sim_status": _gs_status,
+            "chip_gate_sim_reason": _gs_reason,
         }
     else:
         return {

--- a/orchestrator/tests/test_chip_top_gate_sim.py
+++ b/orchestrator/tests/test_chip_top_gate_sim.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""chip_top gate-sim: replay integration-DV vectors through the FLAT netlist.
+
+The flat chip netlist is the artifact that becomes silicon. Every functional
+gate upstream reads RTL and every PPA gate reads a netlist, so nothing
+simulated the assembled top. A per-block gate-sim cannot close that gap: a
+block netlist is an intermediate, and its stimulus is that block's own
+testbench rather than real chip traffic.
+"""
+from __future__ import annotations
+
+import orchestrator.harness.gate_sim as gs
+import pytest
+from orchestrator.langgraph.backend_graph import _run_chip_top_gate_sim
+
+
+@pytest.fixture()
+def run_dir(tmp_path):
+    (tmp_path / "sim_build" / "integration").mkdir(parents=True)
+    (tmp_path / "sim_build" / "integration" / "test_my_chip.py").write_text(
+        "# integration testbench\n")
+    (tmp_path / "my_chip.v").write_text("module my_chip(input clk);\nendmodule\n")
+    return tmp_path
+
+
+def _state(run_dir, **kw):
+    base = {
+        "project_root": str(run_dir),
+        "design_name": "my_chip",
+        "top_rtl_path": str(run_dir / "my_chip.v"),
+    }
+    base.update(kw)
+    return base
+
+
+class TestDisabledIsRecordedNotSilent:
+    def test_gate_off_reports_disabled_with_a_reason(self, run_dir, monkeypatch):
+        monkeypatch.setenv(gs.GATE_SIM_ENV, "0")
+        ok, status, reason = _run_chip_top_gate_sim(_state(run_dir), "net.v")
+        assert ok is None                      # never True when it did not run
+        assert status == gs.STATUS_DISABLED
+        assert reason                          # absence is always explained
+
+
+class TestStimulusResolution:
+    def test_missing_integration_tb_is_not_run_not_pass(self, tmp_path, monkeypatch):
+        """No integration vectors => cannot judge. Must NOT report success."""
+        monkeypatch.setenv(gs.GATE_SIM_ENV, "1")
+        state = _state(tmp_path)               # no sim_build/integration
+        ok, status, reason = _run_chip_top_gate_sim(state, "net.v")
+        assert ok is None and status == gs.STATUS_NOT_RUN
+        assert "integration" in reason.lower()
+
+    def test_uses_the_integration_testbench_as_reference(self, run_dir, monkeypatch):
+        """The stimulus must be integration DV -- real traffic through the
+        assembled chip -- not a per-block testbench."""
+        monkeypatch.setenv(gs.GATE_SIM_ENV, "1")
+        seen = {}
+
+        def fake_check(*, block, netlist_path, rtl_path, tb_path):
+            seen.update(block=block, netlist=netlist_path, tb=tb_path)
+            return gs.GateSimResult(ran=True, ok=True, status=gs.STATUS_PASS,
+                                    reason="ok", cycles_compared=10,
+                                    output_bits_compared=100)
+
+        monkeypatch.setattr(gs, "check_gate_sim", fake_check)
+        ok, status, _ = _run_chip_top_gate_sim(_state(run_dir), "flat_net.v")
+        assert ok is True and status == gs.STATUS_PASS
+        assert seen["tb"].endswith("sim_build/integration/test_my_chip.py")
+        assert seen["netlist"] == "flat_net.v", "must judge the FLAT netlist"
+        # marked chip_top so the scope guard admits it
+        assert seen["block"]["is_chip_top"] is True
+
+
+class TestVerdicts:
+    def test_divergence_is_a_hard_failure(self, run_dir, monkeypatch):
+        monkeypatch.setenv(gs.GATE_SIM_ENV, "1")
+        monkeypatch.setattr(gs, "check_gate_sim", lambda **k: gs.GateSimResult(
+            ran=True, ok=False, status=gs.STATUS_FAIL,
+            reason="diverged at cycle 42 on port done"))
+        ok, status, reason = _run_chip_top_gate_sim(_state(run_dir), "n.v")
+        assert ok is False and status == gs.STATUS_FAIL and "cycle 42" in reason
+
+    def test_plumbing_error_never_crashes_the_backend(self, run_dir, monkeypatch):
+        """A gate that explodes must not take the backend down -- nor pass."""
+        monkeypatch.setenv(gs.GATE_SIM_ENV, "1")
+
+        def boom(**_kw):
+            raise RuntimeError("verilator exploded")
+
+        monkeypatch.setattr(gs, "check_gate_sim", boom)
+        ok, status, reason = _run_chip_top_gate_sim(_state(run_dir), "n.v")
+        assert ok is None and status == gs.STATUS_NOT_RUN
+        assert "RuntimeError" in reason
+
+    def test_not_run_from_the_harness_is_propagated_as_none(self, run_dir, monkeypatch):
+        monkeypatch.setenv(gs.GATE_SIM_ENV, "1")
+        monkeypatch.setattr(gs, "check_gate_sim", lambda **k: gs.GateSimResult(
+            ran=False, ok=True, status=gs.STATUS_NOT_RUN,
+            reason="no verilator on PATH"))
+        ok, status, _ = _run_chip_top_gate_sim(_state(run_dir), "n.v")
+        assert ok is None and status == gs.STATUS_NOT_RUN

--- a/orchestrator/tests/test_chip_top_gate_sim.py
+++ b/orchestrator/tests/test_chip_top_gate_sim.py
@@ -12,8 +12,9 @@ testbench rather than real chip traffic.
 """
 from __future__ import annotations
 
-import orchestrator.harness.gate_sim as gs
 import pytest
+
+import orchestrator.harness.gate_sim as gs
 from orchestrator.langgraph.backend_graph import _run_chip_top_gate_sim
 
 


### PR DESCRIPTION
Follow-up to #67, which wired gate-sim **per block**. That is the wrong artifact.

## Why per-block was wrong

**It doesn't verify what becomes silicon.** A per-block netlist is an intermediate that integration re-elaborates; the thing that tapes out is the flat top from `flat_top_synthesis`. Passing gate-sim on eight blocks says nothing rigorous about the assembled design.

**The stimulus is wrong.** Per-block replay uses that block's own testbench vectors — synthetic per-block stimulus, not real chip traffic.

**And it was keyed off a name chosen by an LLM.** The gate looked up its top by *block name*. When an external contract fixes the module name (a Caravel `user_project_wrapper`), block name and module name diverge, and the gate **failed closed on a correctly synthesized netlist** — `top module not found`, 0 cycles compared. Which way it went depended on whether the architecture agent happened to append a suffix. A signoff gate whose subject is named by a language model is not a signoff gate.

## What this does

`_run_chip_top_gate_sim` runs **after `flat_top_synthesis`, before `run_pnr`** — the first point a flat chip netlist exists, and no reason to spend P&R on a netlist that doesn't reproduce the verified RTL.

Reference stimulus is the **integration DV testbench**: real traffic through the assembled chip, from the run that already matched the golden. So `flat netlist == integration reference` transitively means `flat netlist == golden`.

Verdict lands in `chip_gate_sim_ok` / `_status` / `_reason` on `BackendState`.

## Fail semantics — unchanged and deliberate

`None` means the gate **did not apply** (disabled, no integration testbench, toolchain absent) and is *always* recorded with a reason, so absence never reads as success. A plumbing error is `None` — never a pass — and never crashes the backend.

## Nothing new was needed

The replay engine, the **structural top resolver** (derives the top from the netlist's own module graph — verified 8/8 on preserved netlists from 22 KB to 46 MB, no names supplied), the sky130 UDP shims, and the generated macro models all already exist and are tested. This wires them to the right artifact.

## Tests

`test_chip_top_gate_sim.py`, 6 tests, and 56 pass across both gate-sim suites. `ruff` clean.

- disabled reports `DISABLED` with a reason and `ok is None` — never `True` when it didn't run
- **missing integration testbench is `not_run`, not a pass** — no vectors means cannot judge
- the reference really is `sim_build/integration/test_<design>.py`, the netlist really is the **flat** one, and the subject is marked `is_chip_top` so the scope guard admits it
- divergence is a hard `FAIL`
- a harness exception is `not_run` and does not propagate

## Note

Depends on the scope guard in the same file (`CORESMITH_GATE_SIM_SCOPE`, default `chip_top`), which makes a leaf block `not_run`. Together these mean the gate now judges exactly one thing: the assembled chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)