### PR TITLE
fix(opencode): stop hosted-Kimi reasoning from starving large file-write turns

### DIFF
--- a/orchestrator/langchain/agents/coresmith_llm.py
+++ b/orchestrator/langchain/agents/coresmith_llm.py
@@ -753,6 +753,122 @@ DEFAULT_OPENCODE_MODEL = "openrouter/moonshotai/kimi-k3"
 # Override with CORESMITH_BLOCK_MODEL env var.
 BLOCK_MODEL = "sonnet-5"
 
+# --- OpenCode reasoning-effort ("--variant") handling ------------------------
+# OpenRouter's hosted Kimi models (kimi-k3 / kimi-k2-thinking) expose reasoning
+# EFFORT tiers {low, high, max} ONLY. "minimal" -- the natural thing to reach
+# for when you want to *cap* reasoning -- is NOT a valid effort for these
+# models; the provider silently ignores it and leaves FULL (high) reasoning in
+# effect. That is a silent, high-cost footgun: on a large tool-emitting turn
+# (e.g. the ~18K-token block_diagram.json write) full reasoning can burn the
+# whole ~32K completion budget before the file tool is ever called, truncating
+# mid-turn (reason="length") so nothing is written. We therefore normalise the
+# configured variant to a provider-valid tier (mapping known aliases, dropping
+# anything unrecognised with a warning) instead of shipping a no-op flag.
+_OPENCODE_KIMI_VALID_VARIANTS = frozenset({"low", "high", "max"})
+_OPENCODE_VARIANT_ALIASES = {
+    "minimal": "low",
+    "min": "low",
+    "minimum": "low",
+    "none": "low",
+    "off": "low",
+    "medium": "high",  # no "medium" tier on Kimi -- round to the nearest valid
+    "mid": "high",
+    "xhigh": "max",
+    "highest": "max",
+}
+# Architecture pipeline steps whose LLM turn emits a LARGE structured artifact
+# through a file-write tool. For these, full reasoning starves the completion
+# budget before the write lands, so we default the reasoning effort to "low"
+# when the operator has not set CORESMITH_OPENCODE_VARIANT. Frontend / diagnose
+# steps (where deep reasoning is valuable and outputs are small) are left at the
+# provider default. Keyed on the ``run_name`` label call() records.
+_OPENCODE_LOW_REASONING_STEPS = frozenset({"block_diagram"})
+
+
+def _normalize_opencode_variant(variant: str, resolved_model: str) -> str:
+    """Return a provider-valid ``--variant`` value, or "" to omit the flag.
+
+    ``variant`` is the raw configured reasoning-effort string. For OpenRouter's
+    hosted Kimi models only low/high/max are accepted; an unknown value
+    (notably "minimal") is silently ignored by the provider and leaves full
+    reasoning in effect. We map known aliases to a valid tier and drop
+    unrecognised values (with a warning) so the caller never ships a no-op flag
+    that a reader would mistake for an applied reasoning cap. Non-Kimi opencode
+    models pass through unchanged (their own effort vocabulary is respected).
+    """
+    v = (variant or "").strip().lower()
+    if not v:
+        return ""
+    if "kimi" not in (resolved_model or "").lower():
+        return v
+    if v in _OPENCODE_KIMI_VALID_VARIANTS:
+        return v
+    mapped = _OPENCODE_VARIANT_ALIASES.get(v)
+    if mapped:
+        logger.warning(
+            "CORESMITH_OPENCODE_VARIANT=%r is not a valid reasoning effort for "
+            "%s (valid: %s); using %r instead.",
+            variant, resolved_model,
+            sorted(_OPENCODE_KIMI_VALID_VARIANTS), mapped,
+        )
+        return mapped
+    logger.warning(
+        "CORESMITH_OPENCODE_VARIANT=%r is not recognised for %s (valid: %s); "
+        "omitting --variant so the provider default reasoning applies.",
+        variant, resolved_model, sorted(_OPENCODE_KIMI_VALID_VARIANTS),
+    )
+    return ""
+
+
+def _resolve_opencode_variant(resolved_model: str, run_name: str) -> str:
+    """Resolve the effective ``--variant`` value for one opencode call.
+
+    Precedence: an explicit ``CORESMITH_OPENCODE_VARIANT`` (normalised) wins;
+    otherwise large-output architecture steps (``_OPENCODE_LOW_REASONING_STEPS``)
+    default to "low" reasoning so a big file-writing turn cannot be starved of
+    completion tokens before the write. Everything else stays at the provider
+    default (no flag).
+    """
+    raw = os.environ.get("CORESMITH_OPENCODE_VARIANT", "").strip()
+    if not raw and run_name in _OPENCODE_LOW_REASONING_STEPS:
+        raw = "low"
+    return _normalize_opencode_variant(raw, resolved_model)
+
+
+# Error signatures that indicate a TRANSIENT provider/network failure (as
+# opposed to a deterministic bad request or a clean completion). OpenRouter
+# routinely drops long streams with a 502 "Network connection lost"
+# (provider_unavailable) mid-turn; retrying the whole call is the correct
+# recovery and cheap relative to losing a completed architecture step.
+_OPENCODE_TRANSIENT_SIGNATURES = (
+    "provider_unavailable",
+    "network connection lost",
+    "connection error",
+    "socket hang up",
+    "econnreset",
+    "temporarily unavailable",
+    "overloaded",
+    "502",
+    "503",
+    "429",
+)
+
+
+def _is_transient_opencode_failure(
+    returncode: int, output: str, stderr: str
+) -> bool:
+    """Whether an opencode failure looks transient enough to retry.
+
+    Returns False for a clean exit (returncode 0) and for signal-kills
+    (returncode < 0, e.g. SIGTERM from a daemon pause/shutdown -- retrying an
+    externally-cancelled turn is wrong). Otherwise matches known transient
+    provider/network signatures in the combined stderr/stdout.
+    """
+    if returncode == 0 or returncode < 0:
+        return False
+    blob = f"{stderr or ''}\n{output or ''}".lower()
+    return any(sig in blob for sig in _OPENCODE_TRANSIENT_SIGNATURES)
+
 
 def _resolve_model(model: str, provider: str = "claude_cli") -> str:
     """Map short model name to the selected CLI model ID.
@@ -2228,6 +2344,16 @@ class ClaudeLLM:
             "--dir", workdir,
             "--auto",
         ]
+        # Reasoning-effort variant (opencode --variant). For hosted Kimi the
+        # valid tiers are low/high/max (NOT "minimal" -- see
+        # _normalize_opencode_variant). CORESMITH_OPENCODE_VARIANT, when set,
+        # wins after normalisation; otherwise large-output architecture steps
+        # (block_diagram) default to "low" so a big JSON file-write turn is not
+        # starved of completion tokens by runaway reasoning (reason="length").
+        _run_name = (_call_site_context.get(None) or {}).get("run_name", "")
+        _variant = _resolve_opencode_variant(resolved_model, _run_name)
+        if _variant:
+            cmd.extend(["--variant", _variant])
 
         process_env = os.environ.copy()
         if self.disable_tools:
@@ -2250,38 +2376,72 @@ class ClaudeLLM:
             len(user_prompt),
             len(system_prompt),
         )
-        t0 = _time_mod.monotonic()
-        span_start_ns = _time_mod.time_ns()
+        # Bounded retry on TRANSIENT provider failures (OpenRouter 5xx / dropped
+        # stream). Default 1 retry; override with CORESMITH_OPENCODE_MAX_RETRIES.
         try:
-            output, stderr_text, returncode, elapsed, timed_out, stalled, usage = (
-                self._run_cli_with_watchdog(
-                    cmd,
-                    combined_prompt,
-                    project_root,
-                    resolved_model,
-                    t0,
-                    process_env=process_env,
+            _max_retries = int(
+                os.environ.get("CORESMITH_OPENCODE_MAX_RETRIES", "1") or 1
+            )
+        except ValueError:
+            _max_retries = 1
+        _attempt = 0
+        while True:
+            t0 = _time_mod.monotonic()
+            span_start_ns = _time_mod.time_ns()
+            try:
+                output, stderr_text, returncode, elapsed, timed_out, stalled, usage = (
+                    self._run_cli_with_watchdog(
+                        cmd,
+                        combined_prompt,
+                        project_root,
+                        resolved_model,
+                        t0,
+                        process_env=process_env,
+                    )
                 )
-            )
-        except FileNotFoundError:
-            elapsed = _time_mod.monotonic() - t0
-            error_msg = "OpenCode CLI binary not found"
-            output = (
-                "[ClaudeLLM error: OpenCode CLI binary not found. "
-                "Install: npm install -g opencode-ai]"
-            )
-            _log_llm_call(
-                model=resolved_model,
-                provider="opencode_cli",
-                system_prompt=system_prompt,
-                user_prompt=user_prompt,
-                response=output,
-                duration_s=elapsed,
-                timeout=self.timeout,
-                error=error_msg,
-                start_ts_ns=span_start_ns,
-            )
-            return output
+            except FileNotFoundError:
+                elapsed = _time_mod.monotonic() - t0
+                error_msg = "OpenCode CLI binary not found"
+                output = (
+                    "[ClaudeLLM error: OpenCode CLI binary not found. "
+                    "Install: npm install -g opencode-ai]"
+                )
+                _log_llm_call(
+                    model=resolved_model,
+                    provider="opencode_cli",
+                    system_prompt=system_prompt,
+                    user_prompt=user_prompt,
+                    response=output,
+                    duration_s=elapsed,
+                    timeout=self.timeout,
+                    error=error_msg,
+                    start_ts_ns=span_start_ns,
+                )
+                return output
+
+            if (
+                _attempt < _max_retries
+                and not timed_out
+                and not stalled
+                and _is_transient_opencode_failure(returncode, output, stderr_text)
+            ):
+                _attempt += 1
+                logger.warning(
+                    "OpenCode transient provider failure (retry %d/%d): %s",
+                    _attempt, _max_retries,
+                    (stderr_text or output or "")[:200],
+                )
+                self._write_llm_event(project_root, "llm_transient_retry", {
+                    "model": resolved_model,
+                    "provider": "opencode_cli",
+                    "attempt": _attempt,
+                    "max_retries": _max_retries,
+                    "returncode": returncode,
+                    "detail": (stderr_text or output or "")[:300],
+                })
+                _time_mod.sleep(min(2 ** _attempt, 8))
+                continue
+            break
 
         if timed_out or stalled:
             reason = "stalled" if stalled else "timed out"

--- a/orchestrator/tests/test_coresmith_llm.py
+++ b/orchestrator/tests/test_coresmith_llm.py
@@ -28,6 +28,7 @@ from orchestrator.langchain.agents.coresmith_llm import (
     _CLI_MODEL_MAP,
     _CODEX_MODEL_MAP,
     _KIMI_MODEL_MAP,
+    _OPENCODE_LOW_REASONING_STEPS,
     _OPENCODE_MODEL_MAP,
     _RESUME_FLAGS_CACHE,
     BLOCK_MODEL,
@@ -41,15 +42,18 @@ from orchestrator.langchain.agents.coresmith_llm import (
     _call_site_context,
     _codex_resume_supported_flags,
     _detect_provider,
+    _is_transient_opencode_failure,
     _llm_breakers,
     _llm_breakers_lock,
     _log_llm_call,
     _log_opencode_turns,
+    _normalize_opencode_variant,
     _parse_codex_json,
     _parse_kimi_acp_json,
     _parse_opencode_json,
     _register_process,
     _resolve_model,
+    _resolve_opencode_variant,
     _unregister_process,
     kill_active_cli_processes,
 )
@@ -67,6 +71,8 @@ def _clear_provider_env(monkeypatch):
     monkeypatch.delenv("CORESMITH_LLM_PROVIDER", raising=False)
     monkeypatch.delenv("CORESMITH_CODEX_MODEL", raising=False)
     monkeypatch.delenv("CORESMITH_OPENCODE_MODEL", raising=False)
+    monkeypatch.delenv("CORESMITH_OPENCODE_VARIANT", raising=False)
+    monkeypatch.delenv("CORESMITH_OPENCODE_MAX_RETRIES", raising=False)
     monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
     monkeypatch.delenv("CORESMITH_KIMI_MODEL", raising=False)
     monkeypatch.delenv("KIMI_MODEL_NAME", raising=False)
@@ -268,6 +274,173 @@ class TestOpenCodeInvocation:
         assert "<user>\nhello\n</user>" in watchdog.call_args.args[1]
         config = json.loads(watchdog.call_args.kwargs["process_env"]["OPENCODE_CONFIG_CONTENT"])
         assert config == {"theme": "system", "permission": "deny"}
+
+
+_KIMI = "openrouter/moonshotai/kimi-k3"
+
+
+class TestOpenCodeVariantNormalization:
+    """The block-diagram write-failure root cause: 'minimal' is NOT a valid
+    reasoning effort for hosted Kimi (low/high/max only) -- the provider
+    silently ignores it, leaving full reasoning that starves the completion
+    budget before the file is written (reason='length')."""
+
+    @pytest.mark.parametrize("value", ["low", "high", "max", "LOW", " Max "])
+    def test_valid_efforts_pass_through(self, value):
+        assert _normalize_opencode_variant(value, _KIMI) == value.strip().lower()
+
+    @pytest.mark.parametrize(
+        "alias,expected",
+        [
+            ("minimal", "low"), ("min", "low"), ("minimum", "low"),
+            ("none", "low"), ("off", "low"),
+            ("medium", "high"), ("mid", "high"),
+            ("xhigh", "max"), ("highest", "max"),
+        ],
+    )
+    def test_known_aliases_map_to_valid_tier(self, alias, expected):
+        assert _normalize_opencode_variant(alias, _KIMI) == expected
+
+    def test_unknown_value_is_dropped_not_shipped_as_noop(self):
+        # An unrecognised effort would be silently ignored by the provider;
+        # dropping it (return "") makes the no-op explicit rather than passing
+        # a flag a reader mistakes for an applied cap.
+        assert _normalize_opencode_variant("banana", _KIMI) == ""
+
+    def test_empty_returns_empty(self):
+        assert _normalize_opencode_variant("", _KIMI) == ""
+        assert _normalize_opencode_variant("   ", _KIMI) == ""
+
+    def test_non_kimi_model_passes_value_through_unchanged(self):
+        # Non-Kimi opencode models keep their own effort vocabulary.
+        assert _normalize_opencode_variant("minimal", "anthropic/claude-x") == "minimal"
+
+
+class TestOpenCodeVariantResolution:
+    def test_block_diagram_defaults_to_low_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CORESMITH_OPENCODE_VARIANT", raising=False)
+        assert "block_diagram" in _OPENCODE_LOW_REASONING_STEPS
+        assert _resolve_opencode_variant(_KIMI, "block_diagram") == "low"
+
+    def test_other_steps_keep_provider_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CORESMITH_OPENCODE_VARIANT", raising=False)
+        assert _resolve_opencode_variant(_KIMI, "generate_rtl") == ""
+        assert _resolve_opencode_variant(_KIMI, "") == ""
+
+    def test_explicit_env_wins_over_step_default(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_OPENCODE_VARIANT", "high")
+        assert _resolve_opencode_variant(_KIMI, "block_diagram") == "high"
+
+    def test_explicit_minimal_env_is_normalized(self, monkeypatch):
+        # The exact footgun from the theora run: launch env set 'minimal'.
+        monkeypatch.setenv("CORESMITH_OPENCODE_VARIANT", "minimal")
+        assert _resolve_opencode_variant(_KIMI, "generate_rtl") == "low"
+
+
+class TestOpenCodeTransientFailure:
+    def test_clean_exit_not_transient(self):
+        assert _is_transient_opencode_failure(0, "ok", "") is False
+
+    def test_signal_kill_not_transient(self):
+        # -15 = SIGTERM from a daemon pause/shutdown -- retrying is wrong.
+        assert _is_transient_opencode_failure(-15, "provider_unavailable", "") is False
+
+    @pytest.mark.parametrize(
+        "blob",
+        [
+            '{"code":502,"message":"Network connection lost.",'
+            '"metadata":{"error_type":"provider_unavailable"}}',
+            "upstream returned 503",
+            "429 Too Many Requests",
+            "socket hang up",
+        ],
+    )
+    def test_transient_signatures_detected(self, blob):
+        assert _is_transient_opencode_failure(1, blob, "") is True
+        assert _is_transient_opencode_failure(1, "", blob) is True
+
+    def test_deterministic_error_not_transient(self):
+        assert _is_transient_opencode_failure(1, "invalid model id", "") is False
+
+
+class TestOpenCodeVariantInvocation:
+    @patch(
+        "orchestrator.langchain.agents.coresmith_llm._find_opencode_binary",
+        return_value="/usr/bin/opencode",
+    )
+    def test_block_diagram_call_site_adds_variant_low(
+        self, _mock_find, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setenv("CORESMITH_LLM_PROVIDER", "openrouter")
+        monkeypatch.setenv("CORESMITH_PROJECT_ROOT", str(tmp_path))
+        model = ClaudeLLM(model="opus-4.8", timeout=10)
+        token = _call_site_context.set({"run_name": "block_diagram"})
+        try:
+            with patch.object(model, "_run_cli_with_watchdog") as watchdog:
+                watchdog.return_value = ("ready", "", 0, 1.0, False, False, {})
+                model._generate_via_cli("system", "hello")
+        finally:
+            _call_site_context.reset(token)
+        cmd = watchdog.call_args.args[0]
+        assert "--variant" in cmd
+        assert cmd[cmd.index("--variant") + 1] == "low"
+
+    @patch(
+        "orchestrator.langchain.agents.coresmith_llm._find_opencode_binary",
+        return_value="/usr/bin/opencode",
+    )
+    def test_non_arch_call_site_omits_variant(
+        self, _mock_find, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setenv("CORESMITH_LLM_PROVIDER", "openrouter")
+        monkeypatch.setenv("CORESMITH_PROJECT_ROOT", str(tmp_path))
+        model = ClaudeLLM(model="opus-4.8", timeout=10)
+        token = _call_site_context.set({"run_name": "generate_rtl"})
+        try:
+            with patch.object(model, "_run_cli_with_watchdog") as watchdog:
+                watchdog.return_value = ("ready", "", 0, 1.0, False, False, {})
+                model._generate_via_cli("system", "hello")
+        finally:
+            _call_site_context.reset(token)
+        assert "--variant" not in watchdog.call_args.args[0]
+
+    @patch(
+        "orchestrator.langchain.agents.coresmith_llm._find_opencode_binary",
+        return_value="/usr/bin/opencode",
+    )
+    def test_retries_once_on_transient_then_succeeds(
+        self, _mock_find, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setenv("CORESMITH_LLM_PROVIDER", "openrouter")
+        monkeypatch.setenv("CORESMITH_PROJECT_ROOT", str(tmp_path))
+        monkeypatch.setattr(coresmith_llm._time_mod, "sleep", lambda *_a, **_k: None)
+        model = ClaudeLLM(model="opus-4.8", timeout=10)
+        transient = ("[502 provider_unavailable]", "Network connection lost", 1,
+                     1.0, False, False, {})
+        ok = ("ready", "", 0, 1.0, False, False, {})
+        with patch.object(model, "_run_cli_with_watchdog",
+                          side_effect=[transient, ok]) as watchdog:
+            output = model._generate_via_cli("system", "hello")
+        assert output == "ready"
+        assert watchdog.call_count == 2
+
+    @patch(
+        "orchestrator.langchain.agents.coresmith_llm._find_opencode_binary",
+        return_value="/usr/bin/opencode",
+    )
+    def test_no_retry_when_disabled(
+        self, _mock_find, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setenv("CORESMITH_LLM_PROVIDER", "openrouter")
+        monkeypatch.setenv("CORESMITH_PROJECT_ROOT", str(tmp_path))
+        monkeypatch.setenv("CORESMITH_OPENCODE_MAX_RETRIES", "0")
+        model = ClaudeLLM(model="opus-4.8", timeout=10)
+        transient = ("[502]", "provider_unavailable", 1, 1.0, False, False, {})
+        with patch.object(model, "_run_cli_with_watchdog",
+                          side_effect=[transient]) as watchdog:
+            output = model._generate_via_cli("system", "hello")
+        assert watchdog.call_count == 1
+        assert "[ClaudeLLM error:" in output
 
 
 class TestCodexJsonParsing:


### PR DESCRIPTION
## Summary

The architecture **block-diagram** step (openrouter/moonshotai/kimi-k3 via the OpenCode provider) failed to serialize `block_diagram.json` across **6 attempts** on the theora holdout run. Investigation of the recorded turn streams (`opencode_turns.jsonl`) shows the **file writes were never the problem** — OpenCode's `write` tool is auto-approved under `--auto` and landed `prd_spec.json`, `sad_spec.md`, `frd_spec.md`, and (on the 6th attempt) `block_diagram.json` itself. The block diagram is just the **largest** artifact (~18K output tokens), and three integration issues compounded on that one big tool-emitting turn.

## Per-attempt failure classification (from `opencode_turns.jsonl`)

| # | Failure | Write-tool call? |
|---|---------|------------------|
| 1 | OpenRouter **502** provider_unavailable mid-stream | none |
| 2 | **1200s timeout** (16 bash + 10 read, slow streaming) | none |
| 3 | **reason=length** — reasoning 29541 + output 2459 = **exactly 32000** | none |
| 4 | reason=stop, narrated only | none |
| 5 | **reason=length** — reasoning 12104 + output 19896 = **exactly 32000** | none |
| 6 | **write → block_diagram.json, status=completed** (then SIGTERM by daemon pause) | yes |

## Root cause

1. **Reasoning starves a `max_tokens=32000` completion budget.** OpenCode requests `max_tokens=32000` for kimi-k3 (confirmed by an OpenRouter 402 that echoed *"You requested up to 32000 tokens"*), **not** the model's 1M registry limit. Full reasoning (~29.5K tokens) leaves no room for the ~18K-token JSON → truncation before the write. Two attempts died at *exactly* 32000 combined tokens.
2. **The intended reasoning cap was a silent no-op.** The run set `CORESMITH_OPENCODE_VARIANT=minimal`, but hosted Kimi only accepts `{low, high, max}` — `minimal` is silently ignored, leaving full reasoning in effect. An invalid variant *looked* applied but was not.
3. **Transient OpenRouter 502s** dropped long streams with no retry.

Not the cause: permission/approval policy (writes auto-approved), tool exposure (write tool used successfully 4×), path/cwd (absolute target inside the workdir, `read_back_json` reads the file directly).

## Fix (smallest robust change, all env-configurable)

- **`_normalize_opencode_variant()`** — map known aliases (`minimal/min/none/off → low`, `medium → high`, `xhigh → max`) to a provider-**valid** effort and drop unrecognised values with a warning, so an invalid variant can never again masquerade as an applied cap. Non-Kimi opencode models pass through unchanged.
- **`_resolve_opencode_variant()`** — large-output architecture steps (`block_diagram`) default to **`low`** reasoning when `CORESMITH_OPENCODE_VARIANT` is unset, so the big JSON write turn is never starved. An explicit env value still wins (after normalisation); frontend/diagnose steps are unchanged.
- **Bounded transient retry** in the opencode path (5xx / dropped stream); default 1, `CORESMITH_OPENCODE_MAX_RETRIES` to tune. Never retries a clean exit or a signal-kill (SIGTERM from a daemon pause).

The pre-existing uncommitted `--variant` plumbing is folded in and made robust here.

## Proof

Re-running the **recorded theora `block_diagram` prompt** through the fixed provider (variant auto-resolves to `low`) produces a **complete, valid 18-block decomposition in one pass with `reason="stop"`** — no length truncation, no timeout — structurally matching the 21-block codex reference (qspi_slave_frontend, regmap, bitstream_reader, header_parser, dct_token_decode, dc_predict, recon_pipeline, motion_comp, loop_filter, decode_sequencer + hoisted memories in_packet_buffer/codebook_memory/quant_table_memory/reference_frame_memory).

`111/111` tests in `test_coresmith_llm.py` pass; ruff clean. New tests cover variant normalization/resolution, transient-failure detection, block_diagram call-site → `--variant low`, and the retry loop (both branches).

> Note: the OpenRouter account used by the holdout run is now credit-depleted (~$0.23 of $10 remaining), which surfaced as the 402 above during end-to-end validation; it is unrelated to this code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128qTGH91zFnRoSwfzKsPH9