### PR TITLE
Stop deleting the graded pad block; wire and arm the chip_top gate-sim

### DIFF
--- a/bin/gen_ram
+++ b/bin/gen_ram
@@ -26,7 +26,15 @@ silently went missing and were misread as "slow macro" rather than "no data".
 is disabled". Therefore:
 
 * **No DRC and no LVS run during generation.** Those verdicts are reported as
-  ``not run`` (never as a pass) and must come from the backend flow.
+  ``not_run`` -- the same three-state vocabulary as
+  ``orchestrator/langgraph/drc_verdict.py`` and ``harness/gate_sim.py``: a
+  stage that was not measured carries ``status="not_run"``, ``ok=None``,
+  ``violations=None`` and a ``reason``. Never a pass, and never a numeric
+  ``violations`` (a ``-1`` "sentinel" read as "this macro HAS DRC violations"
+  and FAILed two real raster macros for a DRC that never ran). The report also
+  lists every unmeasured stage under the top-level ``unmeasured`` key, so
+  ``verdict: PASS`` cannot be misread as "DRC clean". The authoritative DRC/LVS
+  verdicts must come from the backend flow.
 * **Liberty timing is an ANALYTICAL ESTIMATE, not a SPICE measurement.** This
   is why generated macros report 600-700 MHz while the one macro that was
   fully characterized end-to-end (``sram_1rw1r_16_128_8_sky130``) measures
@@ -308,12 +316,33 @@ def main(argv: list[str] | None = None) -> int:
         _log(f"[liberty] {ldetail} (analytical model, not characterized)")
         if not lok:
             ok, detail = False, f"liberty check failed: {ldetail}"
-        report["stages"]["drc"] = {"ok": None, "detail": "not run by OpenRAM "
-                                   "(check_lvs=False); use the backend DRC flow"}
-        report["stages"]["lvs"] = {"ok": None, "detail": "not run by OpenRAM "
-                                   "(check_lvs=False); use the backend LVS flow"}
-        _log("[drc] not run -- OpenRAM generation has DRC/LVS disabled")
-        _log("[lvs] not run -- OpenRAM generation has DRC/LVS disabled")
+        # DRC/LVS were not measured here. Record that as the engine's honest
+        # NOT-MEASURED state (status=not_run + reason, ok=None, violations=None)
+        # rather than a bare ok=None with prose: `ok=False`/`violations=-1` is
+        # what made an unwritten precheck_magic_drc.rpt read as a real DRC
+        # failure. See orchestrator/langgraph/drc_verdict.py.
+        from orchestrator.langgraph.drc_verdict import (
+            STATUS_NOT_RUN,
+            drc_stage,
+            unmeasured_drc,
+        )
+        _off = ("not run during generation: openram_gen's config sets "
+                "check_lvs=False, so OpenRAM reports \"DRC/LVS/PEX is "
+                "disabled\" and measures nothing")
+        _drc_why = f"{_off}; the authoritative verdict must come from the backend DRC flow"
+        _lvs_why = f"{_off}; the authoritative verdict must come from the backend LVS flow"
+        report["stages"]["drc"] = drc_stage(
+            unmeasured_drc(_drc_why, tool="OpenRAM"))
+        report["stages"]["lvs"] = {
+            "ok": None,
+            "status": STATUS_NOT_RUN,
+            "measured": False,
+            "reason": _lvs_why,
+            "detail": ("OpenRAM LVS COULD NOT BE MEASURED "
+                       f"(status={STATUS_NOT_RUN}): {_lvs_why}"),
+        }
+        _log(f"[drc] {STATUS_NOT_RUN} -- {_drc_why}")
+        _log(f"[lvs] {STATUS_NOT_RUN} -- {_lvs_why}")
     if not ok:
         report["verdict"] = "FAIL"
         _emit(report, args.out)
@@ -328,6 +357,14 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _emit(report: dict, out: Path) -> None:
+    # Name every stage that produced NO measurement at the TOP level, next to
+    # `verdict`, so a reader of "verdict": "PASS" cannot mistake an unmeasured
+    # DRC/LVS for a measured clean one.
+    from orchestrator.langgraph.drc_verdict import STATUS_NOT_RUN
+    report["unmeasured"] = sorted(
+        name for name, stage in (report.get("stages") or {}).items()
+        if isinstance(stage, dict) and stage.get("status") == STATUS_NOT_RUN
+    )
     try:
         out.mkdir(parents=True, exist_ok=True)
         path = out / "gen_ram_report.json"

--- a/docs/TEST-BASELINE.md
+++ b/docs/TEST-BASELINE.md
@@ -92,6 +92,28 @@ code change.
 
 Before you trust any large diff: check the `environment:` line first.
 
+### The `claude`-on-PATH trap works in BOTH directions
+
+Adding `claude` to PATH retires ~50 entries, and it also **adds two**:
+
+    orchestrator/tests/test_live_architecture.py::TestLiveArchitecture16BitAdder::test_ers_questions_generated
+    orchestrator/tests/test_live_architecture.py::TestLiveArchitecture16BitAdder::test_full_architecture_cycle
+
+Those carry `@requires_claude`
+(`pytest.mark.skipif(shutil.which("claude") is None)`), so with no CLI they
+SKIP and never enter the ledger. With the CLI present but not logged in they
+RUN and fail on `Not logged in - Please run /login` (the ERS question list comes
+back as a single `parse_error` entry). Verified both ways on the OCI box: 2
+skipped without it, 2 failed with it.
+
+So a `claude` on PATH that is not authenticated makes the guard report a
+regression that is not one. Neither `--refresh` nor a code change is the answer
+-- refreshing would bake an auth failure into the ledger as though it were a
+known-red test. Either run the guard with the toolchain the baseline was
+measured with, or log the CLI in, and read the `environment:` line before
+believing any verdict.
+
+
 ## Refreshing the ledger, deliberately
 
 Refreshing is a **deliberate, reviewed act**, never a way to get to green.

--- a/docs/TEST-BASELINE.md
+++ b/docs/TEST-BASELINE.md
@@ -1,0 +1,190 @@
+<!--
+Copyright (c) Meta Platforms, Inc. and affiliates.
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+# The test baseline (debt ledger)
+
+`pytest orchestrator/tests` is **red on `main`** and has been for a long time.
+Roughly a hundred tests fail for reasons that predate whatever you are working
+on — assertion strings that drifted, tests pinned to APIs that were renamed,
+tests that need EDA tools or a live LLM that this box does not have.
+
+That is a problem beyond the failures themselves: **when the suite is already
+red, nobody can tell whether a change added the next failure.** Every session
+re-discovers the red suite, re-triages the same hundred failures, and burns time
+deciding "is this one mine?".
+
+Two files fix that:
+
+| Path | What it is |
+| --- | --- |
+| `orchestrator/tests/baseline_failures.txt` | The ledger: every node ID that was **already** failing, one per line, sorted, with a header recording the commit / date / invocation / counts it was measured at. |
+| `scripts/check_test_baseline.py` | The guard: runs the suite, diffs it against the ledger, exits non-zero **only** for failures the ledger does not list. |
+
+**The ledger is a debt ledger, not a permanent excuse.** Its only correct
+direction of travel is shorter. See [Paying it down](#paying-it-down).
+
+## Use it
+
+```bash
+# from the repo root, with the venv + EDA tools on PATH
+python scripts/check_test_baseline.py
+```
+
+Exit codes follow the `bin/coresmith` convention:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Every failing test is already in the ledger. Your change added nothing. |
+| `1` | **Regression.** At least one node ID fails that the ledger does not list — it is printed, and it is yours. |
+| `2` | The guard could not judge: pytest crashed without producing a report, or the ledger is missing/empty. |
+
+The guard is only as good as the PATH you run it with — see
+[The toolchain moves the ledger](#the-toolchain-moves-the-ledger).
+
+Beyond the pass/fail verdict, a run also reports (**without** failing):
+
+* **PROGRESS** — ledger entries that now pass. Prune them.
+* **NOTE** — ledger entries that are now `skipped`/`xfailed`. Marked as skipped
+  is *not* the same as fixed; these are called out separately so a skip cannot
+  quietly masquerade as a repair.
+* **STALE** — ledger entries the run never collected: renamed, deleted, or
+  filtered out by a marker selection. The guard reports and continues rather
+  than crashing on a node ID that no longer resolves.
+
+Useful flags:
+
+```bash
+# keep the raw per-test dump, then re-judge it for free (no second 200s run)
+python scripts/check_test_baseline.py --json-out /tmp/run.json
+python scripts/check_test_baseline.py --from-json /tmp/run.json
+
+# judge against a ledger somewhere else
+python scripts/check_test_baseline.py --baseline /tmp/other_baseline.txt
+```
+
+Anything after the flags is appended to the pytest invocation. That **changes
+the population** being measured (a marker-filtered run collects fewer tests), so
+the guard compares your invocation against the one recorded in the ledger header
+and prints a warning when they differ. Treat the diff from a filtered run as
+advisory only.
+
+## The toolchain moves the ledger
+
+**Most of the first baseline was not code.** Of the 75 entries measured at
+`06d82e8`:
+
+| Count | Cause | Cost to pay down |
+| --- | --- | --- |
+| 50 | `FileNotFoundError: Claude CLI not found` — tests instantiate `ClaudeLLM()` at import/construct time, and `claude` was not on PATH | Put `claude` on PATH. Zero code changes. |
+| 15 | `orchestrator/tests/test_composition_audit.py` — MyHDL-style fixtures vs an auditor migrated to Amaranth `Elaboratable` | Real work; the file's own docstring already documents it |
+| 6 | `orchestrator/tests/test_microarch_exp.py` — same Amaranth migration | Same |
+| 1 | `test_pdk_files_exist` — no `.pdk/` on this box | Install the PDK |
+| 3 | Genuine assertion drift / real red | Cheap, one line each |
+
+That is why the ledger header carries an `environment:` field, and why the guard
+warns when the toolchain present now differs from the toolchain the ledger was
+measured with. Without it, someone adding `claude` to PATH sees 50 tests "get
+fixed", and someone dropping it off PATH sees 50 "regressions" — neither is a
+code change.
+
+Before you trust any large diff: check the `environment:` line first.
+
+## Refreshing the ledger, deliberately
+
+Refreshing is a **deliberate, reviewed act**, never a way to get to green.
+
+```bash
+# 1. Measure from a PRISTINE tree, not from your feature branch. A baseline
+#    taken on a branch with work in flight bakes that work's failures in.
+git worktree add --detach /tmp/wt-baseline origin/main
+cd /tmp/wt-baseline
+
+# 2. Copy in the guard if the pristine commit predates it, then measure.
+python scripts/check_test_baseline.py --refresh \
+    --baseline /tmp/baseline_failures.txt
+
+# 3. Read the diff line by line before committing it.
+diff -u orchestrator/tests/baseline_failures.txt /tmp/baseline_failures.txt
+
+# 4. Clean up.
+cd - && git worktree remove /tmp/wt-baseline
+```
+
+When reviewing that diff:
+
+* **Removed lines are the whole point.** A test dropped out of the ledger
+  because it passes now. Good. Commit it.
+* **Added lines are a confession.** Every added line says "I am blessing a
+  newly-red test". The default answer is *no*: fix the test or fix the code.
+  An added line needs a reason in the commit message, and it should be an
+  external one (a dependency bumped, a tool disappeared from the box) — never
+  "my change broke it".
+* **A ledger that grew is a failed refresh.** If the count went up and you
+  cannot name why, throw the refresh away.
+
+Because the failing set depends on what is installed (EDA tools, `claude` CLI,
+Nix), a refresh on a different machine can legitimately shift the list. The
+header's `pytest-invocation` and `counts` fields exist so you can tell an
+environment shift from a code regression before you believe the diff.
+
+## Paying it down
+
+The ledger is sorted by node ID, so the cheap wins cluster by file. In priority
+order for the `06d82e8` measurement:
+
+1. **Put `claude` on PATH** (`/home/ubuntu/.npm-global/bin` on the OCI box; CI
+   already `npm install -g @anthropic-ai/claude-code`s it). Retires ~50 of 75
+   entries with no code change at all.
+2. **`test_rtl_model_equiv.py::test_non_axis_interface_skips`** — asserts
+   `"AXI-Stream" in res["reason"]`, but the reason string the code emits today
+   reads `"... the default AXIS harness covers single s_axis-in / m_axis-out ..."`.
+   One drifted word. One line.
+3. **`test_composition_audit.py` (15) + `test_microarch_exp.py` (6)** — one root
+   cause: the fixtures are pre-migration MyHDL `@block` functions and the auditor
+   now requires Amaranth `class X(Elaboratable)`. Migrating the fixtures retires
+   21 entries in one commit. `test_composition_audit.py`'s module docstring
+   already spells this out.
+4. **`test_pdk_files_exist`** — wants `.pdk/sky130A/.../sky130_fd_sc_hd__nom.tlef`.
+   Environmental; install the PDK or leave it in the ledger and say so.
+
+Attack the trivial classes first — a drifted assertion string costs one line and
+buys back real signal.
+
+Workflow for paying down debt:
+
+1. Fix the test (or the code — decide which one is actually wrong; a drifted
+   assertion string is usually the test's fault, but an assertion that stopped
+   matching because behavior silently changed is the *code's* fault and is a
+   real bug the ledger has been hiding).
+2. Re-run the guard. The fixed test shows up under **PROGRESS**.
+3. `--refresh` and commit the shrunken ledger with the fix.
+
+Do not batch a hundred fixes into one refresh. One class of failure per commit
+keeps the ledger diff readable, which is the only thing that keeps it honest.
+
+## Design notes
+
+**Why a script, not a pytest test.** The guard has to run the whole suite as a
+subprocess. As a pytest test it would be collected inside its own child run and
+re-spawn the suite recursively. It is also a gate whose product is an exit code
+for CI or a pre-push hook — the same shape as `scripts/nightly_canary.py` and
+`scripts/triage_escalation.py`, which is where this repo already puts
+"run the thing, judge the result, exit non-zero" logic.
+
+**Why a plain-text ledger.** One node ID per line, sorted, no quoting: a new or
+retired failure is exactly one line of diff in review, which makes an
+inflationary refresh impossible to sneak past a reviewer.
+
+**How failures are collected.** The script writes a small pytest plugin to a
+temp dir and loads it with `-p`, so outcomes come from `pytest_runtest_logreport`
+/ `pytest_collectreport` rather than from scraping terminal output. The short
+summary line is `FAILED <nodeid> - <msg>` and a parametrized node ID can itself
+contain `" - "`, so scraping is ambiguous; hooks are not. Module-level import
+errors surface as collect-report failures whose node ID is the file path, and are
+recorded too.
+
+**This box has no `pytest-timeout`.** Passing `--timeout=` to any invocation
+here is an error, not a slow run.

--- a/orchestrator/architecture/specialists/tapeout_diagnosis.py
+++ b/orchestrator/architecture/specialists/tapeout_diagnosis.py
@@ -104,13 +104,28 @@ async def diagnose_tapeout_failure(
 
 
 def _format_drc(result: dict | None, root: Path) -> str:
+    from orchestrator.langgraph.drc_verdict import STATUS_NOT_RUN
+
     if not result:
         return "No DRC result available."
 
-    lines = [
-        f"Clean: {result.get('clean', False)}",
-        f"Violation count: {result.get('violation_count', '?')}",
-    ]
+    if result.get("status") == STATUS_NOT_RUN:
+        # NOT MEASURED is not a violation count. Telling the diagnosis agent
+        # "Clean: False / Violation count: -1" for a DRC that produced no
+        # report sends it hunting for layout violations that were never found.
+        lines = [
+            "DRC COULD NOT BE MEASURED (status=not_run): "
+            f"{result.get('reason') or 'no reason recorded'}",
+            "There is NO violation count for this layout -- diagnose why the "
+            "DRC tool produced no result, do NOT diagnose layout violations.",
+        ]
+    else:
+        count = result.get("violation_count")
+        lines = [
+            f"Clean: {result.get('clean', result.get('pass', False))}",
+            "Violation count: "
+            + ("NOT MEASURED" if count is None or count < 0 else str(count)),
+        ]
 
     if result.get("error"):
         lines.append(f"Error: {result['error']}")
@@ -177,11 +192,21 @@ def _format_precheck(result: dict | None) -> str:
     if not result:
         return "No precheck result available."
 
+    from orchestrator.langgraph.drc_verdict import STATUS_NOT_RUN
+
     lines = [f"Overall pass: {result.get('pass', False)}"]
 
     checks = result.get("checks", {})
     for name, check_result in checks.items():
         if isinstance(check_result, dict):
+            if check_result.get("status") == STATUS_NOT_RUN:
+                # A check that produced no measurement is not a FAILED check.
+                # Rendering it as FAIL is how "Magic wrote no report" reached
+                # this agent as "the layout has DRC violations".
+                lines.append(
+                    f"  {name}: NOT MEASURED (status=not_run) -- "
+                    f"{check_result.get('reason') or 'no reason recorded'}")
+                continue
             passed = check_result.get("pass", False)
             lines.append(f"  {name}: {'PASS' if passed else 'FAIL'}")
             if not passed and check_result.get("errors"):

--- a/orchestrator/harness/gate_sim.py
+++ b/orchestrator/harness/gate_sim.py
@@ -73,14 +73,20 @@ SKY130 GATE-SIM UNDER VERILATOR (the footguns, and what we do about them)
   block. Without ``--timing`` both delays collapse to zero and the X-drive races
   the consumer, destroying every read; with ``VERBOSE=1`` they also ``$display``
   on every access. We therefore substitute a generated CYCLE-ACCURATE model per
-  instantiated macro (:func:`macro_model_source`), derived from the macro's own
-  registry geometry, reproducing the PDK model's cycle semantics with no delays
-  and no tracing. ``CORESMITH_GATE_SIM_MACRO_MODEL=pdk`` opts back into the
-  PDK's own file for a simulator that honours delays.
+  instantiated macro (:func:`macro_model_source`), reproducing the PDK model's
+  cycle semantics with no delays and no tracing. Its INTERFACE -- which ports
+  exist, and how wide each one is -- is read from the REAL macro's own Verilog
+  (:func:`macro_interface`), never computed from registry metadata: a stand-in
+  whose ports are guessed produces a confidently wrong verdict (see the comment
+  above :func:`macro_interface`). ``CORESMITH_GATE_SIM_MACRO_MODEL=pdk`` opts
+  back into the PDK's own file for a simulator that honours delays.
 
 ENV GATES
 ---------
 ``CORESMITH_GATE_SIM``            default **ON**. ``0/false/no/off`` disables.
+``CORESMITH_GATE_SIM_SCOPE``      ``chip_top`` (default) | ``block`` | ``any``.
+                                  Which artifact the gate may judge; a subject
+                                  outside the scope is ``not_run`` with a reason.
 ``CORESMITH_GATE_SIM_STRICT``     default off. When on, a MISSING TOOLCHAIN
                                   (no Verilator, no PDK cell models) is a FAIL
                                   instead of a non-blocking ``not_run``.
@@ -88,6 +94,11 @@ ENV GATES
                                   at most this many cycles.
 ``CORESMITH_GATE_SIM_TIMEOUT_S``  default 1800.
 ``CORESMITH_GATE_SIM_MACRO_MODEL`` ``generated`` (default) | ``pdk``.
+``CORESMITH_GATE_SIM_DEBUG``      default off. TRIAGE AID: keep comparing past
+                                  the first divergence and report how many there
+                                  were in total. Does not change the verdict.
+``CORESMITH_GATE_SIM_MAX_DIVERGENCES`` default 32. How many mismatches the debug
+                                  mode records in full.
 
 FAIL SEMANTICS (fail-closed is the whole point)
 -----------------------------------------------
@@ -133,17 +144,58 @@ def _flag(name: str, default: bool) -> bool:
 
 
 def gate_sim_enabled() -> bool:
-    """Whether the post-synthesis gate-level simulation gate runs. Default ON.
+    """Whether the post-synthesis gate-level simulation gate runs.
 
-    Default-on matches the repo's other honest gates (synth, PnR route-DRC,
-    DRC-report fallback, read-timing) and is justified by what it closes: the
-    only check in the pipeline that ever exercises the artifact that becomes
-    silicon. Every other functional gate reads RTL, so with this off the
-    netlist is never simulated at all and a synthesis-side stub is invisible
-    end to end. Set ``CORESMITH_GATE_SIM=0`` to restore the pre-fix behaviour
-    (netlist never simulated).
+    **Default ON.** Nothing else in the flow simulates the artifact that becomes
+    silicon: every functional gate reads RTL, every PPA gate reads a netlist.
+
+    The gate was briefly turned default-OFF because it was MIS-SCOPED -- it ran
+    per block, and a per-block netlist is an intermediate whose stimulus is that
+    block's own testbench rather than real chip traffic. That is fixed by
+    :func:`gate_sim_scope`, not by disabling the gate: the default scope is now
+    ``chip_top``, so what is default-on is the judgement of the FLAT CHIP
+    NETLIST against the integration-DV vectors. Per-block replay still exists as
+    fast local feedback (``CORESMITH_GATE_SIM_SCOPE=block``) -- it is how a
+    synthesis-side stub scoring 143/144 line coverage was caught.
+
+    ``CORESMITH_GATE_SIM=0`` disables it entirely, which is recorded as
+    ``disabled`` with a reason that names what is no longer being checked.
     """
     return _flag(GATE_SIM_ENV, True)
+
+
+GATE_SIM_SCOPE_ENV = "CORESMITH_GATE_SIM_SCOPE"
+
+
+def gate_sim_scope() -> str:
+    """Which artifact this gate is allowed to judge. Default ``"chip_top"``.
+
+    A PER-BLOCK netlist is not what becomes silicon -- the integrated
+    ``chip_top`` netlist is -- and per-block replay uses that block's own
+    testbench vectors rather than real chip traffic. So the gate is scoped to
+    chip_top: any other subject is ``not_run`` with an explicit reason, never
+    a pass and never a failure.
+
+    ``CORESMITH_GATE_SIM_SCOPE=block`` opts back into per-block replay, which
+    is genuinely useful as fast local feedback -- it is how a synthesis-side
+    stub scoring 143/144 line coverage was caught. ``=any`` judges whatever it
+    is handed.
+
+    The chip-top subject is real: ``backend_graph`` runs this gate immediately
+    after ``flat_top_synthesis`` -- the first point at which a flat chip netlist
+    exists on disk -- and marks the subject ``is_chip_top``, so the guard admits
+    it (see :func:`block_is_chip_top`).
+    """
+    val = os.environ.get(GATE_SIM_SCOPE_ENV, "").strip().lower()
+    return val if val in {"block", "chip_top", "any"} else "chip_top"
+
+
+def block_is_chip_top(block: dict) -> bool:
+    """True when this subject is the integrated chip top, not a leaf block."""
+    if block.get("is_chip_top") or block.get("scope") == "chip_top":
+        return True
+    name = str(block.get("name", ""))
+    return name in {"chip_top", "integration"} or name.endswith("_chip_top")
 
 
 def gate_sim_strict() -> bool:
@@ -178,6 +230,41 @@ def gate_sim_timeout_s() -> int:
 def gate_sim_macro_model_mode() -> str:
     raw = (os.environ.get("CORESMITH_GATE_SIM_MACRO_MODEL", "") or "generated").strip().lower()
     return "pdk" if raw == "pdk" else "generated"
+
+
+GATE_SIM_DEBUG_ENV = "CORESMITH_GATE_SIM_DEBUG"
+
+
+def gate_sim_debug() -> bool:
+    """TRIAGE AID: keep comparing after the first divergence. Default off.
+
+    The default driver stops at the first mismatch, so ``cycles_compared`` reads
+    like a test length when it is really "where it stopped" -- 5151 of 200000
+    recorded vectors is 2.6% of the stimulus, and nothing says whether the
+    remaining 97% would have diverged once or ten thousand times. That is the
+    difference between "one wrong beat" and "the memory never writes", and it is
+    the first thing a human wants to know.
+
+    This does NOT change the verdict: one divergence has always been a FAIL and
+    still is. It only adds ``divergence_count`` and the first
+    :func:`gate_sim_max_divergences` mismatches to ``detail``. The default
+    verdict JSON is byte-for-byte unchanged, because the driver is generated
+    without the debug code at all when this is off.
+    """
+    return _flag(GATE_SIM_DEBUG_ENV, False)
+
+
+def gate_sim_max_divergences() -> int:
+    """How many individual mismatches debug mode records in full (default 32).
+
+    Bounded on purpose: a design whose memory never writes diverges on every
+    output beat, and 200000 recorded mismatches is not a report, it is a
+    denial of service on the reader. The COUNT is always exact.
+    """
+    try:
+        return max(1, int(os.environ.get("CORESMITH_GATE_SIM_MAX_DIVERGENCES", "") or 32))
+    except ValueError:
+        return 32
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +335,12 @@ class GateSimResult:
                 f"    expected : {div.get('expected')}   (RTL reference)",
                 f"    actual   : {div.get('actual')}   (gate netlist)",
             ]
+        # Only present when the run was made under CORESMITH_GATE_SIM_DEBUG: the
+        # default driver stops at the first mismatch, so it cannot know a total.
+        total = (self.detail or {}).get("divergence_count")
+        if total:
+            lines.append(f"    total    : {total} diverging port-cycles "
+                         f"(CORESMITH_GATE_SIM_DEBUG kept comparing)")
         lines += [
             "",
             "WHAT THIS MEANS: RTL DV, coverage and every PPA/PnR number were "
@@ -283,6 +376,37 @@ class Port:
     width: int = 1
     msb: int = 0
     lsb: int = 0
+
+
+_MODULE_DECL_RE = re.compile(r"^[ \t]*module[ \t]+([A-Za-z_][\w$]*)", re.MULTILINE)
+_INSTANCE_RE = re.compile(
+    r"^[ \t]*([A-Za-z_][\w$]*)[ \t]+(?:#\s*\([^;]*?\)\s*)?[A-Za-z_\\][\w$\\.\[\]]*[ \t]*\(",
+    re.MULTILINE,
+)
+
+
+def resolve_netlist_top(netlist_text: str) -> Optional[str]:
+    """Return the netlist's top module, derived from STRUCTURE not from a name.
+
+    The top is the one declared module that no other module instantiates. This
+    is deterministic and identifier-agnostic, which is the point: a block's
+    architectural name is chosen by the architecture agent and is NOT a stable
+    key. Keying a signoff gate off that name made it fail on a correctly
+    synthesized netlist whenever the name diverged from the mandated module
+    name (a Caravel ``user_project_wrapper``, a vendor-locked top).
+
+    Returns ``None`` when the answer is ambiguous -- zero candidates, or more
+    than one -- so the caller can FAIL rather than guess. A netlist with two
+    un-instantiated modules is not something to pick a winner from.
+    """
+    declared = set(_MODULE_DECL_RE.findall(netlist_text))
+    if not declared:
+        return None
+    instantiated = {m for m in _INSTANCE_RE.findall(netlist_text) if m in declared}
+    roots = declared - instantiated
+    if len(roots) == 1:
+        return roots.pop()
+    return None
 
 
 _MODULE_RE_TMPL = r"^[ \t]*module[ \t]+{top}[ \t]*\("
@@ -323,6 +447,71 @@ def parse_netlist_ports(netlist_text: str, top: str) -> list[Port]:
                      msb=hi, lsb=lo)
             )
     return ports
+
+
+# ---------------------------------------------------------------------------
+# Power/ground boundary nets
+# ---------------------------------------------------------------------------
+#
+# A tri-state SIGNAL boundary genuinely defeats vector replay: nothing tells the
+# driver when the pin is an input and when it is an output, so neither driving
+# nor comparing it is honest. A POWER RAIL declared ``inout`` is not that. It is
+# a constant, it carries no behaviour, and it is ``inout`` only because that is
+# the convention every PDK/harness uses for supplies.
+#
+# Refusing on any ``inout`` therefore made the gate structurally unable to judge
+# the one artifact it exists for: a Caravel ``user_project_wrapper``, whose ONLY
+# bidirectional ports are ``vdda1 vdda2 vssa1 vssa2 vccd1 vccd2 vssd1 vssd2``.
+# That is the artifact the external grader drives, so "no honest verdict is
+# available" was a hole exactly where the gate is supposed to be strongest.
+#
+# Conservative on purpose: recognition is by EXACT name against a curated list,
+# not by prefix or substring. An unrecognised inout is a SIGNAL and still vetoes
+# the gate -- mis-classifying a real tri-state as a rail would tie it to a
+# constant and then not compare it, i.e. fabricate a pass.
+_SUPPLY_INOUTS = frozenset({
+    "vdd", "vdd1v8", "vdd3v3", "vdda", "vdda1", "vdda2", "vddio", "vddd",
+    "vccd", "vccd1", "vccd2", "vccd3",
+    "vpwr", "vpb",          # cell-level views (VPWR / p-substrate bias)
+})
+_GROUND_INOUTS = frozenset({
+    "vss", "vssa", "vssa1", "vssa2", "vssio", "vssd", "vssd1", "vssd2", "vssd3",
+    "gnd", "vgnd", "vnb",   # cell-level views (VGND / n-well bias)
+})
+
+
+def power_inout_level(name: str) -> Optional[int]:
+    """``1`` for a supply rail, ``0`` for a ground rail, ``None`` otherwise.
+
+    ``None`` means "this is a signal", which is the safe answer: the caller then
+    declines to render a verdict at all. Only add a name here when it is a rail
+    in every context, because the consequence of a wrong entry is a pass that
+    ignored a real port.
+    """
+    key = str(name).lstrip("\\").strip().lower()
+    if key in _SUPPLY_INOUTS:
+        return 1
+    if key in _GROUND_INOUTS:
+        return 0
+    return None
+
+
+def split_inouts(ports: list[Port]) -> tuple[list[Port], list[Port]]:
+    """``(power_rails, signal_inouts)`` among the top's bidirectional ports.
+
+    A rail wider than one bit is not a rail we understand, so it is reported as a
+    signal rather than tied to a guessed constant.
+    """
+    rails: list[Port] = []
+    signals: list[Port] = []
+    for p in ports:
+        if p.direction != "inout":
+            continue
+        if p.width == 1 and power_inout_level(p.name) is not None:
+            rails.append(p)
+        else:
+            signals.append(p)
+    return rails, signals
 
 
 def pick_clock(ports: list[Port], hint: str = "") -> Optional[Port]:
@@ -673,8 +862,300 @@ def cell_model_files(
 # ---------------------------------------------------------------------------
 
 
-def macro_model_source(name: str, ports: str, data_bits: int, words: int,
-                       mask_bits: int = 0) -> str:
+# The stand-in's INTERFACE is read from the real macro's own Verilog, never
+# computed from registry metadata. Arithmetic on metadata got this wrong twice on
+# one design, in opposite directions:
+#
+#   * ``sram_1rw1r_8_4096_8`` (word_size == write_size == 8) declares NO
+#     ``wmask0`` port at all -- one whole-word mask bit IS the write enable, so
+#     OpenRAM legitimately omits it. The old generator emitted ``wmask0``
+#     unconditionally and gated writes on ``wmask0[0]``. The flat netlist
+#     correctly leaves the pin unconnected, Verilator ties the floating input
+#     low, EVERY write is suppressed, and every read returns zero -- a
+#     confident gate-sim FAIL on a correctly synthesized netlist.
+#   * ``sram_1rw1r_9_4096_8`` DOES declare ``wmask0``, as ``[1:0]``
+#     (NUM_WMASKS == ceil(9/8) == 2). The old generator computed ``9 // 8 == 1``
+#     and declared ``[0:0]``, so the netlist drove ``2'h3`` into a 1-bit port.
+#     Harmless only because that mask happens to be a constant.
+#
+# Both are one defect: a stand-in whose interface is GUESSED. The same guess also
+# hard-coded active-low ``csb0`` while the OpenROM mask-ROM models declare
+# active-HIGH ``cs0``, which would have inverted every ROM access.
+#
+# So: read the ports, the widths, the select polarity, the mask slices and the
+# ROM contents out of the macro. When any of that cannot be read, return "" --
+# the caller reports the macro as unresolved, which is a FAIL ("refusing to
+# simulate a design whose memories are undriven"). Never fall back to the guess.
+
+_MACRO_COMMENT_RE = re.compile(r"//[^\n]*|/\*.*?\*/", re.DOTALL)
+_MACRO_SUBPROG_RE = re.compile(
+    r"\bfunction\b.*?\bendfunction\b|\btask\b.*?\bendtask\b", re.DOTALL)
+_MACRO_PARAM_RE = re.compile(
+    r"\b(?:parameter|localparam)\b\s*(?:integer|signed)?\s*(?:\[[^\]]*\]\s*)?"
+    r"([A-Za-z_]\w*)\s*=\s*([^;,]+)")
+_MACRO_PORT_DECL_RE = re.compile(
+    r"\b(input|output|inout)\b\s+(?:(?:wire|reg|logic|signed)\s+)*"
+    r"(?:\[\s*([^:\]]+?)\s*:\s*([^\]]+?)\s*\]\s*)?([A-Za-z_]\w*)\s*(?=[;,)])")
+_MACRO_READMEM_RE = re.compile(r"\$readmem([bh])\s*\(\s*\"([^\"]+)\"")
+# The PDK model's own write-merge function is the GROUND TRUTH for which data
+# bits each mask bit covers -- including a partial final group (a 9-bit word
+# with write_size 8 has mask bit 1 covering exactly ``[8:8]``).
+_MACRO_MERGE_RE = re.compile(
+    r"if\s*\(\s*write_mask\s*\[\s*(\d+)\s*\]\s*\)\s*"
+    r"merge_write\d+\s*\[\s*(\d+)\s*:\s*(\d+)\s*\]")
+_MACRO_IDENT_RE = re.compile(r"[A-Za-z_]\w*")
+_MACRO_LITERAL_RE = re.compile(r"\b(\d+)'\s*([bodhBODH])\s*([0-9a-fA-FxzXZ_]+)")
+_MACRO_SAFE_EXPR_RE = re.compile(r"^[0-9+\-*/%()<>\s]+$")
+# Roles the generator understands. ``csb`` before ``cs`` so the active-low form
+# is not mis-read as the active-high one -- getting that backwards yields a
+# memory selected exactly when it should be idle.
+_MACRO_ROLE_RE = re.compile(r"^(clk|csb|cs|web|wmask|addr|din|dout)(\d+)$")
+
+
+def _macro_eval_int(expr: str, params: dict) -> Optional[int]:
+    """Evaluate one small integer expression out of a macro's own source.
+
+    Handles what OpenRAM/OpenROM actually write (``64``, ``1 << ADDR_WIDTH``,
+    ``DATA_WIDTH-1``, sized literals). Returns ``None`` for anything else --
+    an unresolvable width must propagate as "unknown", never as a default.
+    """
+    e = str(expr).strip().rstrip(";").strip()
+    if not e:
+        return None
+
+    def _lit(m: re.Match) -> str:
+        base = {"b": 2, "o": 8, "d": 10, "h": 16}[m.group(2).lower()]
+        try:
+            return str(int(m.group(3).replace("_", ""), base))
+        except ValueError:
+            return "?"
+
+    e = _MACRO_LITERAL_RE.sub(_lit, e)
+
+    def _ident(m: re.Match) -> str:
+        v = params.get(m.group(0))
+        return f"({v})" if isinstance(v, int) else "?"
+
+    e = _MACRO_IDENT_RE.sub(_ident, e)
+    if "?" in e or not _MACRO_SAFE_EXPR_RE.match(e):
+        return None
+    # Verilog `/` is integer division; every identifier is already substituted,
+    # so what is left is digits and operators only.
+    e = e.replace("/", "//")
+    try:
+        val = eval(e, {"__builtins__": {}}, {})  # noqa: S307 - whitelisted chars
+    except Exception:  # noqa: BLE001 - any arithmetic error means "unknown"
+        return None
+    return int(val) if isinstance(val, int) and not isinstance(val, bool) else None
+
+
+def _macro_params(text: str) -> dict:
+    """``{name: int}`` for every parameter whose value we can evaluate.
+
+    Iterated because a parameter may reference one declared later; a parameter we
+    cannot evaluate is simply absent, which only matters if a port width needs it.
+    """
+    params: dict = {}
+    pending = _MACRO_PARAM_RE.findall(text)
+    for _ in range(6):
+        rest = []
+        for nm, expr in pending:
+            val = _macro_eval_int(expr, params)
+            if val is None:
+                rest.append((nm, expr))
+            else:
+                params[nm] = val
+        if not rest or len(rest) == len(pending):
+            break
+        pending = rest
+    return params
+
+
+def _macro_balanced(text: str, open_at: int) -> tuple[str, int]:
+    """Text inside the parens starting at ``open_at``, and the index past them."""
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_at + 1:i], i + 1
+    return "", len(text)
+
+
+def _macro_split_power_guard(header: str) -> tuple[str, str]:
+    """Split a module header into (unguarded, ``USE_POWER_PINS``-guarded) text.
+
+    The supplies live behind ```ifdef USE_POWER_PINS`` and are NOT part of the
+    functional port list; treating them as ordinary ports would declare pins the
+    netlist never connects.
+    """
+    plain: list[str] = []
+    guarded: list[str] = []
+    stack: list[bool] = []
+    for line in header.splitlines():
+        s = line.strip()
+        if s.startswith("`"):
+            tok = s[1:].split()
+            kw = tok[0] if tok else ""
+            if kw in ("ifdef", "ifndef"):
+                arg = tok[1] if len(tok) > 1 else ""
+                stack.append(arg == "USE_POWER_PINS" and kw == "ifdef")
+            elif kw == "else" and stack:
+                stack[-1] = not stack[-1]
+            elif kw == "endif" and stack:
+                stack.pop()
+            continue
+        (guarded if any(stack) else plain).append(line)
+    return "\n".join(plain), "\n".join(guarded)
+
+
+def _macro_header_names(region: str) -> list[str]:
+    """Port names from a module header region, in declaration order.
+
+    Serves both header styles: non-ANSI (``clk0,csb0,addr0``) and ANSI
+    (``input wire [11:0] addr0``) -- in both, the LAST identifier of each
+    comma-separated item is the port name.
+    """
+    out: list[str] = []
+    depth = 0
+    item: list[str] = []
+    items: list[str] = []
+    for ch in region:
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        if ch == "," and depth == 0:
+            items.append("".join(item))
+            item = []
+            continue
+        item.append(ch)
+    items.append("".join(item))
+    for it in items:
+        ids = _MACRO_IDENT_RE.findall(it)
+        if ids and ids[-1] not in out:
+            out.append(ids[-1])
+    return out
+
+
+@dataclass
+class MacroIface:
+    """One hard macro's DECLARED interface, read from its own Verilog model.
+
+    Everything here is a fact stated by the macro, not a derivation from a name
+    or from registry metadata. ``ranges`` keeps the declared ``[msb:lsb]`` (not
+    just the width) so the stand-in's declaration is textually equivalent to the
+    real one.
+    """
+
+    name: str = ""
+    order: list = field(default_factory=list)      # port names, decl order
+    dirs: dict = field(default_factory=dict)       # name -> input/output/inout
+    ranges: dict = field(default_factory=dict)     # name -> (msb, lsb) or None
+    widths: dict = field(default_factory=dict)     # name -> declared width
+    power_pins: list = field(default_factory=list)  # USE_POWER_PINS-guarded
+    mask_slices: list = field(default_factory=list)  # [(hi, lo)] per mask bit
+    contents: str = ""                             # $readmem file, absolute
+    contents_radix: str = ""                       # "b" | "h"
+
+
+def macro_interface(name: str, verilog_path: str | Path) -> Optional[MacroIface]:
+    """Read one macro's declared interface out of its own Verilog model.
+
+    Returns ``None`` when the model cannot be read, its module cannot be found,
+    or any declared port's width cannot be resolved. ``None`` must degrade to
+    "macro unresolved" -> FAIL; it must never degrade to a guessed interface.
+
+    The port list is the module header's own, in declaration order. It is then
+    CROSS-CHECKED against
+    :func:`orchestrator.langgraph.macro_prebind.macro_ports` -- the same function
+    the pre-synthesis binder uses to decide which pins to CONNECT. If the binder
+    cannot see a port the header declares, the netlist will not connect it and
+    the stand-in would be modelling a different interface than the one being
+    simulated, so that disagreement returns ``None``. Note it must NOT resolve by
+    dropping the port: an absent input ties low, which is how every write got
+    silently suppressed in the first place.
+    """
+    p = Path(verilog_path)
+    if not str(verilog_path) or not p.is_file():
+        return None
+    try:
+        raw = p.read_text(errors="ignore")
+    except OSError:
+        return None
+
+    try:
+        from orchestrator.langgraph.macro_prebind import macro_ports
+    except Exception:  # pragma: no cover - import guard
+        return None
+    declared = macro_ports(p)
+    if not declared:
+        return None
+
+    text = _MACRO_COMMENT_RE.sub(" ", raw)
+    m = re.search(r"\bmodule\s+%s\b" % re.escape(name), text)
+    if not m:
+        return None
+    open_at = text.find("(", m.end())
+    if open_at < 0:
+        return None
+    header, past = _macro_balanced(text, open_at)
+    body = _MACRO_SUBPROG_RE.sub(" ", text[past:])
+    plain_hdr, guarded_hdr = _macro_split_power_guard(header)
+
+    iface = MacroIface(name=name)
+    iface.order = _macro_header_names(plain_hdr)
+    if not iface.order or any(n not in declared for n in iface.order):
+        return None
+    iface.power_pins = [n for n in _macro_header_names(guarded_hdr)
+                        if n in declared]
+
+    params = _macro_params(text)
+    # Declarations may be in the header (ANSI) or the body (non-ANSI); scan both.
+    # Subprograms are stripped from the body first so a function's own `input`
+    # declarations cannot be mistaken for ports.
+    for d in _MACRO_PORT_DECL_RE.finditer(plain_hdr + "\n" + body):
+        direction, msb, lsb, nm = d.group(1), d.group(2), d.group(3), d.group(4)
+        if nm not in iface.order or nm in iface.widths:
+            continue
+        if msb is None:
+            iface.dirs[nm] = direction
+            iface.ranges[nm] = None
+            iface.widths[nm] = 1
+            continue
+        hi, lo = _macro_eval_int(msb, params), _macro_eval_int(lsb, params)
+        if hi is None or lo is None:
+            return None          # a width we cannot resolve is not a width
+        iface.dirs[nm] = direction
+        iface.ranges[nm] = (hi, lo)
+        iface.widths[nm] = abs(hi - lo) + 1
+    if any(nm not in iface.widths for nm in iface.order):
+        return None              # a port with no resolvable declaration
+
+    for bit, hi, lo in _MACRO_MERGE_RE.findall(text):
+        iface.mask_slices.append((int(bit), int(hi), int(lo)))
+    iface.mask_slices = [(hi, lo) for _b, hi, lo in
+                         sorted(iface.mask_slices, key=lambda t: t[0])]
+
+    rm = _MACRO_READMEM_RE.search(text)
+    if rm:
+        iface.contents_radix = rm.group(1)
+        cand = Path(rm.group(2))
+        if not cand.is_absolute():
+            cand = p.parent / cand
+        iface.contents = str(cand)
+    return iface
+
+
+def _macro_range_str(rng) -> str:
+    return "" if rng is None else f"[{rng[0]}:{rng[1]}]"
+
+
+def macro_model_source(name: str, ports: str = "", data_bits: int = 0,
+                       words: int = 0, mask_bits: int = 0,
+                       iface: Optional[MacroIface] = None) -> str:
     """Generate a cycle-accurate simulation model for one hard memory macro.
 
     Reproduces the OpenRAM behavioural model's CYCLE semantics -- inputs
@@ -684,89 +1165,176 @@ def macro_model_source(name: str, ports: str, data_bits: int, words: int,
     redrive race that makes the PDK's own model unusable in a zero-delay
     simulator, and the per-access tracing that makes it unusable at scale.
 
-    Supports the ``1rw``/``1rw1r``/``1r`` port sets used by the sky130 SRAM and
-    ROM macro families. Returns ``""`` for an unrecognised port set, which the
-    caller reports as ``not_run`` (or FAIL under strict) rather than guessing.
+    ``iface`` (from :func:`macro_interface`) is REQUIRED and is the only source
+    of the port list, the port widths, the select polarity, the write-mask
+    slicing and the memory depth. ``ports``/``data_bits``/``words``/``mask_bits``
+    are registry metadata used for the header comment and as the fallback
+    mask granularity only -- they never decide what the interface looks like.
+    See the comment above :func:`macro_interface` for the two false verdicts
+    that deriving the interface arithmetically produced.
+
+    Returns ``""`` -- "unresolved", which the caller turns into a FAIL -- when
+    there is no ``iface``, when the macro declares a port this generator does not
+    understand, when the geometry is inconsistent, or when a read-only memory's
+    contents cannot be located. Guessing in any of those cases produces a
+    confident verdict about hardware that was never simulated.
     """
-    addr_bits = max(1, (words - 1).bit_length())
-    nmask = max(1, data_bits // mask_bits) if mask_bits else 1
-    has_rw = "rw" in ports
-    n_r = 0
-    m = re.search(r"(\d+)r(?!w)", ports)
-    if m:
-        n_r = int(m.group(1))
-    if not has_rw and n_r == 0:
+    if iface is None or not iface.order:
         return ""
 
+    # --- classify every declared port; refuse on anything unrecognised -------
+    roles: dict = {}
+    for nm in iface.order:
+        m = _MACRO_ROLE_RE.match(nm)
+        if not m:
+            return ""            # an unknown pin means we do not know this macro
+        role, idx = m.group(1), int(m.group(2))
+        if role in roles.setdefault(idx, {}):
+            return ""            # duplicate declaration
+        roles[idx][role] = nm
+    if not roles:
+        return ""
+
+    def _w(nm: str) -> int:
+        return int(iface.widths.get(nm, 0) or 0)
+
+    # --- geometry, entirely from the declarations ----------------------------
+    data_names = [r[k] for r in roles.values() for k in ("din", "dout") if k in r]
+    addr_names = [r["addr"] for r in roles.values() if "addr" in r]
+    if not data_names or not addr_names:
+        return ""
+    if len({_w(n) for n in data_names}) != 1:
+        return ""                # din/dout disagree: not a memory we understand
+    if len({_w(n) for n in addr_names}) != 1:
+        return ""
+    dwidth = _w(data_names[0])
+    awidth = _w(addr_names[0])
+    if dwidth <= 0 or awidth <= 0:
+        return ""
+    # Matches the PDK model exactly: ``RAM_DEPTH = 1 << ADDR_WIDTH``. Sizing from
+    # the registry's word count instead would leave an addressable index out of
+    # range for a non-power-of-two macro (e.g. a 127-word SRAM with 7 address
+    # bits).
+    depth = 1 << awidth
+    data_rng = _macro_range_str(iface.ranges.get(data_names[0]))
+    if not data_rng:
+        data_rng = "[0:0]"
+
     decl: list[str] = []
+    for nm in iface.order:
+        kw = "output reg" if iface.dirs.get(nm) == "output" else \
+             f"{iface.dirs.get(nm, 'input')}  wire"
+        rng = _macro_range_str(iface.ranges.get(nm))
+        decl.append(f"  {kw} {rng + ' ' if rng else ''}{nm};")
+
     body: list[str] = []
-    portnames: list[str] = []
-
-    if has_rw:
-        portnames += ["clk0", "csb0", "web0", "wmask0", "addr0", "din0", "dout0"]
-        decl += [
-            "  input  wire                    clk0;",
-            "  input  wire                    csb0;",
-            "  input  wire                    web0;",
-            f"  input  wire [{nmask - 1}:0]{' ' * 12}wmask0;",
-            f"  input  wire [{addr_bits - 1}:0] addr0;",
-            f"  input  wire [{data_bits - 1}:0] din0;",
-            f"  output reg  [{data_bits - 1}:0] dout0;",
-        ]
-        wr = []
-        if mask_bits and nmask > 1:
-            for i in range(nmask):
-                hi = (i + 1) * mask_bits - 1
-                lo = i * mask_bits
-                wr.append(f"        if (wmask0[{i}]) mem[addr0][{hi}:{lo}] "
-                          f"<= din0[{hi}:{lo}];")
+    for idx in sorted(roles):
+        r = roles[idx]
+        clk, addr = r.get("clk"), r.get("addr")
+        dout, din, web = r.get("dout"), r.get("din"), r.get("web")
+        if not clk or not addr or not dout:
+            return ""            # a port with no clock/address/data path
+        # Select polarity is READ, not assumed: OpenRAM SRAMs declare active-low
+        # `csb`, OpenROM mask ROMs declare active-high `cs`.
+        if "csb" in r:
+            sel = f"!{r['csb']}"
+        elif "cs" in r:
+            sel = r["cs"]
         else:
-            wr.append("        if (wmask0[0]) mem[addr0] <= din0;")
-        body.append(
-            "  always @(posedge clk0) begin\n"
-            "    if (!csb0) begin\n"
-            "      if (!web0) begin\n"
-            + "\n".join(wr) + "\n"
-            "      end else begin\n"
-            "        dout0 <= mem[addr0];\n"
-            "      end\n"
-            "    end\n"
-            "  end"
-        )
+            sel = "1'b1"
 
-    base = 1 if has_rw else 0
-    for k in range(n_r):
-        idx = base + k
-        portnames += [f"clk{idx}", f"csb{idx}", f"addr{idx}", f"dout{idx}"]
-        decl += [
-            f"  input  wire                    clk{idx};",
-            f"  input  wire                    csb{idx};",
-            f"  input  wire [{addr_bits - 1}:0] addr{idx};",
-            f"  output reg  [{data_bits - 1}:0] dout{idx};",
-        ]
-        body.append(
-            f"  always @(posedge clk{idx}) begin\n"
-            f"    if (!csb{idx}) dout{idx} <= mem[addr{idx}];\n"
-            f"  end"
-        )
+        if web and din:
+            wmask = r.get("wmask")
+            writes: list[str] = []
+            if wmask is None:
+                # The macro has NO write mask: word_size == write_size, so the
+                # write enable IS the mask. Gating on a pin that does not exist
+                # is how every write got silently dropped.
+                writes.append(f"        mem[{addr}] <= {din};")
+            else:
+                nmask = _w(wmask)
+                slices = list(iface.mask_slices)
+                if len(slices) != nmask:
+                    # No usable merge function in the model: fall back to the
+                    # registry's write granularity, but only if it reproduces the
+                    # DECLARED mask width exactly. Otherwise refuse.
+                    gran = int(mask_bits or 0)
+                    if gran <= 0 or -(-dwidth // gran) != nmask:
+                        return ""
+                    slices = [(min((i + 1) * gran - 1, dwidth - 1), i * gran)
+                              for i in range(nmask)]
+                if nmask == 1 and slices[0] == (dwidth - 1, 0):
+                    writes.append(f"        if ({wmask}[0]) mem[{addr}] <= {din};")
+                else:
+                    for i, (hi, lo) in enumerate(slices):
+                        writes.append(
+                            f"        if ({wmask}[{i}]) mem[{addr}][{hi}:{lo}] "
+                            f"<= {din}[{hi}:{lo}];")
+            body.append(
+                f"  always @(posedge {clk}) begin\n"
+                f"    if ({sel}) begin\n"
+                f"      if (!{web}) begin\n"
+                + "\n".join(writes) + "\n"
+                "      end else begin\n"
+                f"        {dout} <= mem[{addr}];\n"
+                "      end\n"
+                "    end\n"
+                "  end"
+            )
+        elif web or din:
+            return ""            # half a write port is not something to guess at
+        else:
+            body.append(
+                f"  always @(posedge {clk}) begin\n"
+                f"    if ({sel}) {dout} <= mem[{addr}];\n"
+                f"  end"
+            )
 
+    # A memory with no write port anywhere is a ROM: its behaviour IS its
+    # contents, so a stand-in that cannot load them would read zeros and hand
+    # back a verdict about hardware it never modelled.
+    writable = any("web" in r and "din" in r for r in roles.values())
+    init = ""
+    if iface.contents:
+        if not Path(iface.contents).is_file():
+            return ""
+        init = (f'  initial $readmem{iface.contents_radix or "b"}'
+                f'("{iface.contents}", mem, 0, {depth - 1});\n\n')
+    elif not writable:
+        return ""
+
+    pin_list = list(iface.order)
+    guard_hdr = guard_decl = ""
+    if iface.power_pins:
+        guard_hdr = ("`ifdef USE_POWER_PINS\n"
+                     + "".join(f"  {n},\n" for n in iface.power_pins)
+                     + "`endif\n")
+        guard_decl = ("`ifdef USE_POWER_PINS\n"
+                      + "".join(f"  inout {n};\n" for n in iface.power_pins)
+                      + "`endif\n")
+
+    geom = f"{ports or '?'}, {words or depth}w x {data_bits or dwidth}b"
     return (
         "// Generated by coresmith harness.gate_sim -- cycle-accurate stand-in\n"
-        f"// for hard macro {name} ({ports}, {words}w x {data_bits}b).\n"
+        f"// for hard macro {name} ({geom}).\n"
         "// The PDK's own behavioural model drives `#(T_HOLD) dout = 'bx;` from\n"
         "// a posedge block and re-drives on negedge: that races to destruction\n"
         "// in a zero-delay simulator, and its VERBOSE $display floods a\n"
         "// full-length gate run. Cycle semantics below match the PDK model.\n"
+        "//\n"
+        "// PORT LIST AND WIDTHS ARE READ FROM THE REAL MACRO'S OWN VERILOG --\n"
+        "// a port it does not declare must not appear here (an unconnected\n"
+        "// input ties low, which silently suppressed every write), and a port\n"
+        "// it does declare must have the same width.\n"
         "`default_nettype wire\n"
         "`timescale 1ns / 1ps\n\n"
         f"module {name} (\n"
-        "`ifdef USE_POWER_PINS\n"
-        "  inout wire vccd1,\n"
-        "  inout wire vssd1,\n"
-        "`endif\n"
-        "  " + ",\n  ".join(portnames) + "\n);\n"
+        + guard_hdr
+        + "  " + ",\n  ".join(pin_list) + "\n);\n"
+        + guard_decl
         + "\n".join(decl) + "\n\n"
-        f"  reg [{data_bits - 1}:0] mem [0:{words - 1}];\n\n"
+        f"  reg {data_rng} mem [0:{depth - 1}];\n\n"
+        + init
         + "\n\n".join(body) + "\n"
         "endmodule\n"
     )
@@ -778,7 +1346,8 @@ def macro_model_files(netlist_path: str | Path, work_dir: Path) -> tuple[list[st
     Returns ``(files, unresolved)``. ``unresolved`` names macros we could not
     model -- the caller must FAIL rather than simulate a design with an
     undriven memory (an unmodelled macro is a guaranteed false verdict, in
-    either direction).
+    either direction). A macro whose own Verilog cannot be read or parsed lands
+    here too: the interface is never guessed.
     """
     try:
         from orchestrator.langgraph import macro_registry
@@ -796,13 +1365,15 @@ def macro_model_files(netlist_path: str | Path, work_dir: Path) -> tuple[list[st
     unresolved: list[str] = []
     work_dir.mkdir(parents=True, exist_ok=True)
     for info in found:
-        if mode == "pdk" and getattr(info, "verilog", ""):
-            src = Path(info.verilog)
+        model = getattr(info, "verilog", "") or ""
+        if mode == "pdk" and model:
+            src = Path(model)
             if src.exists():
                 files.append(str(src))
                 continue
         src_text = macro_model_source(
             info.name, info.ports, info.data_bits, info.words, info.mask_bits,
+            iface=macro_interface(info.name, model),
         )
         if not src_text:
             unresolved.append(info.name)
@@ -839,15 +1410,39 @@ def write_if_changed(path: Path, text: str) -> None:
     path.write_text(text)
 
 
-def render_driver_cpp(top: str, ports: list[Port], clock: str) -> str:
+def render_driver_cpp(top: str, ports: list[Port], clock: str,
+                      debug: Optional[bool] = None,
+                      max_divergences: Optional[int] = None) -> str:
     """Generate the C++ testbench that replays the recorded vectors.
 
     Fully design-agnostic: the port list is derived from the netlist, so the
     same generator serves any design. The driver writes a JSON verdict and only
     ever reports success when it actually compared cycles AND bits.
+
+    Power/ground ``inout`` ports are tied to their own rail every cycle and never
+    compared -- see :func:`power_inout_level`. A non-power ``inout`` never reaches
+    here: :func:`check_gate_sim` declines to render a verdict on it.
+
+    ``debug`` (default: :func:`gate_sim_debug`) keeps comparing past the first
+    divergence and adds ``divergence_count`` plus the first ``max_divergences``
+    mismatches to the verdict. When it is off the debug code is not emitted at
+    all, so the default driver and its verdict JSON are unchanged.
     """
+    if debug is None:
+        debug = gate_sim_debug()
+    if max_divergences is None:
+        max_divergences = gate_sim_max_divergences()
     ins = [p for p in ports if p.direction == "input" and p.name != clock]
     outs = [p for p in ports if p.direction == "output"]
+    rails, _ = split_inouts(ports)
+
+    # Supplies are constants, but they are re-asserted every cycle: an `inout`
+    # can be driven from inside the netlist during eval(), and a rail that
+    # collapses mid-run would poison every cell it feeds.
+    tie: list[str] = [
+        f"    dut->{p.name} = {power_inout_level(p.name)};   // power rail, not compared"
+        for p in rails
+    ]
 
     drive: list[str] = []
     for i, p in enumerate(ins):
@@ -896,6 +1491,42 @@ def render_driver_cpp(top: str, ports: list[Port], clock: str) -> str:
     }}""")
 
     n_in, n_out = len(ins), len(outs)
+
+    # --- opt-in debug instrumentation ---------------------------------------
+    # Emitted only under CORESMITH_GATE_SIM_DEBUG so the default driver, its
+    # verdict JSON and its PASS/FAIL semantics are exactly as before.
+    if debug:
+        dbg_globals = f"""
+// CORESMITH_GATE_SIM_DEBUG: keep comparing after the first mismatch. The verdict
+// is unchanged (one divergence is still a FAIL); this only distinguishes "one
+// wrong beat" from "every beat is wrong", which the first-mismatch-only report
+// cannot.
+static const size_t DIV_LIMIT = {max_divergences};
+static std::vector<std::string> div_all;
+static long long div_count = 0;
+"""
+        dbg_record = """  div_count++;
+  if (div_all.size() < DIV_LIMIT) {
+    char buf[512];
+    snprintf(buf, sizeof(buf),
+             "{\\"cycle\\": %lld, \\"port\\": \\"%s\\", \\"expected\\": \\"%s\\", "
+             "\\"actual\\": \\"%s\\"}",
+             cycle, port, e.c_str(), to_bits(a, e.size()).c_str());
+    div_all.push_back(buf);
+  }
+"""
+        dbg_break = ("    // CORESMITH_GATE_SIM_DEBUG: do NOT stop at the first "
+                     "divergence.")
+        dbg_json = """  fprintf(jf, ", \\"divergence_count\\": %lld, \\"divergences\\": [",
+          div_count);
+  for (size_t i = 0; i < div_all.size(); i++)
+    fprintf(jf, "%s%s", i ? ", " : "", div_all[i].c_str());
+  fprintf(jf, "]");
+"""
+    else:
+        dbg_globals = dbg_record = dbg_json = ""
+        dbg_break = "    if (div_cycle >= 0) break;   // stop at the first divergence"
+
     return f"""// Generated by coresmith harness.gate_sim -- vector-replay driver for
 // the post-synthesis gate netlist of `{top}`. No cocotb, no design knowledge:
 // the port list below was parsed from the netlist itself.
@@ -935,7 +1566,7 @@ static void parse_wide(const std::string &v, uint32_t *w, int nw) {{
 
 static long long div_cycle = -1;
 static std::string div_port, div_exp, div_act;
-
+{dbg_globals}
 // Render the actual value in the SAME binary form as the recorded expected
 // value, so the divergence line in the report compares like with like.
 static std::string to_bits(uint64_t v, size_t width) {{
@@ -957,7 +1588,7 @@ static std::string word_bits(const std::string &e, int k) {{
 
 static void record(const char *port, long long cycle, const std::string &e,
                    uint64_t a) {{
-  if (div_cycle >= 0) return;
+{dbg_record}  if (div_cycle >= 0) return;
   div_cycle = cycle; div_port = port; div_exp = e;
   div_act = to_bits(a, e.size());
 }}
@@ -975,6 +1606,9 @@ int main(int argc, char **argv) {{
   std::string line;
   std::vector<std::string> in_tok({n_in}), out_tok({n_out});
 
+  // Power/ground boundary: bring the rails up before the first eval().
+{chr(10).join(tie) or "  // (none)"}
+
   while (std::getline(vf, line)) {{
     if (line.empty() || line[0] == '#') continue;
     size_t bar = line.find('|');
@@ -990,6 +1624,7 @@ int main(int argc, char **argv) {{
 
     // Apply the recorded pre-edge inputs and let combinational logic settle.
     dut->{clock} = 0;
+{chr(10).join(tie)}
 {chr(10).join(drive)}
     dut->eval();
 
@@ -1001,7 +1636,7 @@ int main(int argc, char **argv) {{
     dut->{clock} = 1; dut->eval();
     dut->{clock} = 0; dut->eval();
     cycle++;
-    if (div_cycle >= 0) break;   // stop at the first divergence
+{dbg_break}
   }}
 
   dut->final();
@@ -1012,11 +1647,12 @@ int main(int argc, char **argv) {{
           compared, bits_compared);
   if (div_cycle >= 0) {{
     fprintf(jf, "\\"diverged\\": true, \\"first_divergence\\": {{\\"cycle\\": %lld, "
-            "\\"port\\": \\"%s\\", \\"expected\\": \\"%s\\", \\"actual\\": \\"%s\\"}}}}\\n",
+            "\\"port\\": \\"%s\\", \\"expected\\": \\"%s\\", \\"actual\\": \\"%s\\"}}",
             div_cycle, div_port.c_str(), div_exp.c_str(), div_act.c_str());
   }} else {{
-    fprintf(jf, "\\"diverged\\": false, \\"first_divergence\\": {{}}}}\\n");
+    fprintf(jf, "\\"diverged\\": false, \\"first_divergence\\": {{}}");
   }}
+{dbg_json}  fprintf(jf, "}}\\n");
   fclose(jf);
   delete dut;
   return div_cycle >= 0 ? 1 : 0;
@@ -1148,15 +1784,20 @@ def check_gate_sim(
     sim_runner: Optional[Callable] = None,
     pdk_root: str | Path | None = None,
 ) -> GateSimResult:
-    """Run the post-synthesis gate-level simulation for one block.
+    """Run the post-synthesis gate-level simulation for one subject.
 
     ``sim_runner`` is injected by tests; it defaults to
     ``pipeline_helpers.run_simulation`` and must accept
     ``(block, rtl_path, tb_path, attempt, extra_defines=, sim_subdir=,
     extra_args=)``.
+
+    The two gates that decide whether a verdict is even ADMISSIBLE come first,
+    before anything is read off disk: the env switch (:func:`gate_sim_enabled`)
+    and the scope (:func:`gate_sim_scope`). "Off" outranks "out of scope" --
+    when the gate is off, that is the whole story, and a reader must not be told
+    a leaf block was skipped for scope reasons when nothing would have run.
     """
     block_name = block.get("name", "block")
-    top = block.get("top") or block_name
 
     if not gate_sim_enabled():
         return GateSimResult(
@@ -1164,6 +1805,44 @@ def check_gate_sim(
             reason=f"{GATE_SIM_ENV}=0 -- the synthesized netlist is NEVER "
                    f"simulated; a synthesis-side stub cannot be caught",
         )
+
+    scope = gate_sim_scope()
+    if scope == "chip_top" and not block_is_chip_top(block):
+        return GateSimResult(
+            ran=False, ok=True, status=STATUS_NOT_RUN,
+            reason=(f"scope={scope}: this gate only judges the integrated "
+                    f"chip_top netlist, and '{block_name or '?'}' is a "
+                    f"leaf block. A per-block netlist is not the artifact that "
+                    f"becomes silicon, and per-block replay drives it with that "
+                    f"block's own testbench rather than real chip traffic. Set "
+                    f"{GATE_SIM_SCOPE_ENV}=block for per-block replay."),
+        )
+
+    # Resolve the top from the NETLIST'S STRUCTURE, never from an identifier.
+    #
+    # A block's architectural name is chosen by the architecture agent and is
+    # not a stable key: when an external contract fixes the module name (a
+    # Caravel user_project_wrapper, a vendor-locked top), the block keeps its
+    # own name while the RTL declares the mandated one. Keying this gate off
+    # block_name made it FAIL CLOSED on a correctly synthesized netlist --
+    # "top module not found", 0 cycles compared -- and which way it went
+    # depended on whether the architecture agent happened to append a suffix.
+    #
+    # Precedence: an explicit block["top"] (a deliberate override) > the
+    # netlist's own root module > the RTL's declared module. The structural
+    # answer returns None when ambiguous rather than guessing.
+    top = block.get("top")
+    if not top:
+        try:
+            top = resolve_netlist_top(Path(netlist_path).read_text(errors="replace"))
+        except OSError:
+            top = None
+    if not top:
+        try:
+            from orchestrator.langgraph.pipeline_helpers import rtl_module_name
+            top = rtl_module_name(rtl_path, block_name)
+        except Exception:  # noqa: BLE001 - resolver is best-effort
+            top = block_name
 
     def _not_run(reason: str, **detail) -> GateSimResult:
         strict = gate_sim_strict()
@@ -1219,14 +1898,18 @@ def check_gate_sim(
     if clock is None:
         return _not_run("no clock port identified on the netlist top -- "
                         "cycle-accurate replay needs one")
-    inouts = [p.name for p in ports if p.direction == "inout"]
-    if inouts:
-        # A bidirectional boundary port is neither driven nor compared by the
-        # replay, so a PASS would carry a hole exactly where the gate is
-        # supposed to be strongest. Report it instead of hiding it.
+    rails, signal_inouts = split_inouts(ports)
+    if signal_inouts:
+        # A bidirectional SIGNAL is neither driven nor compared by the replay, so
+        # a PASS would carry a hole exactly where the gate is supposed to be
+        # strongest. Report it instead of hiding it. Power/ground rails are not
+        # this: they are constants, they are tied in the driver, and they are
+        # excluded from the comparison -- otherwise the gate could never judge a
+        # Caravel user_project_wrapper, whose only inouts are supplies, which is
+        # precisely the artifact the external grader drives.
         return _not_run(
             "the netlist top has bidirectional port(s) "
-            + ", ".join(inouts)
+            + ", ".join(p.name for p in signal_inouts)
             + " -- vector replay cannot drive or compare a tri-state boundary, "
               "so no honest verdict is available"
         )
@@ -1346,13 +2029,22 @@ def check_gate_sim(
         return _fail("gate simulation compared 0 output bits (every recorded "
                      "output was unknown) -- that is not a pass")
 
+    detail = {"work_dir": str(work_dir), "recorded_cycles": vec.cycles,
+              "seed": seed}
+    if rails:
+        detail["power_rails_tied"] = [p.name for p in rails]
+    # Present only when the run was built under CORESMITH_GATE_SIM_DEBUG: the
+    # default driver stops at the first mismatch and cannot know a total.
+    if raw.get("divergence_count") is not None:
+        detail["divergence_count"] = int(raw.get("divergence_count") or 0)
+        detail["divergences"] = raw.get("divergences") or []
+
     if raw.get("diverged"):
         res = _fail("the gate netlist diverges from the verified RTL")
         res.cycles_compared = cycles
         res.output_bits_compared = bits
         res.first_divergence = raw.get("first_divergence") or {}
-        res.detail = {"work_dir": str(work_dir), "recorded_cycles": vec.cycles,
-                      "seed": seed}
+        res.detail = detail
         return res
 
     return GateSimResult(
@@ -1361,18 +2053,23 @@ def check_gate_sim(
         netlist_path=netlist_path,
         cycles_compared=cycles,
         output_bits_compared=bits,
-        detail={"work_dir": str(work_dir), "recorded_cycles": vec.cycles,
-                "seed": seed, "macro_models": len(macro_files)},
+        detail={**detail, "macro_models": len(macro_files)},
     )
 
 
 __all__ = [
-    "GATE_SIM_ENV", "GateSimResult", "Port", "Vectors",
+    "GATE_SIM_ENV", "GATE_SIM_SCOPE_ENV", "GATE_SIM_DEBUG_ENV",
+    "GateSimResult", "MacroIface", "Port", "Vectors",
     "STATUS_PASS", "STATUS_FAIL", "STATUS_NOT_RUN", "STATUS_DISABLED",
-    "gate_sim_enabled", "gate_sim_strict", "gate_sim_max_cycles",
+    "gate_sim_enabled", "gate_sim_scope", "block_is_chip_top",
+    "gate_sim_strict", "gate_sim_max_cycles",
     "gate_sim_timeout_s", "gate_sim_macro_model_mode",
-    "parse_netlist_ports", "pick_clock", "extract_vectors", "write_vector_file",
-    "udp_shim_source", "cell_model_files", "macro_model_source",
+    "gate_sim_debug", "gate_sim_max_divergences",
+    "resolve_netlist_top", "parse_netlist_ports", "pick_clock",
+    "power_inout_level", "split_inouts",
+    "extract_vectors", "write_vector_file",
+    "udp_shim_source", "cell_model_files",
+    "macro_interface", "macro_model_source",
     "macro_model_files", "render_driver_cpp", "build_and_run_gate_sim",
     "write_if_changed",
     "check_gate_sim",

--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -577,14 +577,40 @@ def _run_chip_top_gate_sim(state: "BackendState", netlist: str) -> tuple:
         log(f"  [CHIP-GATE-SIM] not run -- {reason}", YELLOW)
         return (None, _gs.STATUS_NOT_RUN, reason)
 
-    top_rtl = state.get("top_rtl_path", "") or ""
-    log("  [CHIP-GATE-SIM] Replaying integration-DV vectors through the FLAT "
-        "chip netlist...", YELLOW)
+    # The reference stimulus is the integration DV's own source set, rebuilt
+    # from the SAME builder that DV used -- never a single path. `top_rtl_path`
+    # was read here originally and is NOT a BackendState field: nothing in the
+    # flow ever set it, so this gate reported not_run on every real run while
+    # its unit test passed by injecting the value itself.
+    from orchestrator.langgraph.integration_helpers import chip_rtl_sources
+
+    # Accept EITHER name. `integration_top_path` is what the backend graph's
+    # own init_design_node produces; `top_rtl_path` is what the frontend state
+    # and .coresmith/integration_result.json call the same artifact. The bug was
+    # never a misspelled key -- it was that NEITHER was populated here, so the
+    # gate silently self-disabled. Reading both, and failing loudly on neither,
+    # is what makes that impossible to reintroduce.
+    top_rtl_path = (state.get("integration_top_path", "")
+                    or state.get("top_rtl_path", "") or "")
+    block_rtl = state.get("block_rtl_paths", {}) or {}
+    if not top_rtl_path:
+        reason = ("no integration top on disk -- the assembled chip's RTL is "
+                  "the gate's reference; without it there is nothing to compare "
+                  "the flat netlist against")
+        log(f"  [CHIP-GATE-SIM] not run -- {reason}", YELLOW)
+        return (None, _gs.STATUS_NOT_RUN, reason)
+    # Dedup: on a Caravel design the assembled top and the pad-adapter block
+    # both declare `module user_project_wrapper`, which is a MODDUP abort.
+    rtl_sources = chip_rtl_sources(
+        top_rtl_path, block_rtl, dedup_dir=root / "sim_build" / "chip_gate_sim_srcs")
+
+    log(f"  [CHIP-GATE-SIM] Replaying integration-DV vectors through the FLAT "
+        f"chip netlist ({len(rtl_sources)} reference source file(s))...", YELLOW)
     try:
         res = _gs.check_gate_sim(
             block={"name": design, "is_chip_top": True},
             netlist_path=netlist,
-            rtl_path=top_rtl,
+            rtl_path=rtl_sources,
             tb_path=tb,
         )
     except Exception as exc:  # noqa: BLE001 - never crash the backend
@@ -692,6 +718,53 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
     except Exception as _exc:  # noqa: BLE001 - macro selection is best-effort
         log(f"  [FLAT-SYNTH] SRAM-macro directive setup skipped: {_exc!r}", YELLOW)
 
+    # --- Pre-synthesis macro binding ---------------------------------------
+    # cs_mem_macro_shell hard-assigns zero ("MACRO is a backend impl, not a sim
+    # model") and synthesis faithfully preserves that tie-off, so the flat
+    # netlist's memories read zero: PnR is fine (the shell is replaced by
+    # LEF/GDS at placement) but the design cannot be gate-simulated -- the
+    # first read of real data diverges. Binding used to run on the finished
+    # netlist and only recorded collateral for PnR. Resolve each geometry to a
+    # concrete macro HERE instead, and swap in a shell that instantiates it, so
+    # one artifact serves synthesis (via `read_verilog -lib`), PnR and sim.
+    if os.environ.get("CORESMITH_MACRO_PREBIND", "1").strip().lower() \
+            not in ("0", "false", "no", "off"):
+        try:
+            from orchestrator.langgraph import macro_prebind as _mp
+            _pb_srcs = [_p for _p in _input_paths if _p]
+            if _sram_wrapper_lib:
+                _pb_srcs.append(_sram_wrapper_lib)
+            _pb = _mp.resolve_prebindings(_pb_srcs, allow_generate=True)
+            for _w in _pb.warnings:
+                log(f"  [PREBIND] {_w}", YELLOW)
+            if _pb.errors or _pb.unresolved:
+                # Loud, and deliberately NOT substituted: a memory we cannot
+                # bind must not be quietly wired to something that reads zero.
+                for _e in _pb.errors:
+                    log(f"  [PREBIND] {_e}", RED)
+                for _u in _pb.unresolved:
+                    log(f"  [PREBIND] unresolved geometry: {_u.describe()}", RED)
+            elif _pb.bindings and _sram_wrapper_lib:
+                _pbs = _mp.prepare_synth_sources(
+                    _sram_wrapper_lib, _pb, Path(pr) / ".coresmith" / "prebind")
+                input_lines = [_l for _l in input_lines
+                               if "SRAM wrapper library" not in _l]
+                _sram_wrapper_lib = _pbs["wrapper_lib"]
+                input_lines.append(
+                    f"- SRAM wrapper library: `{_sram_wrapper_lib}`")
+                input_lines.append(
+                    "- Bound macro shell (REPLACES the zero-driving "
+                    f"cs_mem_macro_shell; read as a normal source): "
+                    f"`{_pbs['bound_shell']}`")
+                for _m in _pbs["models"]:
+                    input_lines.append(
+                        "- Macro model -- read with `read_verilog -lib` so only "
+                        f"its interface is taken and it is NOT synthesized: `{_m}`")
+                log(f"  [PREBIND] bound {len(_pb.bindings)} memory geometry(ies) "
+                    "to concrete macros before synthesis", YELLOW)
+        except Exception as _exc:  # noqa: BLE001
+            log(f"  [PREBIND] skipped: {_exc!r}", YELLOW)
+
     with _tracer.start_as_current_span(f"Flat Top Synthesis [{design_name}]") as span:
         span.set_attribute("design_name", design_name)
 
@@ -772,6 +845,10 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
             "chip_gate_sim_ok": _gs_ok,
             "chip_gate_sim_status": _gs_status,
             "chip_gate_sim_reason": _gs_reason,
+            # Hand diagnose something to work with. Only on a real FAIL: a
+            # not_run must not look like an error downstream.
+            **({"previous_error":
+                f"chip_top gate-sim FAIL: {_gs_reason}"} if _gs_ok is False else {}),
         }
     else:
         return {
@@ -901,11 +978,23 @@ def _composition_plan_bindings(
 
 
 def route_after_flat_synth(state: BackendState) -> str:
-    """Route after flat synthesis: success -> run_pnr, fail -> diagnose."""
+    """Route after flat synthesis: success -> run_pnr, fail -> diagnose.
+
+    A chip_top gate-sim FAIL is a synthesis failure, not an advisory. The flat
+    netlist provably does not reproduce the verified RTL, so P&R would harden a
+    design that does not work -- and it was recorded in state and ignored, which
+    is the one outcome an honest gate must not have.
+
+    ``chip_gate_sim_ok is None`` means the gate did not APPLY (disabled, no
+    integration TB, toolchain absent). That is not a verdict and must not block:
+    it is already logged with a reason at the point it happened.
+    """
     netlist = state.get("flat_netlist_path", "")
-    if netlist and Path(netlist).exists():
-        return "run_pnr"
-    return "diagnose"
+    if not (netlist and Path(netlist).exists()):
+        return "diagnose"
+    if state.get("chip_gate_sim_ok") is False:
+        return "diagnose"
+    return "run_pnr"
 
 
 route_after_flat_synth.__edge_labels__ = {
@@ -1957,7 +2046,14 @@ async def mpw_precheck_node(state: BackendState) -> dict:
     write_graph_event(pr, "MPW Precheck", "graph_node_exit", {
         "block": block_name,
         "pass": submission_ready,
-        "checks": {k: v.get("pass") for k, v in precheck_result.get("checks", {}).items()},
+        # Tri-state on purpose: True / False / None, where None is "could not
+        # be measured" (see langgraph.drc_verdict). Collapsing None to False
+        # would report a check that never ran as a check that FAILED, which is
+        # the exact dishonesty the verdict states were introduced to remove.
+        "checks": {
+            k: (v.get("pass") if v.get("status") != "not_run" else None)
+            for k, v in precheck_result.get("checks", {}).items()
+        },
         "assessment": analysis.get("assessment", ""),
         "graph": "backend",
     })

--- a/orchestrator/langgraph/bfm_lib/__init__.py
+++ b/orchestrator/langgraph/bfm_lib/__init__.py
@@ -12,8 +12,16 @@ families are a follow-on -- the classifier/codegen split is designed to grow a
 new ``*_contract`` + ``*_master_bfm`` per protocol.
 
 Public API:
+  * ``classify_bus_verdict(project_root, top_rtl_source, connections,
+    top_module, top_rtl_path)`` -> ``BusVerdict`` (is this a QSPI-slave chassis,
+    WHERE is the graded Caravel pin boundary, and will the integration sim
+    actually drive it?). Pin-driving callers must use this one: it separates
+    "not the graded boundary" (fail closed) from "not a QSPI design" (advisory).
   * ``classify_chip_bus(project_root, top_rtl_source, connections)`` ->
-    ``QSPIContract | None``  (is this chip-top a QSPI-slave? DUT-blind)
+    ``QSPIContract | None``  (is this chip a QSPI-slave? DUT-blind)
+  * ``find_pin_boundary(...)`` -> ``PinBoundary | None`` (which module declares
+    io_in/io_out/io_oeb, and in which file)
+  * ``boundary_gate_enabled()`` -> the fail-closed pin-boundary gate's env flag
   * ``build_plan_from_run(project_root, contract)`` -> ``StimulusPlan | None``
     (host-flow writes + expected OUT from the LLM golden reference)
   * ``plan_deterministic_dv(...)`` -> ``(contract, plan) | (None, None)``
@@ -27,11 +35,19 @@ import os
 from pathlib import Path
 
 from .classifier import (
+    STATUS_BOUNDARY_OFF_TOP,
+    STATUS_CONTRADICTION,
+    STATUS_NOT_QSPI,
+    STATUS_QSPI_TOP,
+    BusVerdict,
+    PinBoundary,
     arch_indicates_qspi_slave,
+    classify_bus_verdict,
     classify_chip_bus,
     describe_unmodeled_roles,
     detect_bus_roles,
     detect_dut_mastered_buses,
+    find_pin_boundary,
 )
 from .codegen import (
     render_bfm_module,
@@ -48,19 +64,28 @@ from .qspi_rom_bfm import QSPIRomContract, QSPIRomResponderBFM
 from .stimulus import StimulusPlan, build_plan_from_run
 
 __all__ = [
+    "STATUS_BOUNDARY_OFF_TOP",
+    "STATUS_CONTRADICTION",
+    "STATUS_NOT_QSPI",
+    "STATUS_QSPI_TOP",
+    "BusVerdict",
+    "PinBoundary",
     "QSPIContract",
     "QSPIMasterBFM",
     "QSPIRomContract",
     "QSPIRomResponderBFM",
     "StimulusPlan",
     "arch_indicates_qspi_slave",
+    "boundary_gate_enabled",
     "build_plan_from_run",
+    "classify_bus_verdict",
     "classify_chip_bus",
     "conformance_enabled",
     "describe_unmodeled_roles",
     "detect_bus_roles",
     "detect_dut_mastered_buses",
     "deterministic_bfm_enabled",
+    "find_pin_boundary",
     "plan_deterministic_dv",
     "render_bfm_module",
     "render_conformance_tb",
@@ -110,18 +135,61 @@ def conformance_enabled() -> bool:
     return deterministic_bfm_enabled()
 
 
+def boundary_gate_enabled() -> bool:
+    """True when the QSPI PIN-BOUNDARY gate fails the run CLOSED (default ON).
+
+    The gate fires when the run's spec says the external bus is QSPI but the
+    module integration DV elaborates does NOT expose the graded Caravel pin
+    boundary -- either because no ``io_in``/``io_out``/``io_oeb`` boundary exists
+    anywhere (spec/RTL contradiction) or because it lives on another module (the
+    ``user_project_wrapper`` the grader actually drives). Proceeding there means
+    silently keeping the DUT-co-tuned LLM BFM in exactly the runs most likely to
+    be non-conformant, so it is a gate, not a log line.
+
+    Overridable per the repo's gate idiom: ``CORESMITH_QSPI_BOUNDARY_GATE=0``
+    (or the single global rollback knob ``CORESMITH_GATE_FAIL_OPEN=1``) restores
+    the pre-fix advisory-only behavior -- the caller then keeps the LLM BFM but
+    records a carried-forward defect, so the bypass is never silent.
+
+    Scope note: the gate only reaches a run that opted into the deterministic
+    BFM campaign at all (see :func:`conformance_enabled`); with both BFM flags
+    unset this module is never consulted and behavior is byte-identical.
+    """
+    try:
+        from orchestrator.profile import flag_enabled
+        on = flag_enabled("CORESMITH_QSPI_BOUNDARY_GATE", default=True)
+    except Exception:  # noqa: BLE001 - a profile import hiccup must not break a gate
+        raw = (os.environ.get("CORESMITH_QSPI_BOUNDARY_GATE") or "").strip().lower()
+        on = raw not in ("0", "false", "no", "off")
+    if not on:
+        return False
+    try:
+        from orchestrator.langgraph.gate_guard import gate_fail_open_enabled
+        if gate_fail_open_enabled():
+            return False
+    except Exception:  # noqa: BLE001
+        pass
+    return True
+
+
 def plan_deterministic_dv(
     project_root: str,
     top_rtl_source: str,
     connections: list | None = None,
+    top_module: str = "",
+    top_rtl_path: str = "",
 ) -> tuple[QSPIContract | None, StimulusPlan | None]:
     """Classify the chip-top bus and, if QSPI-slave, build a host-flow plan.
 
     Returns ``(contract, plan)`` when a deterministic, contract-enforcing DV is
-    possible, else ``(None, None)`` -- the caller falls back to the LLM BFM with
-    a loud advisory.
+    possible, else ``(None, None)``. ``(None, None)`` alone does NOT tell you
+    whether this is an honest non-QSPI design or a spec/RTL disagreement that
+    must fail the run closed -- use :func:`classify_bus_verdict` for that.
     """
-    contract = classify_chip_bus(project_root, top_rtl_source, connections)
+    verdict = classify_bus_verdict(
+        project_root, top_rtl_source, connections, top_module, top_rtl_path
+    )
+    contract = verdict.contract if verdict.contract_enforcing else None
     if contract is None:
         return None, None
     plan = build_plan_from_run(project_root, contract)

--- a/orchestrator/langgraph/bfm_lib/classifier.py
+++ b/orchestrator/langgraph/bfm_lib/classifier.py
@@ -11,35 +11,241 @@ never inspects internal DUT logic (only the top-level port list, which is part
 of the public contract), so a non-conformant DUT cannot fool it into relaxing
 the contract.
 
-If the bus is not QSPI-slave (or the evidence is ambiguous), returns None -- the
-caller then keeps the existing LLM BFM and logs a loud advisory that the run's
-DV is NOT contract-enforcing.
+WHERE the boundary lives matters as much as whether it exists. The external
+grader drives the LOCKED Caravel pinout -- ``io_in``/``io_out``/``io_oeb`` on
+``user_project_wrapper`` -- so that, and only that, is the *graded boundary*. An
+assembled integration top whose own ports are design-prefixed (``qspi_io_in``,
+``qspi_io_out``, ``qspi_drive_en``) is **not** the graded boundary even though
+the chassis genuinely is QSPI-slave: those are different pins on a different
+module. :func:`find_pin_boundary` therefore looks past the assembled top into
+the project's Caravel wrapper (``rtl/user_project_wrapper.v`` and friends), and
+counts a wrapper only when it REALLY DECLARES the three pad busses as ports --
+a doc comment naming them (every hand-written wrapper has one) is not evidence.
+
+That look-past is DIAGNOSTIC, never compensating. Finding the wrapper does NOT
+re-point DV at it and does NOT let the run proceed: a boundary that is not the
+module the sim elaborates is reported as a FAILURE
+(:data:`STATUS_BOUNDARY_OFF_TOP`, identical fail-closed treatment to "no
+boundary at all"), with the wrapper's path in the message. The reason to look is
+that the wrapper's existence NAMES the upstream breakage -- the graded module was
+written but never made the top, typically because the Caravel pad-adapter block
+was dropped during assembly -- instead of leaving the operator with a vague "not
+a QSPI bus". Compensating for a mis-assembled chip by quietly driving a
+different module would hide exactly the defect this reports.
+
+:func:`classify_bus_verdict` reports the whole picture so the caller can never
+silently downgrade to the DUT-co-tuned LLM BFM:
+
+``qspi_slave_on_simulated_top``       the graded pins are on the module the
+                                     integration sim will elaborate -> the
+                                     deterministic BFM can drive them.
+``qspi_boundary_not_on_simulated_top`` the graded pins exist, but on another
+                                     module (typically the wrapper) -> the
+                                     integration sim is NOT driving the graded
+                                     boundary. Fail closed.
+``spec_says_qspi_but_no_pin_boundary`` the spec declares a QSPI bus and NO pad
+                                     boundary exists anywhere -> spec/RTL
+                                     CONTRADICTION. Fail closed.
+``not_qspi_slave``                    genuinely not a QSPI-slave chassis (no pad
+                                     boundary and nothing claims QSPI, or a pad
+                                     boundary with no QSPI corroboration) -> the
+                                     LLM BFM stays, with the historical advisory.
+
+:func:`classify_chip_bus` keeps its original contract-or-None shape. Callers
+that DRIVE pins must use :func:`classify_bus_verdict` and honor
+``boundary.is_simulated_top``: a contract alone no longer implies the sim's
+toplevel exposes ``io_in``/``io_out``/``io_oeb``.
 """
 
 from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 from .qspi_contract import QSPIContract
 
+# ---------------------------------------------------------------------------
+# the graded Caravel pin boundary
+# ---------------------------------------------------------------------------
+
+# The three pad busses the external harness drives. Matched with ``\b`` anchors,
+# so a design-prefixed lookalike (``qspi_io_in``) deliberately does NOT match:
+# it is a DIFFERENT boundary, and loosening this to a substring/suffix match
+# would classify a non-Caravel top as Caravel and then drive the wrong pins.
+_PAD_IO_PORTS: tuple[str, ...] = ("io_in", "io_out", "io_oeb")
+
+# Direction each pad bus must be DECLARED with (``inout`` tolerated for all
+# three -- some hand-written wrappers model the pads as bidirectional).
+_PAD_IO_DIRECTIONS: dict[str, tuple[str, ...]] = {
+    "io_in": ("input", "inout"),
+    "io_out": ("output", "inout"),
+    "io_oeb": ("output", "inout"),
+}
+
+# Mirrors ``integration_helpers.CARAVEL_TOP_MODULE`` (kept local: bfm_lib is
+# deliberately dependency-light and must import without the LangGraph stack).
+CARAVEL_TOP_MODULE = "user_project_wrapper"
+
+# Where a graded Caravel wrapper is conventionally written, relative to the
+# project root. Probed in this order, then a bounded sorted sweep of the RTL
+# tree, so discovery is deterministic (same project in -> same boundary out).
+_WRAPPER_CANDIDATES: tuple[str, ...] = (
+    "rtl/user_project_wrapper.v",
+    "verilog/rtl/user_project_wrapper.v",
+    "rtl/integration/user_project_wrapper.v",
+    "rtl/chip_top.v",
+)
+_WRAPPER_GLOBS: tuple[str, ...] = ("rtl/**/*.v", "verilog/rtl/**/*.v")
+_WRAPPER_SCAN_CAP = 400          # bound the sweep on a pathological tree
+_WRAPPER_MAX_BYTES = 4_000_000   # skip an implausibly large "RTL" file
+
+# classification statuses (see the module docstring)
+STATUS_QSPI_TOP = "qspi_slave_on_simulated_top"
+STATUS_BOUNDARY_OFF_TOP = "qspi_boundary_not_on_simulated_top"
+STATUS_CONTRADICTION = "spec_says_qspi_but_no_pin_boundary"
+STATUS_NOT_QSPI = "not_qspi_slave"
+
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
+_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+_MODULE_START_RE = re.compile(r"\bmodule\s+([A-Za-z_][\w$]*)")
+_DIR_RE = re.compile(r"\b(input|output|inout)\b")
+_NONANSI_DECL_RE = re.compile(r"\b(?:input|output|inout)\b[^;]*;")
+_IDENT_RE = re.compile(r"[A-Za-z_][\w$]*")
+
+# Type/attribute words that may sit between a direction keyword and the port
+# name; never port names themselves.
+_DECL_KEYWORDS = frozenset({
+    "input", "output", "inout", "wire", "reg", "logic", "bit", "signed",
+    "unsigned", "tri", "integer", "real", "supply0", "supply1", "var",
+    "parameter", "localparam", "genvar", "byte", "shortint", "int", "longint",
+})
+
+
+def _strip_comments(src: str) -> str:
+    """Comment-free copy of ``src`` (evidence must be code, not prose)."""
+    return _LINE_COMMENT_RE.sub("", _BLOCK_COMMENT_RE.sub(" ", src or ""))
+
+
+def _paren_group(text: str, open_idx: int) -> tuple[str, int]:
+    """``(inner_text, index_after_close)`` for the paren group at ``open_idx``."""
+    depth = 0
+    for i in range(open_idx, len(text)):
+        ch = text[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx + 1:i], i + 1
+    return text[open_idx + 1:], len(text)
+
+
+def _iter_modules(src: str) -> list[tuple[str, str]]:
+    """``[(module_name, module_text)]`` for each ``module .. endmodule``.
+
+    Comments are stripped first, so a header comment describing the Caravel
+    interface can never be mistaken for a port declaration.
+    """
+    text = _strip_comments(src)
+    out: list[tuple[str, str]] = []
+    for m in _MODULE_START_RE.finditer(text):
+        end = text.find("endmodule", m.end())
+        out.append((m.group(1), text[m.start():end if end != -1 else len(text)]))
+    return out
+
+
+def _port_decl_chunks(module_text: str) -> list[str]:
+    """The module's PORT DECLARATION text: the ANSI header + non-ANSI statements.
+
+    Internal ``wire``/``reg`` declarations and body code are excluded -- an
+    internal net named ``io_out`` is not a boundary.
+    """
+    chunks: list[str] = []
+    body = module_text
+    open_idx = module_text.find("(")
+    if open_idx != -1:
+        hash_idx = module_text.find("#")
+        if hash_idx != -1 and hash_idx < open_idx:
+            # `module m #(params) (ports);` -- skip the parameter list
+            _params, after = _paren_group(module_text, open_idx)
+            open_idx = module_text.find("(", after)
+        if open_idx != -1:
+            header, after = _paren_group(module_text, open_idx)
+            chunks.append(header)
+            body = module_text[after:]
+    chunks.extend(_NONANSI_DECL_RE.findall(body))
+    return chunks
+
+
+def _decl_identifiers(item: str) -> list[str]:
+    """Declared names in one declaration item (ranges/keywords removed)."""
+    txt = re.sub(r"\[[^\]]*\]", " ", item)
+    return [t for t in _IDENT_RE.findall(txt) if t not in _DECL_KEYWORDS]
+
+
+def declared_pad_ports(module_text: str) -> dict[str, str]:
+    """``{pad bus -> declared direction}`` for the Caravel pads this module DECLARES.
+
+    Evidence-based: only a real port declaration counts (an ANSI header entry or
+    a non-ANSI ``input``/``output`` statement) and the direction must be the one
+    the Caravel pinout mandates. A prose mention or an internal net does not
+    count, and ``qspi_io_in`` is not ``io_in``.
+    """
+    found: dict[str, str] = {}
+    for chunk in _port_decl_chunks(module_text):
+        direction = ""
+        for item in re.split(r"[;,]", chunk):
+            dirs = _DIR_RE.findall(item)
+            if dirs:
+                direction = dirs[-1]
+            if not direction:
+                continue
+            names = set(_decl_identifiers(item))
+            for sig in _PAD_IO_PORTS:
+                if sig in found or sig not in names:
+                    continue
+                if direction in _PAD_IO_DIRECTIONS[sig]:
+                    found[sig] = direction
+    return found
+
+
+def module_declares_pin_boundary(module_text: str) -> bool:
+    """True iff this module declares ALL THREE Caravel pad busses as ports."""
+    return len(declared_pad_ports(module_text)) == len(_PAD_IO_PORTS)
+
+
+def declared_port_names(module_text: str) -> list[str]:
+    """The module's declared port names, in declaration order (for diagnostics)."""
+    out: list[str] = []
+    for chunk in _port_decl_chunks(module_text):
+        direction = ""
+        for item in re.split(r"[;,]", chunk):
+            dirs = _DIR_RE.findall(item)
+            if dirs:
+                direction = dirs[-1]
+            if not direction:
+                continue
+            for name in _decl_identifiers(item):
+                if name not in out:
+                    out.append(name)
+    return out
+
 
 def _top_has_gpio_pin_boundary(top_rtl_source: str) -> bool:
-    """True if the top exposes the Caravel ``io_in``/``io_out``/``io_oeb`` bus.
+    """True if the given source declares the Caravel ``io_in``/``io_out``/``io_oeb``.
 
     This is the QSPI-slave chassis pin boundary (no AXI-Stream): the whole
-    external contract is pins on a standard off-chip bus. We require all three
-    (in/out/oeb) so a design that merely names ``io_in`` for something else is
-    not misclassified.
+    external contract is pins on a standard off-chip bus. All three (in/out/oeb)
+    must be DECLARED AS PORTS of some module in the source, so neither a design
+    that merely names ``io_in`` for something else nor a header comment
+    describing the Caravel interface is misclassified.
     """
-    src = top_rtl_source
-    have = 0
-    for sig in ("io_in", "io_out", "io_oeb"):
-        # a port declaration like `... io_in`  (input/output [..]/reg/wire)
-        if re.search(rf"\b{sig}\b", src):
-            have += 1
-    return have == 3
+    return any(
+        module_declares_pin_boundary(text)
+        for _name, text in _iter_modules(top_rtl_source)
+    )
 
 
 def _bus_protocol_says_qspi(project_root: str) -> bool:
@@ -216,25 +422,355 @@ def describe_unmodeled_roles(
     return roles["summary"]
 
 
+# ---------------------------------------------------------------------------
+# WHERE the graded boundary lives
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PinBoundary:
+    """The module that DECLARES the graded Caravel pad boundary, and where it is.
+
+    ``is_simulated_top`` is the load-bearing field: the deterministic BFM drives
+    ``dut.io_in`` / samples ``dut.io_out``, so it can only enforce the bus
+    contract when the module the integration sim elaborates is this one.
+    """
+
+    module: str
+    path: str = ""                       # file it was found in ("" -> from source text)
+    ports: tuple[str, ...] = ()          # the pad busses found, sorted
+    in_top_source: bool = False          # found in the assembled top's own source
+    is_simulated_top: bool = False       # the module the integration sim elaborates
+
+    def describe(self) -> str:
+        where = self.path or "the assembled top source"
+        return f"module '{self.module}' in {where}"
+
+
+@dataclass(frozen=True)
+class BusVerdict:
+    """Full, DUT-blind classification of the chip's external bus + its boundary."""
+
+    status: str
+    contract: QSPIContract | None = None
+    boundary: PinBoundary | None = None
+    spec_says_qspi: bool = False
+    connections_say_qspi: bool = False
+    simulated_top: str = ""
+    reason: str = ""
+    top_ports: tuple[str, ...] = ()
+
+    @property
+    def contract_enforcing(self) -> bool:
+        """True when a deterministic, contract-enforcing DV is actually possible."""
+        return self.status == STATUS_QSPI_TOP and self.contract is not None
+
+    @property
+    def fails_closed(self) -> bool:
+        """True when proceeding would silently keep the DUT-co-tuned LLM BFM.
+
+        Both cases are spec/RTL disagreements, not design choices: either the
+        graded pins are on a module the DV does not drive, or the spec claims a
+        QSPI bus that no RTL boundary implements.
+        """
+        return self.status in (STATUS_BOUNDARY_OFF_TOP, STATUS_CONTRADICTION)
+
+
+def resolve_simulated_top_module(
+    top_rtl_source: str, top_module: str = "", top_rtl_path: str = ""
+) -> str:
+    """The module cocotb will elaborate as ``TOPLEVEL`` for the integration sim.
+
+    MIRRORS ``run_integration_simulation``: the caller-supplied design/top module
+    when that module is declared in the top file, else the top file's stem.
+    Returns ``""`` when neither is known -- callers then accept a boundary found
+    ANYWHERE in the top source (the historical 3-argument behavior).
+    """
+    src = top_rtl_source or ""
+    if top_module and re.search(
+        rf"^\s*module\s+{re.escape(top_module)}\b", src, re.MULTILINE
+    ):
+        return top_module
+    if top_rtl_path:
+        return Path(top_rtl_path).stem
+    return ""
+
+
+def _wrapper_search_paths(project_root: str, skip: str = "") -> list[Path]:
+    """Deterministic candidate list of files that may declare the graded boundary."""
+    root = Path(project_root)
+    skip_resolved = ""
+    if skip:
+        try:
+            skip_resolved = str(Path(skip).resolve())
+        except OSError:
+            skip_resolved = skip
+    out: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(p: Path) -> None:
+        try:
+            key = str(p.resolve())
+        except OSError:
+            key = str(p)
+        if key in seen or key == skip_resolved or not p.is_file():
+            return
+        seen.add(key)
+        out.append(p)
+
+    for rel in _WRAPPER_CANDIDATES:
+        _add(root / rel)
+    for pattern in _WRAPPER_GLOBS:
+        try:
+            hits = sorted(root.glob(pattern))
+        except OSError:
+            hits = []
+        for p in hits:
+            if len(out) >= _WRAPPER_SCAN_CAP:
+                return out
+            _add(p)
+    return out
+
+
+def find_pin_boundary(
+    project_root: str,
+    top_rtl_source: str = "",
+    *,
+    top_module: str = "",
+    top_rtl_path: str = "",
+) -> PinBoundary | None:
+    """Locate the GRADED Caravel pad boundary for this project, or None.
+
+    Looks in the order that matters for DV:
+
+    1. the assembled top's own source -- preferring the module the integration
+       sim will actually elaborate (that is the only boundary the deterministic
+       BFM can drive);
+    2. failing that, the project's Caravel wrapper
+       (``rtl/user_project_wrapper.v`` and the other conventional locations,
+       then a bounded sorted sweep of the RTL tree).
+
+    A candidate counts ONLY if it really declares ``io_in``/``io_out``/``io_oeb``
+    as ports with the mandated directions -- never because a comment names them,
+    an internal net is called ``io_out``, or a port is *called something like*
+    ``qspi_io_in``. Returning a boundary whose ``is_simulated_top`` is False is
+    the honest answer "the graded pins exist, but not where DV is looking".
+
+    Step 2 does NOT nominate a replacement top. Its only effect is that the
+    fail-closed message can name the file the graded module was written to, which
+    points straight at the upstream defect (a pad-adapter block that never got
+    instantiated). Callers must not treat an ``is_simulated_top=False`` boundary
+    as drivable.
+    """
+    sim_top = resolve_simulated_top_module(top_rtl_source, top_module, top_rtl_path)
+    fallback: PinBoundary | None = None
+    for name, text in _iter_modules(top_rtl_source):
+        pads = declared_pad_ports(text)
+        if len(pads) != len(_PAD_IO_PORTS):
+            continue
+        is_sim_top = (not sim_top) or name == sim_top
+        cand = PinBoundary(
+            module=name,
+            path=top_rtl_path,
+            ports=tuple(sorted(pads)),
+            in_top_source=True,
+            is_simulated_top=is_sim_top,
+        )
+        if is_sim_top:
+            return cand
+        if fallback is None:
+            fallback = cand
+    if fallback is not None:
+        # A pad boundary sits in the top FILE but not on the simulated module --
+        # already conclusive (and more relevant than any other wrapper copy).
+        return fallback
+    for path in _wrapper_search_paths(project_root, skip=top_rtl_path):
+        try:
+            if path.stat().st_size > _WRAPPER_MAX_BYTES:
+                continue
+            src = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        mods = _iter_modules(src)
+        # Prefer the module literally named user_project_wrapper: on a Caravel
+        # chassis that is the graded module by definition.
+        for name, text in sorted(
+            mods, key=lambda kv: (0 if kv[0] == CARAVEL_TOP_MODULE else 1, kv[0])
+        ):
+            pads = declared_pad_ports(text)
+            if len(pads) != len(_PAD_IO_PORTS):
+                continue
+            return PinBoundary(
+                module=name,
+                path=str(path),
+                ports=tuple(sorted(pads)),
+                in_top_source=False,
+                is_simulated_top=bool(sim_top) and name == sim_top,
+            )
+    return None
+
+
+def _spec_evidence(project_root: str, connections: list | None) -> str:
+    bits = []
+    if _bus_protocol_says_qspi(project_root):
+        bits.append(".coresmith/{prd,ers}_spec.json dataflow.bus_protocol names QSPI")
+    if _connections_have_qspi(connections):
+        bits.append("an architecture connection references a qspi interface")
+    return "; ".join(bits) or "no QSPI evidence in the architecture artifacts"
+
+
+_OVERRIDE_NOTE = (
+    "Override (records a carried-forward defect instead of failing): "
+    "CORESMITH_QSPI_BOUNDARY_GATE=0, or the global CORESMITH_GATE_FAIL_OPEN=1."
+)
+
+_WHY_IT_MATTERS = (
+    "Without the graded pin boundary the only integration TB available is the "
+    "LLM-authored BFM, which CO-TUNES to the DUT: that is exactly how a "
+    "non-conformant read serializer passed CoreSmith DV and failed the real "
+    "fixed host (the AES bug the deterministic BFM exists to prevent)."
+)
+
+
+def classify_bus_verdict(
+    project_root: str,
+    top_rtl_source: str,
+    connections: list | None = None,
+    top_module: str = "",
+    top_rtl_path: str = "",
+) -> BusVerdict:
+    """Classify the external bus AND where its graded boundary lives.
+
+    This is the API a pin-driving caller must use: it distinguishes "not the
+    graded boundary" (loud, fail-closed) from "not a QSPI-slave design at all"
+    (an honest advisory), instead of collapsing both into ``None``.
+    """
+    spec_qspi = _bus_protocol_says_qspi(project_root)
+    conn_qspi = _connections_have_qspi(connections)
+    corroborated = spec_qspi or conn_qspi
+    sim_top = resolve_simulated_top_module(top_rtl_source, top_module, top_rtl_path)
+    boundary = find_pin_boundary(
+        project_root,
+        top_rtl_source,
+        top_module=top_module,
+        top_rtl_path=top_rtl_path,
+    )
+    top_ports: tuple[str, ...] = ()
+    for name, text in _iter_modules(top_rtl_source):
+        if not sim_top or name == sim_top:
+            top_ports = tuple(declared_port_names(text))
+            break
+
+    def _mk(status: str, contract: QSPIContract | None, reason: str) -> BusVerdict:
+        return BusVerdict(
+            status=status,
+            contract=contract,
+            boundary=boundary,
+            spec_says_qspi=spec_qspi,
+            connections_say_qspi=conn_qspi,
+            simulated_top=sim_top,
+            reason=reason,
+            top_ports=top_ports,
+        )
+
+    shown_ports = ", ".join(top_ports[:12]) or "(none parsed)"
+    if boundary is None:
+        if corroborated:
+            return _mk(
+                STATUS_CONTRADICTION,
+                None,
+                "SPEC/RTL CONTRADICTION: the architecture declares a QSPI bus ("
+                + _spec_evidence(project_root, connections)
+                + ") but NO Caravel pin boundary (io_in/io_out/io_oeb declared as "
+                "ports) exists anywhere in this project -- not on the simulated "
+                f"top '{sim_top or '(unknown)'}' (ports: {shown_ports}) and not in "
+                "any of rtl/user_project_wrapper.v, verilog/rtl/"
+                "user_project_wrapper.v, rtl/chip_top.v or the rtl/ tree. The "
+                "external grader drives io_in/io_out/io_oeb on "
+                f"{CARAVEL_TOP_MODULE}, so integration DV cannot enforce the bus "
+                "contract on any module that exists. " + _WHY_IT_MATTERS + " Fix "
+                "the disagreement: assemble/keep the graded "
+                f"{CARAVEL_TOP_MODULE} (pad-adapter block + "
+                "CORESMITH_DETERMINISTIC_CARAVEL_TOP=1), or correct the spec's "
+                "bus_protocol if this design genuinely has no QSPI pin boundary. "
+                + _OVERRIDE_NOTE,
+            )
+        return _mk(
+            STATUS_NOT_QSPI,
+            None,
+            "not a QSPI-slave chassis: no Caravel pin boundary "
+            "(io_in/io_out/io_oeb) is declared anywhere and nothing in the "
+            "architecture artifacts claims a QSPI bus "
+            f"({_spec_evidence(project_root, connections)}).",
+        )
+    if not corroborated:
+        return _mk(
+            STATUS_NOT_QSPI,
+            None,
+            f"a Caravel pin boundary exists ({boundary.describe()}) but the "
+            "architecture artifacts never name a QSPI bus "
+            f"({_spec_evidence(project_root, connections)}) -- not classified as "
+            "QSPI-slave, so the standard QSPI contract is not imposed.",
+        )
+    contract = QSPIContract(**_reg_map_overrides(project_root))
+    if boundary.is_simulated_top:
+        return _mk(
+            STATUS_QSPI_TOP,
+            contract,
+            f"QSPI-slave chassis on the simulated top: {boundary.describe()} "
+            f"declares {', '.join(boundary.ports)}.",
+        )
+    return _mk(
+        STATUS_BOUNDARY_OFF_TOP,
+        contract,
+        "GRADED BOUNDARY IS NOT THE SIMULATED TOP: this IS a QSPI-slave chassis "
+        f"({_spec_evidence(project_root, connections)}) and the graded Caravel "
+        f"pin boundary is declared by {boundary.describe()} "
+        f"({', '.join(boundary.ports)}) -- but integration DV elaborates "
+        f"'{sim_top or '(unknown)'}', whose ports are: {shown_ports}. Those are "
+        "DIFFERENT pins on a DIFFERENT module: a design-prefixed group such as "
+        "qspi_io_in/qspi_io_out/qspi_drive_en is not the graded io_in/io_out/"
+        "io_oeb, so the deterministic BFM cannot drive the boundary the grader "
+        "drives. " + _WHY_IT_MATTERS + " LIKELY UPSTREAM CAUSE: the graded "
+        f"module was written but never instantiated -- the {CARAVEL_TOP_MODULE} "
+        "pad-adapter block was dropped during assembly (e.g. its RTL never "
+        "resolved from the block spec's rtl_target, so integration_check parsed "
+        "N-1 blocks and the deterministic Caravel assembler never ran). Fix "
+        f"THERE, by making the graded {CARAVEL_TOP_MODULE} the integration top "
+        "(pad-adapter block present + CORESMITH_DETERMINISTIC_CARAVEL_TOP=1) -- "
+        "not here: this classifier deliberately does NOT retarget DV at the "
+        f"wrapper it found in {boundary.path or 'the top source'}, because "
+        "driving a module the assembled chip does not use would hide the "
+        "mis-assembly. " + _OVERRIDE_NOTE,
+    )
+
+
 def classify_chip_bus(
     project_root: str,
     top_rtl_source: str,
     connections: list | None = None,
+    top_module: str = "",
+    top_rtl_path: str = "",
 ) -> QSPIContract | None:
-    """Return a QSPIContract if the chip-top external bus is QSPI-slave, else None.
+    """Return a QSPIContract if this chip's external bus is QSPI-slave, else None.
 
     Decision (all DUT-blind):
-      * REQUIRED: the top exposes the Caravel ``io_in``/``io_out``/``io_oeb``
-        pin boundary (the QSPI-slave chassis; no AXI-Stream).
+      * REQUIRED: the GRADED Caravel ``io_in``/``io_out``/``io_oeb`` pin boundary
+        is declared somewhere in the project -- on the assembled top, or (when
+        the top's own pins are design-prefixed) in the project's Caravel wrapper.
+        A wrapper counts only if it really declares the three pad busses.
       * plus at least one corroborating signal: the PRD/ERS bus_protocol names
         QSPI, or an architecture connection references a qspi interface.
+
+    NOTE for pin-driving callers: a contract here does NOT promise that the
+    module your sim elaborates exposes the pads. Use :func:`classify_bus_verdict`
+    and honor ``boundary.is_simulated_top`` / ``verdict.fails_closed``.
     """
-    if not _top_has_gpio_pin_boundary(top_rtl_source):
-        return None
-    corroborated = _bus_protocol_says_qspi(project_root) or _connections_have_qspi(
-        connections
+    verdict = classify_bus_verdict(
+        project_root,
+        top_rtl_source,
+        connections,
+        top_module=top_module,
+        top_rtl_path=top_rtl_path,
     )
-    if not corroborated:
-        return None
-    overrides = _reg_map_overrides(project_root)
-    return QSPIContract(**overrides)
+    return verdict.contract

--- a/orchestrator/langgraph/drc_verdict.py
+++ b/orchestrator/langgraph/drc_verdict.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Honest DRC verdicts: "could not measure" is a state of its own.
+
+THE DEFECT THIS CLOSES
+----------------------
+The macro DRC stage (``bin/gen_ram`` -> ``_run_magic_drc_on_gds``) rendered a
+DRC run that produced NO REPORT AT ALL as::
+
+    {"pass": false, "violation_count": -1}   ->   stage {"ok": false, "violations": -1}
+
+Two real macros in ``exp-raster-macro-20260727`` (``w32_d64``, ``w9_d512``)
+carry exactly that, and the ``precheck_magic_drc.rpt`` those verdicts name was
+never written -- Magic produced nothing even though the binary was on PATH.
+``-1`` was *intended* as a "could not measure" sentinel, but every consumer read
+``ok: false`` / a negative count as "this macro HAS DRC violations", and the
+macro was marked FAIL for a measurement that never happened.
+
+That is the proxy-not-property dishonesty the engine's honest gates exist to
+prevent: absence of evidence rendered as evidence of failure -- and, in the
+KLayout sibling (a missing XML report counted as ``violation_count = 0``),
+absence of evidence rendered as evidence of SUCCESS. Both are false verdicts;
+neither is a DRC measurement.
+
+THE VOCABULARY
+--------------
+Deliberately the SAME words :mod:`orchestrator.harness.gate_sim` uses, IMPORTED
+from it rather than re-spelled, so the engine has exactly one status vocabulary:
+
+``pass``     the DRC tool completed, wrote a non-empty report, and that report
+             yielded a parseable count of ZERO. A real clean result.
+``fail``     a real, measured violation count of N > 0.
+``not_run``  NO MEASUREMENT EXISTS: no report, an empty report, a tool that
+             never started / died / timed out, or a report carrying no parseable
+             count. Neither clean nor dirty. It ALWAYS carries a ``reason``
+             naming why nothing could be measured, and it is NEVER ``pass``.
+
+FAIL-CLOSED RULES (in the order :func:`classify_drc` applies them)
+-----------------------------------------------------------------
+1. A POSITIVE count is a real measurement whatever the tool's exit status -- a
+   report holding violation rects is evidence even from a tool that then died.
+   So N > 0 is always ``fail``.
+2. Everything else is only a CANDIDATE "clean", and clean must be EARNED by
+   positive evidence: tool completed AND report exists AND report is non-empty
+   AND the count parsed. Any missing link is ``not_run`` with a reason, never a
+   pass and never a fabricated count.
+3. ``violation_count`` is ``None`` when unmeasured. It is NEVER ``-1``: a
+   negative "count" invites arithmetic (``count != 0`` -> "dirty",
+   ``count >= 0`` -> "measured") that silently converts absence into a verdict.
+
+This module is pure and import-cheap (stdlib + the gate_sim status constants).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestrator.harness.gate_sim import (
+    STATUS_FAIL,
+    STATUS_NOT_RUN,
+    STATUS_PASS,
+)
+
+__all__ = [
+    "STATUS_FAIL",
+    "STATUS_NOT_RUN",
+    "STATUS_PASS",
+    "classify_drc",
+    "drc_stage",
+    "drc_summary",
+    "unmeasured_drc",
+]
+
+# The legacy sentinel the producers used to emit for "no verdict". Kept only so
+# a value arriving from older code/JSON is normalized to the honest ``None``.
+LEGACY_UNMEASURED_COUNT = -1
+
+_NOT_A_COUNT = (
+    " This is NOT a violation count and NOT a clean result -- no DRC "
+    "measurement exists for this layout."
+)
+
+
+def _verdict(status: str, reason: str, count: int | None,
+             report_path: str, tool: str) -> dict:
+    v: dict = {
+        "tool": tool,
+        "status": status,
+        "reason": reason,
+        # `measured` is the question every consumer actually wants answered:
+        # does a violation count exist at all?
+        "measured": status in (STATUS_PASS, STATUS_FAIL),
+        # `pass` is True ONLY for a real clean measurement. Kept for the
+        # existing precheck consumers, which stay fail-closed on not_run.
+        "pass": status == STATUS_PASS,
+        # None -- never -1 -- when nothing was measured.
+        "violation_count": count,
+        "report_path": str(report_path or ""),
+    }
+    if status == STATUS_NOT_RUN:
+        # Readers that only surface `error` (e.g. tapeout_diagnosis) still say
+        # WHY there is no measurement instead of printing a bare "-1".
+        v["error"] = reason
+    return v
+
+
+def unmeasured_drc(reason: str, *, report_path: str = "",
+                   tool: str = "Magic") -> dict:
+    """An explicit "no DRC measurement exists" verdict.
+
+    For callers that know up front that no DRC ran (e.g. a generator whose
+    config disables DRC). Never a pass, never a count, always a reason.
+    """
+    return _verdict(STATUS_NOT_RUN, reason.strip() or "no reason recorded",
+                    None, report_path, tool)
+
+
+def classify_drc(*, violation_count: int | None, report_path: str = "",
+                 tool_ran: bool = True, tool_error: str = "",
+                 tool: str = "Magic") -> dict:
+    """Classify one DRC attempt into ``pass`` / ``fail`` / ``not_run``.
+
+    Args:
+        violation_count: the count the tool reported, or ``None``/negative when
+            no count could be parsed. Negative is treated as UNMEASURED.
+        report_path: the report the verdict claims to be derived from. Its
+            existence and emptiness are checked here -- a verdict that names a
+            report which was never written is the bug this module closes.
+        tool_ran: did the tool actually complete (returncode 0 / no exception)?
+        tool_error: tool diagnostics, folded into the ``reason`` when it failed.
+        tool: tool name, for human-readable reasons ("Magic", "KLayout", ...).
+    """
+    count = violation_count
+    if isinstance(count, bool):
+        count = None
+    if count is not None:
+        try:
+            count = int(count)
+        except (TypeError, ValueError):
+            count = None
+    if count is not None and count < 0:
+        count = None  # legacy -1 sentinel: absence, not a count
+
+    rp = str(report_path or "")
+
+    # Rule 1: a positive count is a measurement, however the tool exited.
+    if count is not None and count > 0:
+        where = f" in {rp}" if rp else ""
+        return _verdict(STATUS_FAIL,
+                        f"{tool} DRC measured {count} violation(s){where}",
+                        count, rp, tool)
+
+    # Rules 2/3: "clean" must be earned by positive evidence.
+    if not tool_ran:
+        detail = (tool_error or "").strip()
+        why = (f"{tool} did not complete, so it produced no DRC measurement"
+               + (f": {detail[:400]}" if detail else
+                  " (no tool diagnostics were captured)"))
+        return unmeasured_drc(why + _NOT_A_COUNT, report_path=rp, tool=tool)
+
+    if not rp:
+        return unmeasured_drc(
+            f"no DRC report path was recorded for {tool}, so nothing could be "
+            f"counted." + _NOT_A_COUNT, report_path=rp, tool=tool)
+
+    p = Path(rp)
+    if not p.is_file():
+        return unmeasured_drc(
+            f"{tool} left NO DRC report at {p} -- the report this verdict "
+            f"would be derived from does not exist." + _NOT_A_COUNT,
+            report_path=rp, tool=tool)
+
+    try:
+        text = p.read_text(errors="replace")
+    except OSError as exc:
+        return unmeasured_drc(
+            f"the DRC report {p} could not be read ({exc})." + _NOT_A_COUNT,
+            report_path=rp, tool=tool)
+
+    if not text.strip():
+        try:
+            size = p.stat().st_size
+        except OSError:
+            size = 0
+        return unmeasured_drc(
+            f"the DRC report {p} is EMPTY ({size} bytes) -- {tool} wrote a "
+            f"file but no result into it." + _NOT_A_COUNT,
+            report_path=rp, tool=tool)
+
+    if count is None:
+        return unmeasured_drc(
+            f"{tool} wrote {p} but it carries no parseable violation count, so "
+            f"the layout was never actually judged." + _NOT_A_COUNT,
+            report_path=rp, tool=tool)
+
+    return _verdict(STATUS_PASS, f"{tool} DRC clean: 0 violations in {p}",
+                    0, rp, tool)
+
+
+def drc_summary(verdict: dict) -> str:
+    """One line for a human / LLM / log reader.
+
+    An unmeasured DRC says so IN WORDS, so no reader has to infer it from a
+    bare ``-1`` (which reads as a violation) or a bare ``0`` (which reads as
+    clean).
+    """
+    verdict = verdict or {}
+    status = verdict.get("status") or STATUS_NOT_RUN
+    tool = verdict.get("tool") or "DRC"
+    if status == STATUS_PASS:
+        return f"{tool} DRC: clean, 0 violations"
+    if status == STATUS_FAIL:
+        return f"{tool} DRC: {verdict.get('violation_count')} violation(s)"
+    return (f"{tool} DRC COULD NOT BE MEASURED (status={STATUS_NOT_RUN}): "
+            f"{verdict.get('reason') or 'no reason recorded'}")
+
+
+def drc_stage(verdict: dict) -> dict:
+    """Render a verdict as a ``gen_ram``-report ``stages[...]`` entry.
+
+    ``ok`` is TRI-STATE and deliberately so:
+
+    * ``True``  -- measured clean.
+    * ``False`` -- measured N > 0 violations.
+    * ``None``  -- NOT MEASURED. It is not ``False`` (that claims violations
+      were found) and not ``True`` (that claims clean). ``if not ok`` still
+      treats it as non-passing, so nothing downstream can read it as success,
+      while ``ok is None`` tells a reader that checks the difference.
+
+    ``violations`` is ``None`` when unmeasured -- never ``-1``.
+    """
+    verdict = verdict or {}
+    status = verdict.get("status") or STATUS_NOT_RUN
+    ok: bool | None
+    if status == STATUS_PASS:
+        ok = True
+    elif status == STATUS_FAIL:
+        ok = False
+    else:
+        ok = None
+    return {
+        "ok": ok,
+        "status": status,
+        "measured": bool(verdict.get("measured")),
+        "violations": verdict.get("violation_count"),
+        "reason": verdict.get("reason", ""),
+        "report_path": verdict.get("report_path", ""),
+        "detail": drc_summary(verdict),
+    }

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -22,10 +22,12 @@ from pathlib import Path
 
 from orchestrator.langgraph.pipeline_helpers import (
     PROJECT_ROOT,
+    RED,
     _write_step_log,
     _write_step_log_error,
     apply_build_fingerprint,
     clear_build_products,
+    log,
     run_wavekit_vcd_audit,
 )
 
@@ -1006,6 +1008,41 @@ def generate_caravel_wrapper_top(
                 return p
         return None
 
+    def _channel_fields(bn: str, chan: str) -> list[VerilogPort]:
+        """Ports implementing a CHANNEL named ``chan``, ordered by suffix.
+
+        A contract edge names a channel; the RTL exposes it prefix-expanded
+        (contract ``framebuffer_read`` -> ports ``framebuffer_read_req_addr``,
+        ``framebuffer_read_read_enable``, ``framebuffer_read_rdata``,
+        ``framebuffer_read_rvalid``, ``framebuffer_read_fault``). Without this,
+        every such edge failed ``_port_exact``, counted as a wiring hazard, and
+        took the whole deterministic Caravel assembly down with it -- on this
+        engine's own RTL conventions, i.e. always.
+
+        Ordered by the suffix FOLLOWING the prefix, so when both sides name the
+        same channel the caller's positional pairing is suffix-to-suffix. Shared
+        clock/reset, power pins and the wrapper's pad vector are excluded for the
+        same reasons ``_bundle_ports`` excludes them: they are wired globally,
+        not per edge.
+
+        Returns [] when nothing matches, which the caller already treats as a
+        hazard. This only ever ADDS resolutions -- every width, count and suffix
+        check downstream still applies.
+        """
+        pre = str(chan).lower() + "_"
+        out: list[tuple[str, VerilogPort]] = []
+        for p in modules[bn].ports:
+            low = p.name.lower()
+            if not low.startswith(pre) or len(low) == len(pre):
+                continue
+            if _wrap_shared_signal(p.name) or _is_power_pin(p.name):
+                continue
+            if bn == wrapper_block and p.name in _PAD_IO_PORTS:
+                continue
+            out.append((low[len(pre):], p))
+        out.sort(key=lambda t: t[0])
+        return [p for _sfx, p in out]
+
     keyed = {bn: _bundle_ports(bn) for bn in modules}
     uf = _WireUnion()
     # Wiring hazards that make the deterministic top UNSAFE. When non-empty the
@@ -1038,9 +1075,16 @@ def generate_caravel_wrapper_top(
         out: list[VerilogPort] = []
         for part in parts:
             p = _port_exact(bn, part)
-            if p is None:
+            if p is not None:
+                out.append(p)
+                continue
+            # Not a port name -- try it as a CHANNEL whose fields the RTL
+            # prefix-expanded. Exact match is still preferred, so a block that
+            # really has a port of this name is unaffected.
+            grp = _channel_fields(bn, part)
+            if not grp:
                 return []
-            out.append(p)
+            out.extend(grp)
         return out
 
     edge_bound: set[frozenset] = set()
@@ -1802,6 +1846,60 @@ def _dedup_module_sources(
     return out_paths
 
 
+def chip_rtl_sources(
+    top_rtl_path: str,
+    block_rtl_paths: dict[str, str],
+    dedup_dir=None,
+) -> list[str]:
+    """Every Verilog source needed to elaborate the ASSEMBLED chip, top first.
+
+    Single definition on purpose. The integration/validation DV sims and the
+    chip_top gate-sim's REFERENCE run must elaborate the identical source set:
+    the gate compares the flat netlist against that reference, so a reference
+    built from a different source list is not a reference at all -- it is a
+    second design, and any verdict against it is meaningless.
+
+    Top-first ordering matters: callers resolve the Verilator TOPLEVEL from the
+    first entry.
+    """
+    sources = [top_rtl_path]
+    for bp in block_rtl_paths.values():
+        if Path(bp).exists() and bp != top_rtl_path:
+            sources.append(bp)
+    # Include the generic SRAM wrapper lib if any block instantiates cs_sram, so
+    # the chip-level Verilator build can resolve cs_sram_1rw/1rw1r (without it
+    # the sim hard-fails with "Cannot find module cs_sram_1rw1r"). Best-effort.
+    try:
+        from orchestrator.langgraph.sram_wrapper import (
+            uses_wrapper as _uses_wrapper,
+        )
+        from orchestrator.langgraph.sram_wrapper import (
+            wrapper_lib_path as _wrapper_lib_path,
+        )
+        _all_rtl = "".join(
+            Path(p).read_text(errors="replace")
+            for p in sources if Path(p).exists()
+        )
+        _wlib = _wrapper_lib_path()
+        if _uses_wrapper(_all_rtl) and _wlib not in sources:
+            sources.append(_wlib)
+    except Exception:
+        pass
+    # A deterministically-assembled Caravel top and the pad-adapter BLOCK it was
+    # built from both declare `module user_project_wrapper`, and blocks commonly
+    # each bundle the same shared macro. Two compilation units defining one
+    # module is a Verilator MODDUP abort before any transaction runs, so a caller
+    # that hands this list straight to a simulator must dedup. Pass a scratch dir
+    # to get an elaborable list back; omit it to get raw paths.
+    if dedup_dir is not None:
+        # _dedup_module_sources WRITES the stripped copies and does not create
+        # its own output dir, so a caller passing a fresh scratch path would get
+        # back paths to files that do not exist.
+        Path(dedup_dir).mkdir(parents=True, exist_ok=True)
+        sources = _dedup_module_sources(sources, dedup_dir)
+    return sources
+
+
 def run_integration_simulation(
     design_name: str,
     top_rtl_path: str,
@@ -1843,28 +1941,7 @@ def run_integration_simulation(
     # so validation_dv never overwrites integration_dv's raw sim log.
     _log_step = f"{sim_scope}_sim"
 
-    all_sources = [top_rtl_path]
-    for bp in block_rtl_paths.values():
-        if Path(bp).exists() and bp != top_rtl_path:
-            all_sources.append(bp)
-    # Include the generic SRAM wrapper lib if any block instantiates cs_sram, so
-    # the chip-level Verilator build can resolve cs_sram_1rw/1rw1r (this fn backs
-    # BOTH integration_dv and validation_dv sims; without it both hard-fail with
-    # "Cannot find module cs_sram_1rw1r"). Best-effort.
-    try:
-        from orchestrator.langgraph.sram_wrapper import (
-            uses_wrapper as _uses_wrapper,
-        )
-        from orchestrator.langgraph.sram_wrapper import (
-            wrapper_lib_path as _wrapper_lib_path,
-        )
-        _all_rtl = "".join(
-            Path(p).read_text() for p in all_sources if Path(p).exists()
-        )
-        if _uses_wrapper(_all_rtl):
-            all_sources.append(_wrapper_lib_path())
-    except Exception:
-        pass
+    all_sources = chip_rtl_sources(top_rtl_path, block_rtl_paths)
     # Dedup shared macro modules (e.g. SRAM) bundled by multiple blocks, else
     # Verilator MODDUP-aborts elaboration before any transaction.
     all_sources = _dedup_module_sources(all_sources, sim_dir)
@@ -2079,14 +2156,42 @@ include $(shell cocotb-config --makefiles)/Makefile.sim
         return {"passed": False, "log": f"Tool not found: {e}", "log_path": log_path}
 
 
+def _eligible_blocks(completed_blocks: list[dict]) -> list[tuple[str, dict]]:
+    """(name, block) for every block that is supposed to be in the chip."""
+    out = []
+    for block in completed_blocks:
+        name = block.get("name", block.get("block_name", ""))
+        if not name:
+            continue
+        if block.get("aborted") or block.get("skipped"):
+            continue
+        out.append((name, block))
+    return out
+
+
 def discover_block_rtl(
     project_root: str,
     completed_blocks: list[dict],
 ) -> dict[str, str]:
     """Discover RTL file paths for all completed blocks.
 
-    Uses completed_blocks state to find RTL paths, falling back to
-    convention-based discovery.  Also searches subdirectories of rtl/.
+    Resolution order: the block result's own ``rtl_path``, then the block
+    spec's ``rtl_target``, then filename convention.
+
+    ``rtl_target`` is NOT optional politeness -- it is the only correct answer
+    whenever a block's Verilog file is not named after the block, which is
+    exactly the case for a block whose module name is locked by an interface
+    contract (a Caravel ``user_project_wrapper``, a vendor-mandated top). Before
+    it was consulted, such a block resolved to nothing and was dropped from the
+    returned dict with no error, which structurally DELETED it from the
+    assembled chip: the pad adapter never reached ``modules``, so
+    ``detect_wrapper_block`` returned None, the deterministic Caravel assembler
+    never ran, and the resulting top -- and netlist, and GDS -- carried no
+    io_in/io_out/io_oeb at all.
+
+    An eligible block that still resolves to nothing is logged as an ERROR
+    rather than omitted quietly. Callers that must not assemble a partial chip
+    should gate on :func:`unresolved_block_rtl`.
 
     Returns:
         Dict mapping block_name -> rtl_file_path.
@@ -2094,20 +2199,23 @@ def discover_block_rtl(
     root = Path(project_root)
     rtl_paths: dict[str, str] = {}
 
-    for block in completed_blocks:
-        name = block.get("name", block.get("block_name", ""))
-        if not name:
-            continue
-
-        # Skip failed/aborted blocks
-        if block.get("aborted") or block.get("skipped"):
-            continue
-
+    for name, block in _eligible_blocks(completed_blocks):
         # Try rtl_path from block result
         rtl_path = block.get("rtl_path", "")
         if rtl_path and Path(rtl_path).exists():
             rtl_paths[name] = rtl_path
             continue
+
+        # The block spec's declared target. Accepts absolute or
+        # project-root-relative, since both forms appear in block_specs.json.
+        target = block.get("rtl_target", "") or ""
+        if target:
+            for cand in (Path(target), root / target):
+                if cand.is_file():
+                    rtl_paths[name] = str(cand)
+                    break
+            if name in rtl_paths:
+                continue
 
         # Convention-based discovery
         candidates = [
@@ -2130,7 +2238,43 @@ def discover_block_rtl(
                             rtl_paths[name] = str(candidate)
                             break
 
+        if name not in rtl_paths:
+            log(f"  [INTEGRATION] NO RTL FOUND for block '{name}' "
+                f"(rtl_target={target or '<unset>'}) -- it will be ABSENT from "
+                f"the assembled chip. A block that silently stops existing is "
+                f"how a locked pad adapter was dropped and the chip shipped "
+                f"with no GPIO boundary.", RED)
+
     return rtl_paths
+
+
+def missing_from(
+    rtl_paths: dict[str, str],
+    completed_blocks: list[dict],
+) -> list[str]:
+    """Eligible blocks absent from a resolution the CALLER already has.
+
+    This is the form a gate wants. It judges the exact dict the caller is about
+    to assemble from, rather than re-deriving one -- so a caller (or a test)
+    that supplied or patched its own discovery cannot end up gated on a second,
+    different answer.
+    """
+    return [n for n, _ in _eligible_blocks(completed_blocks) if n not in rtl_paths]
+
+
+def unresolved_block_rtl(
+    project_root: str,
+    completed_blocks: list[dict],
+) -> list[str]:
+    """Eligible blocks whose RTL could not be located, so a caller can fail
+    closed instead of assembling a chip that is missing a block.
+
+    Standalone query: it runs its own discovery. A caller that ALREADY has a
+    resolution should use :func:`missing_from` on that, so the gate and the
+    assembler can never be judging two different dicts.
+    """
+    return missing_from(
+        discover_block_rtl(project_root, completed_blocks), completed_blocks)
 
 
 def detect_glue_block_needs(

--- a/orchestrator/langgraph/macro_prebind.py
+++ b/orchestrator/langgraph/macro_prebind.py
@@ -1,0 +1,505 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Resolve memory macros BEFORE synthesis and emit a bound shell.
+
+Why this exists
+---------------
+``cs_sram.v`` selects its implementation with a ``MEM_IMPL`` parameter, and the
+``"MACRO"`` arm instantiates ``cs_mem_macro_shell`` -- a leaf that *hard-assigns
+zero*::
+
+    // Reads are 0 in pure RTL sim -- "MACRO" is a backend impl, not a sim model
+    assign rdata0 = {WIDTH{1'b0}};
+
+Synthesis faithfully preserves that tie-off, so the flat netlist's memories read
+zero and a gate-level simulation of a MACRO-mode design can never pass: the
+first read of real data diverges. Macro *binding* today runs on the finished
+netlist (``bind_macro_shells``) and only records collateral for PnR -- it never
+gives the shell a body.
+
+The fix is ordering. Resolve each shell geometry to a concrete macro *before*
+synthesis, then emit a ``cs_mem_macro_shell`` whose body instantiates that
+macro. One artifact then serves every consumer:
+
+===============  =============================================================
+yosys            ``read_verilog -lib <macro>.v`` -- interface only, 0 flops,
+                 exactly the property the zero tie-off was protecting
+PnR              LEF/GDS keyed to the macro name already in the netlist
+gate-sim         the same ``<macro>.v`` read normally -- a real memory
+integration DV   ditto, so DV and silicon share one memory model
+===============  =============================================================
+
+An unresolvable geometry must never degrade to zeros or to a flop array, so the
+fallback arm references a deliberately undefined module: both yosys and
+Verilator fail on an unknown module, which makes the failure loud in every tool
+rather than silent in one.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Undefined on purpose -- see module docstring. Any tool elaborating this arm
+# errors out, which is the whole point.
+UNBOUND_SENTINEL = "cs_mem_macro_shell__UNBOUND_GEOMETRY__see_macro_prebind_py"
+
+
+#: Memory wrappers a block may instantiate, mapped to their port count.
+#: ``detect_macro_shells`` only matches ``cs_*_macro_shell`` instantiations,
+#: which exist solely AFTER the backend re-derives MEM_IMPL="MACRO" -- block
+#: RTL instantiates the wrapper instead (``cs_sram_1rw1r #(.WIDTH(8),
+#: .DEPTH(4096))``), so pre-synthesis binding has to read that form.
+_WRAPPERS = {
+    "cs_sram_1rw1r": 2,
+    "cs_mem_1rw1r": 2,
+    "cs_sram_1rw": 1,
+    "cs_mem_1rw": 1,
+}
+
+
+def _balanced(text: str, open_at: int) -> tuple[str, int]:
+    """Return the text inside the parens starting at ``open_at`` and the index
+    just past the closer. Parameter lists contain nested parens (``.WIDTH(8)``),
+    so a non-greedy regex would stop at the first inner ``)``."""
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_at + 1:i], i + 1
+    return "", len(text)
+
+
+def _param(params: str, name: str) -> int | None:
+    import re
+    m = re.search(r"\.\s*%s\s*\(\s*([0-9]+)\s*\)" % name, params)
+    return int(m.group(1)) if m else None
+
+
+def detect_memory_instances(text: str) -> list[tuple[int, int, int, int]]:
+    """Every ``(width, depth, nport, mask_bits)`` the source instantiates.
+
+    Reads the *wrapper* form used by block RTL. ``mask_bits`` is derived from
+    ``USE_WMASK``/``WMASK_GRAN`` so a masked write binds to a macro that has a
+    ``wmask0`` port. Deduped by geometry, order-stable.
+    """
+    import re
+
+    out: list[tuple[int, int, int, int]] = []
+    seen: set[tuple[int, int, int, int]] = set()
+    for name, nport in _WRAPPERS.items():
+        # `\b` on both sides: cs_sram_1rw must not match inside cs_sram_1rw1r.
+        for m in re.finditer(r"\b%s\b\s*#\s*\(" % re.escape(name), text):
+            params, after = _balanced(text, m.end() - 1)
+            w, d = _param(params, "WIDTH"), _param(params, "DEPTH")
+            if not w or not d:
+                continue
+            mask = 0
+            if (_param(params, "USE_WMASK") or 0) == 1:
+                gran = _param(params, "WMASK_GRAN") or 8
+                mask = (w + gran - 1) // gran
+            key = (w, d, nport, mask)
+            if key not in seen:
+                seen.add(key)
+                out.append(key)
+    return out
+
+
+@dataclass
+class PrebindResult:
+    """Outcome of pre-synthesis macro resolution."""
+
+    bindings: list = field(default_factory=list)      # [(ShellSpec, MacroInfo)]
+    unresolved: list = field(default_factory=list)    # [ShellSpec]
+    errors: list = field(default_factory=list)        # [str]
+    warnings: list = field(default_factory=list)      # [str] -- do not block
+
+    @property
+    def ok(self) -> bool:
+        """True only when every detected geometry bound to a real macro."""
+        return not self.unresolved and not self.errors
+
+    def model_paths(self) -> list[str]:
+        """Macro Verilog models, deduped, order-stable.
+
+        Read these with ``-lib`` for synthesis and normally for simulation.
+        """
+        out: list[str] = []
+        for _spec, macro in self.bindings:
+            v = getattr(macro, "verilog", "") or ""
+            if v and v not in out:
+                out.append(v)
+        return out
+
+
+#: Type/sign/net keywords that may appear between a direction keyword and the
+#: port name. Anything else at depth zero is a port name.
+_PORT_NOISE = frozenset({
+    "wire", "reg", "logic", "bit", "signed", "unsigned", "tri", "tri0", "tri1",
+    "wand", "wor", "triand", "trior", "trireg", "supply0", "supply1", "var",
+    "integer", "real", "realtime", "time", "byte", "shortint", "int", "longint",
+    "input", "output", "inout",
+})
+
+
+def _strip_comments(text: str) -> str:
+    """Remove // and /* */ comments so prose cannot contribute a port name."""
+    import re
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
+    return re.sub(r"//[^\n]*", " ", text)
+
+
+def macro_ports(verilog_path) -> set[str]:
+    """Port names the macro's Verilog model actually declares.
+
+    Trust the model, not registry metadata: ``MacroInfo.mask_bits`` can be
+    non-zero for a macro whose ``.v`` has no ``wmask0`` port, and connecting a
+    pin that does not exist is a hard elaboration error.
+
+    Scanned rather than regexed, because this parser MUST NOT fail by omission.
+    A missing name here is read by ``_ports_for`` as "the macro has no such pin",
+    so the binder leaves it unconnected and it floats low -- a dropped ``addr0``
+    is a memory stuck at word zero, and a dropped ``wmask0`` is what suppressed
+    every framebuffer write in exp-raster-macro-20260727. The previous regex
+    (``[^;)]*``) could not cross a ``)``, so it lost the name in
+    ``input [$clog2(DEPTH)-1:0] addr0;`` -- a form the sky130 macro family and
+    plenty of generated models use.
+
+    Handles non-ANSI (``input clk0;``), multi-name (``input a, b;``) and ANSI
+    (``module m(input wire [3:0] a, output b);``) declarations.
+
+    CONTRACT: the result is a SUPERSET of the module's ports, never a subset.
+    Function argument declarations inside the module body are collected too --
+    the sky130 SRAM models declare ``input [DATA_WIDTH-1:0] new_word;`` inside
+    ``merge_write0``, so ``write_mask``/``new_word``/``old_word`` come back as
+    well. That is deliberate and safe for the consumer that matters:
+    ``_ports_for`` connects a pin only if it is BOTH in its own connection list
+    AND in this set, so a spurious extra name can never create a connection,
+    while a missing real name silently drops one. Do not use this set as an
+    authoritative port list for anything that must be exact -- read the module
+    header for that.
+    """
+    import re
+    try:
+        text = _strip_comments(Path(verilog_path).read_text(errors="ignore"))
+    except OSError:
+        return set()
+
+    ports: set[str] = set()
+    for m in re.finditer(r"\b(?:input|output|inout)\b", text):
+        depth_paren = depth_brack = 0
+        chunk: list[str] = []
+        i = m.end()
+        while i < len(text):
+            c = text[i]
+            if c == "[":
+                depth_brack += 1
+            elif c == "]":
+                depth_brack = max(0, depth_brack - 1)
+            elif c == "(":
+                depth_paren += 1
+            elif c == ")":
+                if depth_paren == 0:
+                    break          # closing paren of an ANSI port list
+                depth_paren -= 1
+            elif c == ";" and depth_paren == 0 and depth_brack == 0:
+                break              # end of a non-ANSI declaration
+            elif depth_paren == 0 and depth_brack == 0:
+                chunk.append(c)
+            i += 1
+        for tok in re.findall(r"[A-Za-z_]\w*", "".join(chunk)):
+            if tok not in _PORT_NOISE and not tok.startswith("$"):
+                ports.add(tok)
+    return ports
+
+
+def _ports_for(macro, spec) -> list[tuple[str, str]]:
+    """Port connections from the OpenRAM macro to the shell's signals.
+
+    OpenRAM sky130 SRAMs use ACTIVE-LOW chip-select and write-enable
+    (``csb0``/``web0``), while the shell's ``ce0``/``we0`` are active high --
+    so these are inverted, not renamed. Getting that backwards yields a memory
+    that is selected exactly when it should be idle, which reads as plausible
+    garbage rather than an obvious failure.
+    """
+    have = macro_ports(getattr(macro, "verilog", "") or "")
+    conns = [
+        ("clk0", "clk"),
+        ("csb0", "~ce0"),
+        ("web0", "~we0"),
+        ("addr0", "addr0"),
+        ("din0", "wdata0"),
+        ("dout0", "rdata0"),
+    ]
+    if "wmask0" in have:
+        nb = int(getattr(macro, "mask_bits", 0) or 0)
+        conns.insert(3, ("wmask0", "{%d{1'b1}}" % nb if nb else "'1"))
+    if int(getattr(spec, "nport", 1) or 1) >= 2:
+        conns += [
+            ("clk1", "clk"),
+            ("csb1", "~ce1"),
+            ("addr1", "addr1"),
+            ("dout1", "rdata1"),
+        ]
+    # Never connect a pin the model does not declare -- that is a hard
+    # elaboration error, and it is how the 4096x8 framebuffer macro (no
+    # wmask0 port) was caught.
+    return [(p, s) for p, s in conns if not have or p in have]
+
+
+def emit_bound_shell(result: PrebindResult) -> str:
+    """Verilog defining ``cs_mem_macro_shell`` bound to concrete macros.
+
+    Dispatch is a ``generate`` over the elaborated WIDTH/DEPTH/NPORT, so one
+    module serves every geometry in the design and the selection is visible to
+    both simulator and synthesiser -- no preprocessor, matching the reasoning
+    already documented in ``cs_sram.v``.
+    """
+    lines = [
+        "// GENERATED by orchestrator/langgraph/macro_prebind.py -- do not edit.",
+        "//",
+        "// Replaces the zero-driving cs_mem_macro_shell with one bound to the",
+        "// concrete macros resolved for this design. Synthesis should read the",
+        "// macro models with `read_verilog -lib` (interface only, 0 flops);",
+        "// simulation reads them normally to get a real memory.",
+        "",
+        "module cs_mem_macro_shell #(",
+        "    parameter integer WIDTH = 32,",
+        "    parameter integer DEPTH = 512,",
+        "    parameter integer NPORT = 1,",
+        "    parameter integer AW    = (DEPTH <= 1) ? 1 : $clog2(DEPTH)",
+        ") (",
+        "    input  wire             clk,",
+        "    input  wire             ce0,",
+        "    input  wire             we0,",
+        "    input  wire [AW-1:0]    addr0,",
+        "    input  wire [WIDTH-1:0] wdata0,",
+        "    output wire [WIDTH-1:0] rdata0,",
+        "    input  wire             ce1,",
+        "    input  wire [AW-1:0]    addr1,",
+        "    output wire [WIDTH-1:0] rdata1",
+        ");",
+        "  generate",
+    ]
+
+    branch = "if"
+    for spec, macro in result.bindings:
+        w, d = int(spec.width), int(spec.depth)
+        n = int(getattr(spec, "nport", 1) or 1)
+        lines.append(
+            f"    {branch} (WIDTH == {w} && DEPTH == {d} && NPORT == {n}) begin : "
+            f"g_w{w}_d{d}_p{n}"
+        )
+        lines.append(f"      {macro.name} u_macro (")
+        conns = _ports_for(macro, spec)
+        for i, (port, sig) in enumerate(conns):
+            comma = "," if i < len(conns) - 1 else ""
+            lines.append(f"        .{port}({sig}){comma}")
+        lines.append("      );")
+        if n < 2:
+            # Single-port macro: the shell still exposes rdata1. Drive it from
+            # port 0 rather than inventing data.
+            lines.append("      assign rdata1 = rdata0;")
+        lines.append("    end")
+        branch = "else if"
+
+    lines += [
+        "    else begin : g_unbound",
+        "      // No macro was resolved for this geometry. Referencing an",
+        "      // undefined module makes yosys AND Verilator fail here, rather",
+        "      // than silently reading zeros (the old behaviour) or inferring",
+        "      // a flop array (worse).",
+        f"      {UNBOUND_SENTINEL} u_unbound_geometry ();",
+        "    end",
+        "  endgenerate",
+        "endmodule",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def resolve_prebindings(sources, *, allow_generate: bool = True,
+                        registry=None) -> PrebindResult:
+    """Detect every macro-shell geometry in RTL SOURCE and bind each one.
+
+    ``detect_macro_shells`` already accepts source as well as netlists (its
+    explicit-``#(.WIDTH..)`` form is the behavioral wrapper), so no new parsing
+    is needed -- only running it earlier.
+    """
+    res = PrebindResult()
+    try:
+        from orchestrator.langgraph.macro_registry import (
+            detect_macro_shells,
+            discover_macros,
+            resolve_shell,
+        )
+    except Exception as exc:  # pragma: no cover - import guard
+        res.errors.append(f"macro_registry unavailable: {exc!r}")
+        return res
+
+    text_parts = []
+    for s in sources:
+        p = Path(s)
+        if p.is_file():
+            text_parts.append(p.read_text(errors="ignore"))
+    if not text_parts:
+        res.errors.append("no readable RTL sources given")
+        return res
+    text = "\n".join(text_parts)
+
+    # Union of both forms: post-derivation shells (netlists / already-derived
+    # sources) and the wrapper instantiations block RTL actually writes.
+    specs = list(detect_macro_shells(text))
+    have = {(int(s.width), int(s.depth), int(getattr(s, "nport", 1) or 1))
+            for s in specs}
+    req_mask: dict[tuple[int, int, int], int] = {}
+    try:
+        from orchestrator.langgraph.macro_registry import ShellSpec
+        for w, d, n, mask in detect_memory_instances(text):
+            if mask:
+                req_mask[(w, d, n)] = mask
+            if (w, d, n) not in have:
+                have.add((w, d, n))
+                specs.append(ShellSpec(kind="sram", width=w, depth=d, nport=n))
+    except Exception as exc:  # pragma: no cover - construction guard
+        res.errors.append(f"could not build ShellSpec for wrapper form: {exc!r}")
+
+    if not specs:
+        return res          # genuinely no memories; nothing to bind
+
+    if registry is None:
+        registry = discover_macros()
+
+    for spec in specs:
+        macro = resolve_shell(spec, registry=registry,
+                              allow_generate=allow_generate)
+        if macro is None or not getattr(macro, "name", ""):
+            res.unresolved.append(spec)
+            continue
+        if not getattr(macro, "verilog", ""):
+            # A macro with no simulation model cannot be gate-simulated. Say so
+            # here rather than letting the sim read an unbound instance.
+            res.unresolved.append(spec)
+            res.errors.append(
+                f"macro {macro.name} for {spec.describe()} has no Verilog model "
+                f"-- cannot simulate; regenerate it so a .v view exists")
+            continue
+        key = (int(spec.width), int(spec.depth),
+               int(getattr(spec, "nport", 1) or 1))
+        if key in req_mask:
+            nb = req_mask[key]
+            macro_has_mask = "wmask0" in macro_ports(macro.verilog)
+            if nb > 1:
+                # A real per-byte mask survives ONLY if it can travel all the way
+                # from the RTL to the macro. Two independent things can break
+                # that, and both end the same way -- the mask is replaced by
+                # all-ones, every partial write becomes a full-word write, and
+                # neighbouring bytes are clobbered. That is data corruption which
+                # passes RTL DV (the BEHAV arm honours the mask) and appears only
+                # in the macro-backed design, so it must be refused here.
+                if macro_has_mask:
+                    # The macro could honour it; the SHELL cannot express it.
+                    # emit_bound_shell's cs_mem_macro_shell has no mask pins and
+                    # _ports_for hardwires wmask0 to all-ones.
+                    detail = (
+                        f"macro {macro.name} HAS a wmask0 port, but "
+                        f"cs_mem_macro_shell carries no mask pins and the "
+                        f"binding ties wmask0 to all-ones, so the RTL's mask is "
+                        f"discarded. Route wmask0 through the shell (shell port "
+                        f"+ _ports_for connection + the cs_sram MACRO arm), or "
+                        f"change the RTL to fold the mask into we0")
+                else:
+                    detail = (
+                        f"macro {macro.name} has no wmask0 port at all. "
+                        f"Regenerate this geometry with a smaller write_size so "
+                        f"OpenRAM emits a mask, or change the RTL to "
+                        f"read-modify-write")
+                res.unresolved.append(spec)
+                res.errors.append(
+                    f"{spec.describe()}: RTL instantiates USE_WMASK with {nb} "
+                    f"mask bits and the mask would NOT reach the memory -- "
+                    f"{detail}. Refusing to bind: a dropped mask turns masked "
+                    f"writes into full-word writes, which RTL DV cannot see.")
+                continue
+            # nb == 1: the mask spans the whole word, so `we0 & mask` is exactly
+            # equivalent to masking inside the macro -- which is why OpenRAM
+            # omits the port when word_size == write_size. Binding is legal
+            # PROVIDED the RTL folds the mask into we0; if it drives we0 from an
+            # unmasked signal the write is no longer suppressed. Still only a
+            # warning because that fold is the correct, common fix and the
+            # geometry is otherwise sound -- but nothing here can prove the RTL
+            # did it.
+            res.warnings.append(
+                f"{spec.describe()}: the requested mask is a single whole-word "
+                f"bit, so it is equivalent to the write enable"
+                f"{'' if macro_has_mask else f' (macro {macro.name} omits wmask0 entirely)'}"
+                f". The shell carries no mask pins, so the mask reaches the "
+                f"memory ONLY if the RTL folds it into we0 "
+                f"(e.g. we0 = write_fire & wmask). UNVERIFIED here.")
+        res.bindings.append((spec, macro))
+    return res
+
+
+def strip_module(text: str, name: str) -> tuple[str, int]:
+    """Remove every ``module <name> ... endmodule`` definition. Returns
+    ``(text, removed_count)``.
+
+    Used to drop the zero-driving ``cs_mem_macro_shell`` from a COPY of the
+    wrapper library so the bound one can take its place. The shared
+    ``cs_sram.v`` is never modified -- other flows still get the documented
+    "MACRO reads zero in pure RTL sim" behaviour.
+    """
+    import re
+    pat = re.compile(r"\bmodule\s+%s\b.*?\bendmodule\b" % re.escape(name),
+                     re.DOTALL)
+    out, n = pat.subn("", text)
+    return out, n
+
+
+def prepare_synth_sources(wrapper_lib: str, result: PrebindResult,
+                          work_dir) -> dict:
+    """Source set for a synthesis that should use real macros.
+
+    Returns ``{"wrapper_lib", "bound_shell", "models"}``:
+
+    * ``wrapper_lib`` -- a copy of the library with the zero-driving shell
+      removed (or the original path when there was nothing to strip)
+    * ``bound_shell`` -- the generated shell instantiating concrete macros
+    * ``models`` -- macro Verilog to be read with ``-lib`` (interface only)
+
+    Reading both the original library and the bound shell would be a duplicate
+    definition of ``cs_mem_macro_shell``, so the strip is not optional.
+    """
+    work = Path(work_dir)
+    work.mkdir(parents=True, exist_ok=True)
+    out = {"wrapper_lib": wrapper_lib, "bound_shell": "", "models": []}
+    if not result.bindings:
+        return out
+
+    if wrapper_lib and Path(wrapper_lib).is_file():
+        text = Path(wrapper_lib).read_text(errors="ignore")
+        stripped, n = strip_module(text, "cs_mem_macro_shell")
+        if n:
+            filtered = work / "cs_sram__prebind.v"
+            filtered.write_text(
+                "// GENERATED: copy of %s with the zero-driving\n"
+                "// cs_mem_macro_shell removed; the bound shell replaces it.\n"
+                % wrapper_lib + stripped)
+            out["wrapper_lib"] = str(filtered)
+
+    out["bound_shell"] = write_bound_shell(
+        result, work / "cs_mem_macro_shell__bound.v")
+    out["models"] = result.model_paths()
+    return out
+
+
+def write_bound_shell(result: PrebindResult, out_path) -> str:
+    """Write the bound shell next to the design. Returns the path written."""
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(emit_bound_shell(result))
+    return str(out)

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -6029,6 +6029,16 @@ def _deterministic_integration_check_enabled() -> bool:
     )
 
 
+def _block_rtl_complete_gate_enabled() -> bool:
+    """Refuse to assemble a chip that is MISSING a block. Default ON; set
+    ``CORESMITH_BLOCK_RTL_COMPLETE_GATE=0`` to restore the old
+    drop-the-block-and-continue behavior (the ``override`` interrupt action
+    remains the per-run escape for a block that genuinely does not belong)."""
+    return (
+        (os.environ.get("CORESMITH_BLOCK_RTL_COMPLETE_GATE", "1") or "1") != "0"
+    )
+
+
 def _deterministic_caravel_top_enabled() -> bool:
     """Defect 4: when the design carries a Caravel pad-adapter block (a block
     named ``user_project_wrapper`` or one exposing io_in/io_out/io_oeb), assemble
@@ -6280,6 +6290,119 @@ async def integration_check_node(state: OrchestratorState) -> dict:
         rtl_paths = await asyncio.to_thread(
             discover_block_rtl, pr, passed_blocks
         )
+
+        # BLOCK-RTL COMPLETENESS GATE: refuse to assemble a chip that is MISSING
+        # a block. `discover_block_rtl` used to drop an unresolvable block
+        # SILENTLY, which structurally DELETES it from the chip: the raster run
+        # lost its locked Caravel pad adapter (whose file is
+        # rtl/user_project_wrapper.v, NOT <block_name>.v, because an interface
+        # contract locks the module name), so `detect_wrapper_block` returned
+        # None, the DEFAULT-ON deterministic Caravel assembler never ran, the LLM
+        # Lead promoted the pad block's own qspi_* ports to the chip boundary, and
+        # the assembled top -- and the netlist, and the GDS -- carried NO
+        # io_in/io_out/io_oeb, while integration DV reported PASS on a co-tuned
+        # BFM. A block that silently stops existing is an ASSEMBLY BLOCKER, not a
+        # warning: park BEFORE spending the Lead call, in the same shape as the
+        # staleness preflight above. Default-on; opt out with
+        # CORESMITH_BLOCK_RTL_COMPLETE_GATE=0.
+        if _block_rtl_complete_gate_enabled():
+            from orchestrator.langgraph.integration_helpers import (
+                missing_from,
+            )
+            # Judge the AUTHORITATIVE dict this node will actually assemble
+            # from, not a second discovery -- a gate and an assembler working
+            # off two different answers is its own bug.
+            _missing_rtl = await asyncio.to_thread(
+                missing_from, rtl_paths, passed_blocks
+            )
+            # Fires only on a PARTIAL resolution: some blocks resolved and at
+            # least one did not, which is the silent-deletion defect (a chip
+            # assembled AROUND a missing block). When NOTHING resolved there is
+            # no chip to assemble at all and the existing "No block RTL could be
+            # parsed" skip below already reports that honestly.
+            if rtl_paths and _missing_rtl:
+                log(f"  [INTEGRATION] BLOCK RTL UNRESOLVED for {_missing_rtl} -- "
+                    f"refusing to assemble a chip that is missing a block (a "
+                    f"silently dropped block is how a locked Caravel pad adapter "
+                    f"vanished and the chip shipped with no GPIO boundary)", RED)
+                write_graph_event(pr, "Integration Check",
+                                  "block_rtl_unresolved",
+                                  {"missing_blocks": _missing_rtl,
+                                   "resolved_blocks": sorted(rtl_paths)})
+                payload = {
+                    "type": "integration_failure",
+                    "error_kind": "unresolved_block_rtl",
+                    "missing_block_rtl": _missing_rtl,
+                    "resolved_block_rtl_paths": rtl_paths,
+                    "error_count": len(_missing_rtl),
+                    "supported_actions": ["retry", "override", "abort"],
+                    "outer_agent_guidance": (
+                        "These eligible blocks have NO locatable RTL file, so "
+                        "assembling now would ship a chip with those blocks "
+                        "DELETED -- no error, no instance, no ports. For each "
+                        "one: confirm the .v file exists on disk and that the "
+                        "block's `rtl_target` in .coresmith/block_specs.json "
+                        "points at it. A block whose module name is locked by an "
+                        "interface contract (e.g. a Caravel "
+                        "user_project_wrapper) is NOT named <block_name>.v, so "
+                        "`rtl_target` is the only correct answer for it. Then "
+                        "resume `retry` to re-run this preflight. `override` "
+                        "assembles WITHOUT those blocks -- only for a block that "
+                        "genuinely does not belong in the chip. `abort` ends "
+                        "integration."
+                    ),
+                    "reference_files": {
+                        "block_specs": ".coresmith/block_specs.json",
+                    },
+                }
+                response = interrupt(payload) or {}
+                _act = response.get("action", "retry")
+                write_graph_event(pr, "Integration Check",
+                                  "block_rtl_unresolved_resume",
+                                  {"action": _act})
+                if _act == "override":
+                    log("  [INTEGRATION] unresolved block RTL OVERRIDE by "
+                        f"chip-lead -- assembling WITHOUT {_missing_rtl}", YELLOW)
+                elif _act == "abort":
+                    result = {
+                        "aborted": True, "skipped": True,
+                        "reason": ("unresolved block RTL (aborted): "
+                                   f"{_missing_rtl}"),
+                        "error": "unresolved_block_rtl",
+                        "error_count": len(_missing_rtl),
+                        "missing_blocks": _missing_rtl,
+                    }
+                    write_graph_event(pr, "Integration Check",
+                                      "graph_node_exit", result)
+                    return {"integration_result": result}
+                else:  # retry (after fixing rtl_target / writing the file)
+                    # Re-discover: a retry means rtl_target was just fixed or
+                    # the file was just written. Then judge THAT dict.
+                    rtl_paths = await asyncio.to_thread(
+                        discover_block_rtl, pr, passed_blocks
+                    )
+                    _missing_rtl2 = await asyncio.to_thread(
+                        missing_from, rtl_paths, passed_blocks
+                    )
+                    if _missing_rtl2:
+                        log("  [INTEGRATION] block RTL STILL unresolved after "
+                            f"retry ({_missing_rtl2}) -- ending integration "
+                            "(fail-closed; resolve the block's rtl_target "
+                            "first)", RED)
+                        result = {
+                            "aborted": True, "skipped": True,
+                            "reason": ("block RTL unresolved after retry: "
+                                       f"{_missing_rtl2}"),
+                            "error": "unresolved_block_rtl",
+                            "error_count": len(_missing_rtl2),
+                            "missing_blocks": _missing_rtl2,
+                        }
+                        write_graph_event(pr, "Integration Check",
+                                          "graph_node_exit", result)
+                        return {"integration_result": result}
+                    log("  [INTEGRATION] block RTL resolved on retry "
+                        f"({len(rtl_paths)} blocks) -- proceeding to assembly",
+                        GREEN)
 
         modules = {}
         block_rtl_sources: dict[str, str] = {}
@@ -8805,10 +8928,23 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                     _top_src = await asyncio.to_thread(
                         lambda: Path(top_rtl_path).read_text(encoding="utf-8")
                     )
-                    _contract, _plan = await asyncio.to_thread(
-                        _bfm_lib.plan_deterministic_dv, pr, _top_src, connections
+                    # Classify the GRADED boundary, not merely "does this file
+                    # mention io_in". The external grader drives io_in/io_out/
+                    # io_oeb on `user_project_wrapper`, so an assembled top whose
+                    # own pins are design-prefixed (qspi_io_in/qspi_io_out/
+                    # qspi_drive_en) is NOT the graded boundary even though the
+                    # chassis IS QSPI-slave -- and the boundary usually still
+                    # exists, in rtl/user_project_wrapper.v. The verdict says
+                    # WHERE it lives and whether THIS sim will drive it.
+                    _verdict = await asyncio.to_thread(
+                        _bfm_lib.classify_bus_verdict, pr, _top_src, connections,
+                        design_name, top_rtl_path,
                     )
+                    _contract = _verdict.contract if _verdict.contract_enforcing else None
                     if _contract is not None:
+                        _plan = await asyncio.to_thread(
+                            _bfm_lib.build_plan_from_run, pr, _contract
+                        )
                         _out = str(
                             PROJECT_ROOT / "tb" / "integration"
                             / f"test_{design_name}.py"
@@ -8851,24 +8987,126 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                                 "turnaround FAILS HERE, not at the secret grader.",
                                 GREEN,
                             )
+                    elif _verdict.fails_closed:
+                        # THE FAIL-OPEN THIS CLOSES. The spec says the external
+                        # bus is QSPI, but the module this DV elaborates does not
+                        # expose the graded pin boundary -- either it lives on
+                        # another module (typically the wrapper the grader drives)
+                        # or no io_in/io_out/io_oeb boundary exists anywhere
+                        # (spec/RTL contradiction). Historically this logged a RED
+                        # advisory and PROCEEDED on the LLM-authored, DUT-co-tuned
+                        # BFM: DV was silently downgraded exactly when the design
+                        # is most likely to be non-conformant, and the run still
+                        # reported "INTEGRATION DV PASSED" (exp-raster-macro-
+                        # 20260727). It is now the run's normal tb_generation
+                        # interrupt (retry/fix_rtl/fix_tb/abort), per the local
+                        # honest-gate idiom.
+                        _gate_on = _bfm_lib.boundary_gate_enabled()
+                        write_graph_event(pr, "Integration DV", "qspi_boundary_gate", {
+                            "gate": "qspi_pin_boundary",
+                            "status": _verdict.status,
+                            "enforced": _gate_on,
+                            "simulated_top": _verdict.simulated_top,
+                            "boundary_module": (
+                                _verdict.boundary.module if _verdict.boundary else ""
+                            ),
+                            "boundary_path": (
+                                _verdict.boundary.path if _verdict.boundary else ""
+                            ),
+                            "top_ports": list(_verdict.top_ports[:16]),
+                            "reason": _verdict.reason,
+                        })
+                        if _gate_on:
+                            log(
+                                "  [INTEG-DV] QSPI PIN-BOUNDARY GATE FAILED "
+                                "(fail-closed -- this is NOT a pass, and the "
+                                "co-tuned LLM BFM is NOT an acceptable fallback "
+                                f"here): {_verdict.reason}",
+                                RED,
+                            )
+                            generation_error = RuntimeError(
+                                "QSPI pin-boundary gate: " + _verdict.reason
+                            )
+                        else:
+                            log(
+                                "  [INTEG-DV] ADVISORY (QSPI pin-boundary gate "
+                                "DISABLED by CORESMITH_QSPI_BOUNDARY_GATE=0 / "
+                                "CORESMITH_GATE_FAIL_OPEN=1): keeping the "
+                                "LLM-authored BFM. THIS RUN'S INTEGRATION DV IS "
+                                "NOT CONTRACT-ENFORCING -- the BFM may co-tune to "
+                                "the DUT and pass a non-conformant design. "
+                                f"{_verdict.reason}",
+                                RED,
+                            )
+                            # An advisory bypass must never be SILENT: carry the
+                            # specific unmodeled boundary forward to the final
+                            # report / validation-DV context.
+                            record_carried_forward_defect(pr, {
+                                "gate": "qspi_pin_boundary",
+                                "kind": "dv_not_contract_enforcing",
+                                "advisory": True,
+                                "unmodeled": (
+                                    "graded Caravel pin boundary (io_in/io_out/"
+                                    "io_oeb) not driven by integration DV "
+                                    f"({_verdict.status}; boundary="
+                                    + (
+                                        _verdict.boundary.describe()
+                                        if _verdict.boundary
+                                        else "absent"
+                                    )
+                                    + f"; simulated top='{_verdict.simulated_top}')"
+                                ),
+                                "first_divergence_block": "",
+                                "note": _verdict.reason,
+                            })
                     else:
                         log(
                             "  [INTEG-DV] ADVISORY: chip-top is not a QSPI-slave "
                             "bus; keeping the LLM-authored BFM. THIS RUN'S "
                             "INTEGRATION DV IS NOT CONTRACT-ENFORCING -- the BFM "
                             "may co-tune to the DUT and pass a non-conformant "
-                            "design.",
+                            f"design. ({_verdict.reason})",
                             RED,
                         )
             except Exception as _bfm_e:  # noqa: BLE001
-                log(
-                    "  [INTEG-DV] deterministic BFM path errored "
-                    f"({_bfm_e}); falling back to LLM BFM",
-                    YELLOW,
-                )
+                # A gate that RAISES is not a pass (gate_guard / A-Fix 2): when the
+                # architecture says the bus is QSPI we must not fall back to the
+                # co-tuned BFM just because the classifier/codegen broke. Fail
+                # closed unless the gate (or the global knob) is explicitly off.
+                _bfm_fail_closed = False
+                try:
+                    from orchestrator.langgraph import bfm_lib as _bfm_probe
+                    _bfm_fail_closed = (
+                        _bfm_probe.boundary_gate_enabled()
+                        and _bfm_probe.arch_indicates_qspi_slave(pr, connections)
+                    )
+                except Exception:  # noqa: BLE001
+                    _bfm_fail_closed = False
+                if _bfm_fail_closed:
+                    log(
+                        "  [INTEG-DV] deterministic BFM path ERRORED on a run "
+                        f"whose spec declares a QSPI bus ({_bfm_e}) -- failing "
+                        "closed: an errored gate is not a pass, and the co-tuned "
+                        "LLM BFM would silently un-enforce the bus contract.",
+                        RED,
+                    )
+                    generation_error = RuntimeError(
+                        "QSPI pin-boundary gate could not run (an errored gate is "
+                        f"not a pass): {_bfm_e}"
+                    )
+                else:
+                    log(
+                        "  [INTEG-DV] deterministic BFM path errored "
+                        f"({_bfm_e}); falling back to LLM BFM",
+                        YELLOW,
+                    )
                 tb_result = None
 
-            if tb_result is None:
+            # `generation_error` set above == the QSPI pin-boundary gate failed
+            # closed. Falling through to the LLM generator is precisely the
+            # outcome the gate forbids, so skip it and let the existing
+            # tb_generation failure path fire the interrupt.
+            if tb_result is None and generation_error is None:
                 # Re-point DV to model-equivalence when block-goldens is on: drive
                 # the RTL and the integrated Amaranth chip model with the same stimulus
                 # and assert RTL == chip model. Flag-off -> chip_model_path stays ""

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -2221,7 +2221,7 @@ def _normalize_cocotb_timing_keywords(tb_file: Path) -> None:
         tb_file.write_text(normalized, encoding="utf-8")
 
 
-def run_simulation(block: dict, rtl_path: str, tb_path: str, attempt: int = 1,
+def run_simulation(block: dict, rtl_path, tb_path: str, attempt: int = 1,
                    extra_defines: list | None = None,
                    sim_subdir: str | None = None,
                    extra_args: list | None = None) -> dict:
@@ -2250,9 +2250,21 @@ def run_simulation(block: dict, rtl_path: str, tb_path: str, attempt: int = 1,
         _build_jobs = max(1, int(os.environ.get("CORESMITH_SIM_BUILD_JOBS", "2") or "2"))
     except ValueError:
         _build_jobs = 2
-    # Include the generic SRAM wrapper lib (behavioral view) when the block
+    # ``rtl_path`` may be a single file OR a sequence of sources. An ASSEMBLED
+    # top is not one file: it needs the integration top plus every block's RTL
+    # plus the wrapper lib, and a lone path yields an empty/partial source list
+    # ("No input Verilog file specified") and therefore NO waveform -- which is
+    # why the chip_top gate-sim could only ever report not_run. A plain string
+    # is normalized to a 1-element list, so " ".join() reproduces it exactly and
+    # every existing caller's Makefile is byte-identical.
+    _srcs = [rtl_path] if isinstance(rtl_path, str) else [str(p) for p in rtl_path]
+    _srcs = [p for p in _srcs if p]
+    # The FIRST source is the primary: it is the file whose declared module the
+    # TOPLEVEL is resolved from. Callers passing a list must put the top first.
+    _primary = _srcs[0] if _srcs else ""
+    # Include the generic SRAM wrapper lib (behavioral view) when the design
     # instantiates it, so cocotb/verilator has the cs_sram_* modules.
-    _verilog_sources = rtl_path
+    _verilog_sources = " ".join(_srcs)
     try:
         from orchestrator.langgraph.sram_wrapper import (
             uses_wrapper as _uses_wrapper,
@@ -2260,9 +2272,15 @@ def run_simulation(block: dict, rtl_path: str, tb_path: str, attempt: int = 1,
         from orchestrator.langgraph.sram_wrapper import (
             wrapper_lib_path as _wrapper_lib_path,
         )
-        _rtl_text = Path(rtl_path).read_text() if Path(rtl_path).exists() else ""
-        if _uses_wrapper(_rtl_text):
-            _verilog_sources = f"{_wrapper_lib_path()} {rtl_path}"
+        # Scan EVERY source, not just the primary: with an assembled top the
+        # cs_sram instantiation lives in a leaf block, so looking only at the
+        # top would miss it and the build would fail on a missing module.
+        _rtl_text = "".join(
+            Path(p).read_text(errors="replace") for p in _srcs if Path(p).exists()
+        )
+        _wlib = _wrapper_lib_path()
+        if _uses_wrapper(_rtl_text) and _wlib not in _srcs:
+            _verilog_sources = " ".join([_wlib] + _srcs)
     except Exception:
         pass
     # Coverage injection. Instrumentation is added when EITHER the explicit
@@ -2294,7 +2312,7 @@ def run_simulation(block: dict, rtl_path: str, tb_path: str, attempt: int = 1,
 
     # TOPLEVEL must be the module Verilator will find with --top-module, which
     # is not always the architectural block name (locked Caravel/vendor tops).
-    _toplevel = rtl_module_name(rtl_path, block_name)
+    _toplevel = rtl_module_name(_primary, block_name)
     if _toplevel != block_name:
         log(f"  [SIM] TOPLEVEL={_toplevel} (block {block_name} declares an "
             f"externally-mandated module name)", CYAN)

--- a/orchestrator/langgraph/rtl_lib/cs_sram.v
+++ b/orchestrator/langgraph/rtl_lib/cs_sram.v
@@ -284,6 +284,20 @@ module cs_sram_1rw1r #(
     parameter integer WIDTH = 32,
     parameter integer DEPTH = 512,
     parameter integer AW    = (DEPTH <= 1) ? 1 : $clog2(DEPTH),
+    // READ_FIRST=1 makes a same-edge port-0 write/port-1 read collision
+    // return the complete pre-write word, matching native OLD-data macros --
+    // which is what real silicon does, so a design that cares should pass it
+    // EXPLICITLY (every memory block in the raster design does).
+    //
+    // The DEFAULT stays 0 (write-first bypass) deliberately. Flipping a shared
+    // library default silently changes the read semantics of every design
+    // already built against it, including ones whose DV has already passed, and
+    // it breaks the documented bypass contract that tb_cs_sram_wmask.v asserts.
+    // A macro-faithful default is arguably the better long-term choice -- BEHAV
+    // should not promise data the macro cannot deliver -- but that is a breaking
+    // change to make deliberately, with the testbench updated to match, not as
+    // a side effect of one design needing it.
+    parameter integer READ_FIRST = 0,
     parameter         INIT_FILE = "",
     // Optional per-byte write mask on port 0 (see cs_mem_1rw1r). Legacy
     // instantiations (USE_WMASK=0, wmask0 unconnected) are unchanged.
@@ -308,7 +322,8 @@ module cs_sram_1rw1r #(
 );
     cs_mem_1rw1r #(
         .MEM_IMPL(MEM_IMPL), .WIDTH(WIDTH), .DEPTH(DEPTH),
-        .INIT_FILE(INIT_FILE), .USE_WMASK(USE_WMASK), .WMASK_GRAN(8)
+        .READ_FIRST(READ_FIRST), .INIT_FILE(INIT_FILE),
+        .USE_WMASK(USE_WMASK), .WMASK_GRAN(8)
     ) u_mem (
         .clk(clk),
         .ce0(ce0), .we0(we0), .addr0(addr0), .wdata0(wdata0), .wmask0(wmask0),

--- a/orchestrator/langgraph/tapeout_helpers.py
+++ b/orchestrator/langgraph/tapeout_helpers.py
@@ -17,6 +17,12 @@ running the individual checks directly via Nix-wrapped EDA tools:
   - Magic DRC (full Sky130 design rules)
   - Netgen LVS (layout vs schematic)
   - Directory/file structure validation
+
+Both DRC runners return the honest three-state verdict built by
+``orchestrator.langgraph.drc_verdict`` (``pass`` / ``fail`` / ``not_run`` + a
+``reason``): a DRC that produced no report, an empty report or no parseable
+count is ``not_run`` with ``violation_count = None``, never a fabricated ``-1``
+that reads as violations and never a ``0`` that reads as clean.
 """
 
 from __future__ import annotations
@@ -33,6 +39,12 @@ from orchestrator.langgraph.backend_helpers import (
     LIBERTY,
     TECH_LEF,
     _resolve_tool,
+)
+from orchestrator.langgraph.drc_verdict import (
+    STATUS_NOT_RUN,
+    classify_drc,
+    drc_summary,
+    unmeasured_drc,
 )
 from orchestrator.langgraph.pipeline_helpers import (
     GREEN,
@@ -915,26 +927,41 @@ def run_mpw_precheck_native(
     # ---- Check 5: KLayout DRC (advisory -- not a hard gate) ----
     if gds_path and Path(gds_path).exists():
         klayout_result = _run_klayout_drc(gds_path, str(sub), timeout)
+        # Marked advisory so an UNMEASURED KLayout run stays non-blocking (as a
+        # missing binary always has) while a MEASURED violation count keeps
+        # blocking exactly as before -- see the hard_checks filter below.
+        klayout_result["advisory"] = True
         results["checks"]["klayout_drc"] = klayout_result
         if not klayout_result.get("pass"):
             if klayout_result.get("skipped"):
-                results["warnings"].append("KLayout DRC skipped (binary not available)")
-            else:
                 results["warnings"].append(
-                    f"KLayout DRC: {klayout_result.get('violation_count', '?')} violations")
+                    "KLayout DRC skipped (binary not available): "
+                    + (klayout_result.get("reason") or "no reason recorded"))
+            else:
+                # drc_summary distinguishes "N violations" from "COULD NOT BE
+                # MEASURED: <why>"; the old text claimed "-1 violations".
+                results["warnings"].append(drc_summary(klayout_result))
 
     # ---- Check 6: Magic DRC (authoritative -- on top-level GDS) ----
     if gds_path and Path(gds_path).exists():
         magic_result = _run_magic_drc_on_gds(gds_path, str(sub), timeout)
         results["checks"]["magic_drc"] = magic_result
-        if not magic_result["pass"]:
+        if not magic_result.get("pass"):
+            # Still fail-closed: signing off a shuttle submission requires a
+            # DRC MEASUREMENT, and an unmeasured DRC is not one. But the text
+            # now says WHICH it is -- "12 violation(s)" vs "COULD NOT BE
+            # MEASURED: Magic left NO DRC report at ..." -- instead of
+            # asserting "-1 violations" about a report that never existed.
             results["pass"] = False
-            results["errors"].append(
-                f"Magic DRC: {magic_result.get('violation_count', '?')} violations")
+            results["errors"].append(drc_summary(magic_result))
 
+    # An ADVISORY check that could not be measured is not evidence of anything,
+    # so it must not flip the hard verdict -- the same posture a missing binary
+    # (``skipped``) has always had. A measured advisory FAILURE still counts.
     hard_checks = {
         k: v for k, v in results["checks"].items()
         if not v.get("skipped")
+        and not (v.get("advisory") and v.get("status") == STATUS_NOT_RUN)
     }
     derived_pass = all(c.get("pass") for c in hard_checks.values()) if hard_checks else False
     if results["pass"] and not derived_pass:
@@ -1223,38 +1250,60 @@ end
 
         _write_step_log("openframe_wrapper", "klayout_drc", cmd, result, 1)
 
-        # Parse the KLayout DRC XML report
-        violation_count = 0
-        if report_path.exists():
-            report_text = report_path.read_text()
-            violation_count = report_text.count("<item>")
+        # Parse the KLayout DRC XML report. A MISSING report is not zero
+        # violations: this used to leave violation_count at 0, which made
+        # "KLayout produced nothing" read as "clean layout".
+        violation_count: int | None = None
+        if report_path.is_file():
+            report_text = report_path.read_text(errors="replace")
+            if report_text.strip():
+                violation_count = report_text.count("<item>")
 
-        return {
-            "pass": violation_count == 0,
-            "violation_count": violation_count,
-            "report_path": str(report_path),
-            "returncode": result.returncode,
-            "stderr": result.stderr[:500] if result.stderr else "",
-        }
+        verdict = classify_drc(
+            violation_count=violation_count,
+            report_path=str(report_path),
+            tool_ran=result.returncode == 0,
+            tool_error=(result.stderr or result.stdout or "")[-500:],
+            tool="KLayout",
+        )
+        verdict["returncode"] = result.returncode
+        verdict["stderr"] = result.stderr[:500] if result.stderr else ""
+        if verdict["status"] == STATUS_NOT_RUN:
+            log(f"  [PRECHECK] {drc_summary(verdict)}", YELLOW)
+        return verdict
     except subprocess.TimeoutExpired:
-        return {
-            "pass": False,
-            "violation_count": -1,
-            "error": f"KLayout DRC timed out ({timeout}s)",
-        }
+        return unmeasured_drc(
+            f"KLayout DRC timed out after {timeout}s, so it produced no "
+            "violation count.",
+            report_path=str(report_path), tool="KLayout")
     except FileNotFoundError:
         log("  [PRECHECK] KLayout not available -- skipping KLayout DRC", YELLOW)
+        # ``skipped`` keeps a missing binary out of the hard verdict, as before.
         return {
-            "pass": False,
-            "violation_count": 0,
-            "error": f"KLayout binary not found: {KLAYOUT_BIN}. Skipped.",
+            **unmeasured_drc(
+                f"KLayout binary not found: {KLAYOUT_BIN} -- the check never "
+                "ran, so nothing about this layout was measured.",
+                report_path=str(report_path), tool="KLayout"),
             "skipped": True,
         }
 
 
 def _run_magic_drc_on_gds(gds_path: str, output_dir: str, timeout: int = 600) -> dict:
-    """Run Magic DRC directly on a GDS file (precheck variant)."""
-    from orchestrator.langgraph.backend_helpers import run_magic
+    """Run Magic DRC directly on a GDS file (precheck variant).
+
+    Returns the honest three-state verdict from
+    :func:`orchestrator.langgraph.drc_verdict.classify_drc`: ``pass`` (report
+    present, count 0), ``fail`` (a measured N > 0) or ``not_run`` + ``reason``
+    when no measurement exists. This function used to return
+    ``{"pass": False, "violation_count": -1}`` when Magic produced nothing at
+    all, which every consumer read as "this layout HAS violations" -- see the
+    ``exp-raster-macro-20260727`` w32_d64 / w9_d512 macro reports, whose named
+    ``precheck_magic_drc.rpt`` was never written.
+    """
+    from orchestrator.langgraph.backend_helpers import (
+        _parse_magic_drc_count,
+        run_magic,
+    )
 
     out = Path(output_dir)
     tcl_path = out / "precheck_magic_drc.tcl"
@@ -1288,9 +1337,30 @@ quit -noprompt
 """)
 
     result = run_magic(str(tcl_path), "precheck", "precheck_drc", timeout=timeout)
+    report_path = out / "precheck_magic_drc.rpt"
 
-    return {
-        "pass": result.get("drc_count", -1) == 0 and result.get("success", False),
-        "violation_count": result.get("drc_count", -1),
-        "report_path": str(out / "precheck_magic_drc.rpt"),
-    }
+    # run_magic's false-clean recount only knows the BACKEND flow's
+    # ``magic_drc.rpt`` filename, so this flow's report was never consulted: a
+    # blank Magic stdout count parsed as 0 while precheck_magic_drc.rpt could
+    # hold thousands of rects. Recount from THIS report before judging.
+    count = result.get("drc_count")
+    if report_path.is_file():
+        try:
+            report_text = report_path.read_text(errors="replace")
+        except OSError:
+            report_text = ""
+        if report_text.strip():
+            count = _parse_magic_drc_count(result.get("stdout", "") or "",
+                                           report_text)
+
+    verdict = classify_drc(
+        violation_count=count,
+        report_path=str(report_path),
+        tool_ran=bool(result.get("success")),
+        tool_error=(result.get("stderr") or result.get("stdout") or "")[-500:],
+        tool="Magic",
+    )
+    verdict["log_path"] = result.get("log_path", "")
+    if verdict["status"] == STATUS_NOT_RUN:
+        log(f"  [PRECHECK] {drc_summary(verdict)}", YELLOW)
+    return verdict

--- a/orchestrator/mcp_server.py
+++ b/orchestrator/mcp_server.py
@@ -3757,8 +3757,12 @@ async def get_tapeout_state() -> str:
         "wrapper_drc_clean": wrapper_drc.get("clean"),
         "wrapper_lvs_match": wrapper_lvs.get("match"),
         "precheck_pass": precheck.get("pass"),
+        # Tri-state: True / False / None ("could not be measured"). An agent
+        # reads this to decide what to do next, so a not_run check flattened to
+        # False sends it off to fix a violation that was never observed.
         "precheck_checks": {
-            k: v.get("pass") for k, v in precheck.get("checks", {}).items()
+            k: (v.get("pass") if v.get("status") != "not_run" else None)
+            for k, v in precheck.get("checks", {}).items()
         },
         "submission_dir": values.get("submission_dir", ""),
         "wrapper_gds_path": values.get("wrapper_gds_path", ""),

--- a/orchestrator/tests/baseline_failures.txt
+++ b/orchestrator/tests/baseline_failures.txt
@@ -1,0 +1,104 @@
+# CoreSmith test-suite failure baseline.
+#
+# THIS IS A DEBT LEDGER, NOT A PERMANENT EXCUSE. Every node ID below is a test
+# that was ALREADY failing before the current work started. The list exists for
+# exactly one reason: so that failure number N+1 -- the one YOU just added -- is
+# visible against a suite that is already red.
+#
+# Rules:
+#   * Never add a line to this file to make your own change go green. Adding a
+#     line is admitting a regression. Fix the test or fix the code.
+#   * Deleting lines is the point. When a test here starts passing, prune it:
+#       python scripts/check_test_baseline.py --refresh
+#   * The guard reads only the node IDs. Header fields are provenance.
+#
+# The failing set depends on the TOOLCHAIN, not only the code -- see the
+# `environment:` field below. On the first measurement 50 of 75 entries failed
+# only because the `claude` binary was off PATH. Put the toolchain back before
+# you believe a big diff.
+#
+# Check a change against it:   python scripts/check_test_baseline.py
+# Full policy:                 docs/TEST-BASELINE.md
+#
+# measured-at-commit: 06d82e85d0ac1ef5e5e2d543ee5c945110f12c45
+# measured-on: 2026-07-30
+# pytest-invocation: python -m pytest orchestrator/tests -q --no-header -p no:cacheprovider
+# environment: claude=NO pdk=NO yosys=yes verilator=yes openroad=yes magic=yes iverilog=yes
+# counts: failed=75 passed=2857 skipped=23 xfailed=8
+# baseline-failures: 75
+#
+orchestrator/tests/test_backend_helpers.py::TestToolResolution::test_pdk_files_exist
+orchestrator/tests/test_bfm_lib.py::test_metatest_accepts_conformant_dut
+orchestrator/tests/test_composition_audit.py::TestBlockPortInfo::test_driven_through_local_helper
+orchestrator/tests/test_composition_audit.py::TestBlockPortInfo::test_signature_and_driven
+orchestrator/tests/test_composition_audit.py::TestBlockPortInfo::test_signature_appendix
+orchestrator/tests/test_composition_audit.py::TestGateIntegration::test_gate_returns_audit_violations_before_sim
+orchestrator/tests/test_composition_audit.py::TestGateIntegration::test_signature_feedback_on_runtime_typeerror
+orchestrator/tests/test_composition_audit.py::TestInstantiationSignature::test_too_many_positionals
+orchestrator/tests/test_composition_audit.py::TestInstantiationSignature::test_unexpected_kwarg_flagged_with_signature
+orchestrator/tests/test_composition_audit.py::TestMultiDriven::test_double_driver_flagged
+orchestrator/tests/test_composition_audit.py::TestRobustness::test_env_kill_switch
+orchestrator/tests/test_composition_audit.py::TestSignatureFeedbackHelper::test_signature_error_gets_appendix
+orchestrator/tests/test_composition_audit.py::TestSymdict::test_symdict_in_chip_model_flagged
+orchestrator/tests/test_composition_audit.py::TestUndrivenNet::test_multi_consumer_undriven_flagged
+orchestrator/tests/test_composition_audit.py::TestUndrivenNet::test_single_consumer_zero_init_is_warning_only
+orchestrator/tests/test_composition_audit.py::TestZeroWidth::test_zero_width_flagged
+orchestrator/tests/test_flow_fixes.py::TestIntegrationReviewAgent::test_constructor
+orchestrator/tests/test_flow_fixes.py::TestIntegrationReviewAgent::test_tools_enabled
+orchestrator/tests/test_flow_fixes.py::TestIntegrationReviewSoftLock::test_inplace_env_var_uses_canonical_path
+orchestrator/tests/test_flow_fixes.py::TestIntegrationReviewSoftLock::test_review_writes_to_review_dir_not_canonical
+orchestrator/tests/test_integration_lead.py::TestBuildPrompt::test_handles_many_connections
+orchestrator/tests/test_integration_lead.py::TestBuildPrompt::test_includes_block_rtl_sources
+orchestrator/tests/test_integration_lead.py::TestBuildPrompt::test_includes_connections
+orchestrator/tests/test_integration_lead.py::TestBuildPrompt::test_includes_design_name
+orchestrator/tests/test_integration_lead.py::TestBuildPrompt::test_includes_port_summaries
+orchestrator/tests/test_integration_lead.py::TestBuildPrompt::test_includes_prd_summary
+orchestrator/tests/test_integration_lead.py::TestBuildPrompt::test_omits_prd_section_when_empty
+orchestrator/tests/test_integration_lead.py::TestBuildPrompt::test_truncates_large_rtl
+orchestrator/tests/test_integration_lead.py::TestIntegrate::test_handles_llm_returning_garbage
+orchestrator/tests/test_integration_lead.py::TestIntegrate::test_integration_with_mismatches
+orchestrator/tests/test_integration_lead.py::TestIntegrate::test_llm_called_with_correct_params
+orchestrator/tests/test_integration_lead.py::TestIntegrate::test_successful_integration
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckNode::test_agent_failure_skips_gracefully
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckNode::test_agent_parse_error_skips
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckNode::test_calls_integration_lead_agent
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckNode::test_clean_integration_passes
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckNode::test_fix_rtl_resume_action
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckNode::test_lint_failure_triggers_interrupt
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckNode::test_mismatch_errors_trigger_interrupt
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckWarningTriage::test_nonblocking_env_var_restores_old_behaviour
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckWarningTriage::test_warning_only_fires_triage_interrupt
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckWarningTriage::test_warning_triage_abort_ends_pipeline
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckWarningTriage::test_warning_triage_accept_proceeds
+orchestrator/tests/test_integration_lead.py::TestIntegrationCheckWarningTriage::test_warning_triage_retry_ends_with_fix_recorded
+orchestrator/tests/test_integration_lead.py::TestModelNameUpdates::test_integration_lead_default_model
+orchestrator/tests/test_integration_lead.py::TestModelNameUpdates::test_integration_testbench_default_model
+orchestrator/tests/test_integration_lead.py::TestParseResponse::test_handles_empty_response
+orchestrator/tests/test_integration_lead.py::TestParseResponse::test_handles_invalid_json
+orchestrator/tests/test_integration_lead.py::TestParseResponse::test_handles_partial_json
+orchestrator/tests/test_integration_lead.py::TestParseResponse::test_parses_json_with_surrounding_text
+orchestrator/tests/test_integration_lead.py::TestParseResponse::test_parses_valid_json
+orchestrator/tests/test_integration_lead.py::TestParseResponse::test_preserves_mismatches
+orchestrator/tests/test_integration_lead.py::TestValidateResult::test_adds_default_fields
+orchestrator/tests/test_integration_lead.py::TestValidateResult::test_adds_default_severity
+orchestrator/tests/test_integration_lead.py::TestValidateResult::test_warns_on_missing_module_declaration
+orchestrator/tests/test_microarch_exp.py::test_elaborate_block_model_clean_passes
+orchestrator/tests/test_microarch_exp.py::test_elaborate_block_model_rejects_verilog_code_override
+orchestrator/tests/test_microarch_exp.py::test_elaborate_block_model_rejects_vhdl_code_override
+orchestrator/tests/test_microarch_exp.py::test_lint_models_node_all_clean
+orchestrator/tests/test_microarch_exp.py::test_lint_models_node_collects_per_block_errors
+orchestrator/tests/test_microarch_exp.py::test_lint_skips_unchanged_passing_block
+orchestrator/tests/test_output_contract_gate.py::test_node_passes_clean
+orchestrator/tests/test_pipeline_efficiency.py::TestIntegrationReviewAgent::test_agent_importable
+orchestrator/tests/test_pipeline_efficiency.py::TestRtlGeneratorModel::test_uses_default_model
+orchestrator/tests/test_pipeline_graph.py::TestDiskFirstAgentToolsEnabled::test_debug_agent_tools_enabled
+orchestrator/tests/test_pipeline_graph.py::TestDiskFirstAgentToolsEnabled::test_integration_lead_tools_enabled
+orchestrator/tests/test_pipeline_graph.py::TestDiskFirstAgentToolsEnabled::test_integration_tb_generator_tools_enabled
+orchestrator/tests/test_pipeline_graph.py::TestDiskFirstAgentToolsEnabled::test_rtl_generator_tools_enabled
+orchestrator/tests/test_pipeline_graph.py::TestDiskFirstAgentToolsEnabled::test_testbench_generator_tools_enabled
+orchestrator/tests/test_pipeline_graph.py::TestDiskFirstAgentToolsEnabled::test_uarch_spec_generator_tools_enabled
+orchestrator/tests/test_pipeline_graph.py::TestGraphConstruction::test_integration_testbench_generator_accepts_written_file
+orchestrator/tests/test_qspi_conformance.py::test_conformance_accepts_conformant_frontend
+orchestrator/tests/test_rtl_model_equiv.py::test_non_axis_interface_skips
+orchestrator/tests/test_stability.py::TestPipelineStability::test_pipeline_single_fft_block_no_crash
+orchestrator/tests/test_stability.py::TestPipelineStability::test_pipeline_three_fft_blocks_no_crash

--- a/orchestrator/tests/test_block_rtl_discovery.py
+++ b/orchestrator/tests/test_block_rtl_discovery.py
@@ -1,0 +1,171 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""A block whose Verilog file is not named after the block must still be found.
+
+`discover_block_rtl` used to resolve a block's RTL only from the block result's
+own ``rtl_path`` or by assuming ``<block_name>.v``. It never read ``rtl_target``,
+the engine-controlled spec field that carries the real path. Every ordinary
+block survives that, because its file IS named after it -- but a block whose
+module name is LOCKED by an interface contract (a Caravel
+``user_project_wrapper``, a vendor-mandated top) is exactly the block whose file
+is named something else, and it was dropped from the returned dict with no
+error at all.
+
+Measured on run exp-raster-macro-20260727, where the spec said
+``user_project_wrapper_io -> rtl/user_project_wrapper.v``:
+
+    7 of 8 blocks parsed, pad adapter absent from `modules`
+      -> detect_wrapper_block() returned None
+      -> the DEFAULT-ON deterministic Caravel assembler never ran
+      -> the LLM Integration Lead promoted the pad block's own ports to the chip
+         boundary instead of instantiating the block
+      -> the assembled top, the flat netlist and the GDS carried NO
+         io_in / io_out / io_oeb -- the graded pinout did not exist
+      -> the bus classifier found no Caravel boundary, integration DV fell back
+         to the co-tuned LLM BFM, and the run reported PASS.
+
+One silent omission, the full length of the flow. These tests cover both halves
+of the fix: resolve ``rtl_target``, and make an unresolvable block impossible to
+lose quietly.
+"""
+from __future__ import annotations
+
+from orchestrator.langgraph.integration_helpers import (
+    detect_wrapper_block,
+    discover_block_rtl,
+    parse_verilog_ports,
+    unresolved_block_rtl,
+)
+
+PAD_ADAPTER = """
+module user_project_wrapper (
+    input  wire [37:0] io_in,
+    output wire [37:0] io_out,
+    output wire [37:0] io_oeb,
+    input  wire        wb_clk_i,
+    input  wire        wb_rst_i
+);
+endmodule
+"""
+
+
+def _leaf(path, name):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"module {name} (input wire clk);\nendmodule\n")
+    return str(path)
+
+
+class TestRtlTargetIsHonored:
+    def test_file_not_named_after_the_block_is_found(self, tmp_path):
+        """THE regression. A locked module name means block name != file name."""
+        (tmp_path / "rtl").mkdir()
+        (tmp_path / "rtl" / "user_project_wrapper.v").write_text(PAD_ADAPTER)
+        found = discover_block_rtl(str(tmp_path), [{
+            "name": "user_project_wrapper_io",
+            "rtl_target": "rtl/user_project_wrapper.v",
+        }])
+        assert found == {
+            "user_project_wrapper_io":
+                str(tmp_path / "rtl" / "user_project_wrapper.v"),
+        }
+
+    def test_absolute_rtl_target_resolves(self, tmp_path):
+        p = _leaf(tmp_path / "rtl" / "odd" / "weird_name.v", "blk")
+        found = discover_block_rtl(str(tmp_path), [
+            {"name": "blk", "rtl_target": p},
+        ])
+        assert found["blk"] == p
+
+    def test_block_result_rtl_path_still_wins(self, tmp_path):
+        """State from the completed block is more specific than the spec."""
+        actual = _leaf(tmp_path / "rtl" / "from_state.v", "blk")
+        _leaf(tmp_path / "rtl" / "from_spec.v", "blk")
+        found = discover_block_rtl(str(tmp_path), [{
+            "name": "blk",
+            "rtl_path": actual,
+            "rtl_target": "rtl/from_spec.v",
+        }])
+        assert found["blk"] == actual
+
+    def test_stale_rtl_target_falls_through_to_convention(self, tmp_path):
+        """A spec pointing at a file that is not there must not shadow a file
+        that IS there -- otherwise a stale spec deletes a real block."""
+        conventional = _leaf(tmp_path / "rtl" / "blk.v", "blk")
+        found = discover_block_rtl(str(tmp_path), [{
+            "name": "blk",
+            "rtl_target": "rtl/moved_away.v",
+        }])
+        assert found["blk"] == conventional
+
+
+class TestConventionalDiscoveryUnchanged:
+    def test_rtl_subdir_layout(self, tmp_path):
+        p = _leaf(tmp_path / "rtl" / "io_subsystem" / "front.v", "front")
+        assert discover_block_rtl(str(tmp_path), [{"name": "front"}]) == {
+            "front": p}
+
+    def test_rtl_flat_layout(self, tmp_path):
+        p = _leaf(tmp_path / "rtl" / "front.v", "front")
+        assert discover_block_rtl(str(tmp_path), [{"name": "front"}]) == {
+            "front": p}
+
+    def test_per_block_dir_layout(self, tmp_path):
+        p = _leaf(tmp_path / "rtl" / "front" / "front.v", "front")
+        assert discover_block_rtl(str(tmp_path), [{"name": "front"}]) == {
+            "front": p}
+
+
+class TestAMissingBlockIsNotLostQuietly:
+    def test_unresolved_block_is_reported(self, tmp_path):
+        _leaf(tmp_path / "rtl" / "present.v", "present")
+        missing = unresolved_block_rtl(str(tmp_path), [
+            {"name": "present"},
+            {"name": "vanished", "rtl_target": "rtl/nowhere.v"},
+        ])
+        assert missing == ["vanished"]
+
+    def test_nothing_unresolved_when_all_are_found(self, tmp_path):
+        _leaf(tmp_path / "rtl" / "a.v", "a")
+        (tmp_path / "rtl" / "pad.v").write_text(PAD_ADAPTER)
+        assert unresolved_block_rtl(str(tmp_path), [
+            {"name": "a"},
+            {"name": "pad_io", "rtl_target": "rtl/pad.v"},
+        ]) == []
+
+    def test_skipped_and_aborted_blocks_are_not_unresolved(self, tmp_path):
+        """They are deliberately not in the chip, so they are not missing."""
+        assert unresolved_block_rtl(str(tmp_path), [
+            {"name": "gone", "skipped": True},
+            {"name": "dead", "aborted": True},
+        ]) == []
+
+
+class TestTheConsequenceThatActuallyBit:
+    def test_pad_adapter_is_detected_once_it_is_discovered(self, tmp_path):
+        """The whole point. detect_wrapper_block can only see blocks that
+        discovery returned, so dropping the pad block silently disabled the
+        deterministic Caravel assembly and produced an ungradeable chip."""
+        (tmp_path / "rtl").mkdir()
+        (tmp_path / "rtl" / "user_project_wrapper.v").write_text(PAD_ADAPTER)
+        _leaf(tmp_path / "rtl" / "core" / "engine.v", "engine")
+
+        blocks = [
+            {"name": "user_project_wrapper_io",
+             "rtl_target": "rtl/user_project_wrapper.v"},
+            {"name": "engine"},
+        ]
+        modules = {}
+        for name, path in discover_block_rtl(str(tmp_path), blocks).items():
+            mod = parse_verilog_ports(path)
+            if mod.name:
+                modules[name] = mod
+
+        assert len(modules) == 2
+        assert detect_wrapper_block(modules) == "user_project_wrapper_io"
+        # And the pre-fix state, for contrast: without the pad block there is
+        # no Caravel boundary to find and the flow silently takes the LLM path.
+        assert detect_wrapper_block(
+            {k: v for k, v in modules.items() if k != "user_project_wrapper_io"}
+        ) is None

--- a/orchestrator/tests/test_caravel_edge_binding.py
+++ b/orchestrator/tests/test_caravel_edge_binding.py
@@ -158,3 +158,106 @@ class TestBlocksInstantiatedCollision:
         err = assert_blocks_instantiated(
             top, ["user_project_wrapper", "dropped_block"])
         assert err and "dropped_block" in err
+
+
+# ---------------------------------------------------------------------------
+# Channel names: the contract names a CHANNEL, the RTL prefix-expands it.
+# ---------------------------------------------------------------------------
+
+def _chan_pair(tmp_path, prod_fields, cons_fields):
+    """A producer/consumer pair whose channel `ch` is prefix-expanded."""
+    prod = tmp_path / "prod.v"
+    prod.write_text(
+        "module prod (\n  input wire wb_clk_i, input wire wb_rst_i,\n  "
+        + ",\n  ".join(f"output wire {w}ch_{n}" for n, w in prod_fields)
+        + "\n);\nendmodule\n")
+    cons = tmp_path / "cons.v"
+    cons.write_text(
+        "module cons (\n  input wire wb_clk_i, input wire wb_rst_i,\n  "
+        + ",\n  ".join(f"input wire {w}ch_{n}" for n, w in cons_fields)
+        + "\n);\nendmodule\n")
+    rtl_paths = {
+        "user_project_wrapper": _wrapper(tmp_path),
+        "prod": str(prod), "cons": str(cons),
+    }
+    modules = {bn: parse_verilog_ports(q) for bn, q in rtl_paths.items()}
+    edges = [{
+        "producer_block": "prod", "consumer_block": "cons",
+        "producer_port": "ch", "consumer_port": "ch", "edge_id": "chan",
+    }]
+    return modules, edges, rtl_paths
+
+
+class TestChannelNameResolution:
+    """An interface contract names a channel; this engine's RTL exposes that
+    channel as a group of ports sharing the channel's name as a prefix
+    (contract `framebuffer_read` -> `framebuffer_read_req_addr`,
+    `framebuffer_read_rdata`, `framebuffer_read_rvalid`, ...).
+
+    Before channel expansion, EVERY such edge failed to resolve, counted as a
+    wiring hazard, and took the whole deterministic Caravel assembly down with
+    it -- on exp-raster-macro-20260727, all 15 contract edges, so the gradeable
+    top was built and then discarded at the last step.
+    """
+
+    def test_matching_field_sets_bind_with_no_hazard(self, tmp_path):
+        fields = [("addr", "[11:0] "), ("data", "[7:0] "), ("valid", "")]
+        modules, edges, rtl_paths = _chan_pair(tmp_path, fields, fields)
+        asm = generate_caravel_wrapper_top(
+            modules, edges, rtl_paths, str(tmp_path / "out"),
+            "user_project_wrapper")
+        assert not asm.get("wiring_errors"), asm.get("wiring_errors")
+        v = asm["verilog"]
+        # All three fields wired, none left dangling on a constant.
+        for n in ("addr", "data", "valid"):
+            assert f"ch_{n}" in v
+
+    def test_an_exact_port_name_still_wins(self, tmp_path):
+        """A block that really HAS a port of that name must be unaffected --
+        channel expansion is a fallback, not a replacement."""
+        modules, edges, rtl_paths = _design(
+            tmp_path, "m_work_write_srdy", "s_butterfly_write_srdy")
+        asm = generate_caravel_wrapper_top(
+            modules, edges, rtl_paths, str(tmp_path / "out"),
+            "user_project_wrapper")
+        assert not asm.get("wiring_errors"), asm.get("wiring_errors")
+
+    def test_a_channel_that_matches_nothing_is_still_a_hazard(self, tmp_path):
+        fields = [("addr", "[11:0] ")]
+        modules, edges, rtl_paths = _chan_pair(tmp_path, fields, fields)
+        edges[0]["producer_port"] = "no_such_channel"
+        asm = generate_caravel_wrapper_top(
+            modules, edges, rtl_paths, str(tmp_path / "out"),
+            "user_project_wrapper")
+        errs = asm.get("wiring_errors") or []
+        assert errs and any("does not resolve" in e for e in errs)
+
+    def test_asymmetric_field_sets_are_refused_not_guessed(self, tmp_path):
+        """The REMAINING blocker, pinned deliberately.
+
+        The two sides of a channel often expose different field names
+        (aperture `host_write_enable` vs store `host_write_accept`). Positional
+        pairing would then cross fields, so the assembler refuses -- correctly.
+        Closing this needs suffix-KEYED matching with handshake aliasing, which
+        is a design decision, not a parser tweak. Until then a design with
+        asymmetric channel fields still falls back to the LLM integrator.
+        """
+        modules, edges, rtl_paths = _chan_pair(
+            tmp_path,
+            [("enable", ""), ("addr", "[11:0] ")],
+            [("accept", ""), ("addr", "[11:0] ")])
+        asm = generate_caravel_wrapper_top(
+            modules, edges, rtl_paths, str(tmp_path / "out"),
+            "user_project_wrapper")
+        errs = asm.get("wiring_errors") or []
+        assert errs, "crossed two differently-named channel fields"
+        assert any("suffix mismatch" in e for e in errs), errs
+
+    def test_width_mismatch_across_a_channel_is_refused(self, tmp_path):
+        modules, edges, rtl_paths = _chan_pair(
+            tmp_path, [("data", "[7:0] ")], [("data", "[15:0] ")])
+        asm = generate_caravel_wrapper_top(
+            modules, edges, rtl_paths, str(tmp_path / "out"),
+            "user_project_wrapper")
+        errs = asm.get("wiring_errors") or []
+        assert any("width" in e for e in errs), errs

--- a/orchestrator/tests/test_chip_gate_sim_wiring.py
+++ b/orchestrator/tests/test_chip_gate_sim_wiring.py
@@ -1,0 +1,233 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The chip_top gate-sim must be WIRED, and its verdict must BITE.
+
+These test the plumbing, not the verdict logic (that is test_chip_top_gate_sim).
+They exist because the gate shipped in a state where it could never run on a
+real design and could never block one, while its unit tests passed:
+
+  * ``_run_chip_top_gate_sim`` read ``state["top_rtl_path"]``, which no part of
+    the backend flow populates -- ``BackendState`` has no such field,
+    ``start_backend``'s initial_state omits it, and ``init_design_node`` does
+    not return it. Its test passed only because the test injected the value.
+    On every real run the gate reported ``not_run``. The one real verdict ever
+    produced came from a hand-written driver that read the source list out of
+    the integration DV's Makefile.
+  * ``run_simulation`` built ``VERILOG_SOURCES`` from ONE path, so even a
+    correct single path could not elaborate an assembled chip.
+  * Nothing read ``chip_gate_sim_ok``. A FAIL was recorded in state and the
+    flow proceeded to P&R anyway.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import orchestrator.harness.gate_sim as gs
+from orchestrator.langgraph.backend_graph import (
+    _run_chip_top_gate_sim,
+    route_after_flat_synth,
+)
+from orchestrator.langgraph.integration_helpers import chip_rtl_sources
+
+
+# ---------------------------------------------------------------------------
+# The reference source list
+# ---------------------------------------------------------------------------
+
+class TestChipRtlSources:
+    """One definition, shared with integration/validation DV. If the gate's
+    reference elaborates a different source set than the DV that passed, the
+    comparison is against a different design and the verdict is meaningless."""
+
+    def test_top_comes_first(self, tmp_path):
+        top = tmp_path / "chip_top.v"
+        top.write_text("module chip_top(); endmodule\n")
+        blocks = {}
+        for n in ("b1", "b2", "b3"):
+            f = tmp_path / f"{n}.v"
+            f.write_text(f"module {n}(); endmodule\n")
+            blocks[n] = str(f)
+        srcs = chip_rtl_sources(str(top), blocks)
+        # Callers resolve the Verilator TOPLEVEL from the first entry.
+        assert srcs[0] == str(top)
+        assert set(srcs) == {str(top)} | set(blocks.values())
+
+    def test_every_block_is_included(self, tmp_path):
+        """The whole point: an assembled top is not one file."""
+        top = tmp_path / "chip_top.v"
+        top.write_text("module chip_top(); endmodule\n")
+        blocks = {}
+        for n in ("alpha", "beta", "gamma", "delta", "epsilon"):
+            f = tmp_path / f"{n}.v"
+            f.write_text(f"module {n}(); endmodule\n")
+            blocks[n] = str(f)
+        assert len(chip_rtl_sources(str(top), blocks)) == 6
+
+    def test_nonexistent_block_is_skipped_not_fatal(self, tmp_path):
+        top = tmp_path / "chip_top.v"
+        top.write_text("module chip_top(); endmodule\n")
+        srcs = chip_rtl_sources(str(top), {"ghost": str(tmp_path / "absent.v")})
+        assert srcs == [str(top)]
+
+    def test_top_is_not_duplicated_when_also_listed_as_a_block(self, tmp_path):
+        """Verilator MODDUP-aborts on a duplicated module before any
+        transaction runs, so a duplicate is a hard build failure."""
+        top = tmp_path / "chip_top.v"
+        top.write_text("module chip_top(); endmodule\n")
+        srcs = chip_rtl_sources(str(top), {"chip_top": str(top)})
+        assert srcs.count(str(top)) == 1
+
+    def test_sram_wrapper_lib_is_added_when_a_BLOCK_uses_it(self, tmp_path):
+        """The cs_sram instantiation lives in a LEAF block, not the top. A
+        builder that only inspected the top would miss it and the chip-level
+        build would die on 'Cannot find module cs_sram_1rw1r'."""
+        top = tmp_path / "chip_top.v"
+        top.write_text("module chip_top(); u_blk b(); endmodule\n")
+        blk = tmp_path / "blk.v"
+        blk.write_text(
+            "module blk();\n"
+            "  cs_sram_1rw1r #(.WIDTH(8), .DEPTH(4096)) u_mem (.clk(clk));\n"
+            "endmodule\n"
+        )
+        srcs = chip_rtl_sources(str(top), {"blk": str(blk)})
+        assert any("cs_sram" in s for s in srcs), srcs
+
+
+# ---------------------------------------------------------------------------
+# The gate is actually fed
+# ---------------------------------------------------------------------------
+
+def _run_dir(tmp_path):
+    (tmp_path / "sim_build" / "integration").mkdir(parents=True)
+    (tmp_path / "sim_build" / "integration" / "test_my_chip.py").write_text("#tb\n")
+    top = tmp_path / "rtl" / "integration" / "my_chip.v"
+    top.parent.mkdir(parents=True)
+    top.write_text("module my_chip(input clk); endmodule\n")
+    blk = tmp_path / "rtl" / "blk.v"
+    blk.write_text("module blk(); endmodule\n")
+    return tmp_path, top, blk
+
+
+class TestTheGateIsFedARealSourceList:
+    def test_sources_come_from_the_backend_state_the_flow_populates(
+        self, tmp_path, monkeypatch
+    ):
+        """``integration_top_path`` + ``block_rtl_paths`` are what
+        ``init_design_node`` really returns. Reading a field the flow never
+        sets is how this gate self-disabled on every real run."""
+        monkeypatch.setenv(gs.GATE_SIM_ENV, "1")
+        root, top, blk = _run_dir(tmp_path)
+        seen = {}
+
+        def fake_check(*, block, netlist_path, rtl_path, tb_path):
+            seen["rtl_path"] = rtl_path
+            return gs.GateSimResult(ran=True, ok=True, status=gs.STATUS_PASS,
+                                    reason="ok", cycles_compared=10,
+                                    output_bits_compared=100)
+
+        monkeypatch.setattr(gs, "check_gate_sim", fake_check)
+        ok, status, _ = _run_chip_top_gate_sim({
+            "project_root": str(root),
+            "design_name": "my_chip",
+            "integration_top_path": str(top),
+            "block_rtl_paths": {"blk": str(blk)},
+        }, "net.v")
+
+        assert ok is True and status == gs.STATUS_PASS
+        srcs = seen["rtl_path"]
+        assert not isinstance(srcs, str), "an assembled chip is not one file"
+        assert str(top) in srcs and str(blk) in srcs
+        assert srcs[0] == str(top)
+
+    def test_no_assembled_top_anywhere_is_not_run_never_a_pass(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv(gs.GATE_SIM_ENV, "1")
+        root, _top, _blk = _run_dir(tmp_path)
+        ok, status, reason = _run_chip_top_gate_sim({
+            "project_root": str(root),
+            "design_name": "my_chip",
+        }, "net.v")
+        assert ok is None and status == gs.STATUS_NOT_RUN
+        assert reason                            # absence is always explained
+
+
+# ---------------------------------------------------------------------------
+# The verdict bites
+# ---------------------------------------------------------------------------
+
+class TestTheVerdictBlocksPnR:
+    def test_fail_routes_to_diagnose_not_pnr(self, tmp_path):
+        """The flat netlist provably does not reproduce the verified RTL.
+        Hardening it would spend hours of P&R on a design that does not work."""
+        net = tmp_path / "net.v"
+        net.write_text("module chip_top(); endmodule\n")
+        assert route_after_flat_synth({
+            "flat_netlist_path": str(net), "chip_gate_sim_ok": False,
+        }) == "diagnose"
+
+    def test_pass_proceeds(self, tmp_path):
+        net = tmp_path / "net.v"
+        net.write_text("module chip_top(); endmodule\n")
+        assert route_after_flat_synth({
+            "flat_netlist_path": str(net), "chip_gate_sim_ok": True,
+        }) == "run_pnr"
+
+    def test_not_applicable_does_not_block(self, tmp_path):
+        """``None`` means the gate did not APPLY (disabled, no integration TB,
+        no toolchain). That is not a verdict, and a gate that cannot run must
+        not wall off the flow -- it is already logged with a reason."""
+        net = tmp_path / "net.v"
+        net.write_text("module chip_top(); endmodule\n")
+        assert route_after_flat_synth({
+            "flat_netlist_path": str(net), "chip_gate_sim_ok": None,
+        }) == "run_pnr"
+        assert route_after_flat_synth({
+            "flat_netlist_path": str(net),
+        }) == "run_pnr"
+
+    def test_missing_netlist_still_diagnoses(self, tmp_path):
+        assert route_after_flat_synth({
+            "flat_netlist_path": str(tmp_path / "absent.v"),
+            "chip_gate_sim_ok": True,
+        }) == "diagnose"
+
+
+class TestModdupHazard:
+    """A deterministically-assembled Caravel top and the pad-adapter BLOCK it
+    was assembled from both declare ``module user_project_wrapper``. Two
+    compilation units defining one module is a Verilator MODDUP abort at
+    elaboration -- before a single transaction runs -- so the reference source
+    list handed to a simulator has to be deduped or the gate reports a build
+    failure that says nothing about the netlist."""
+
+    def _caravel_layout(self, tmp_path):
+        pad = tmp_path / "rtl" / "user_project_wrapper.v"
+        pad.parent.mkdir(parents=True)
+        pad.write_text("module user_project_wrapper (input wire clk);\n"
+                       "endmodule\n")
+        top = tmp_path / "rtl" / "integration" / "user_project_wrapper.v"
+        top.parent.mkdir(parents=True)
+        top.write_text("module user_project_wrapper (input wire clk);\n"
+                       "  user_project_wrapper_pads u_pads ();\n"
+                       "endmodule\n")
+        return top, pad
+
+    def test_duplicate_module_is_removed_when_a_dedup_dir_is_given(self, tmp_path):
+        top, pad = self._caravel_layout(tmp_path)
+        srcs = chip_rtl_sources(
+            str(top), {"user_project_wrapper_io": str(pad)},
+            dedup_dir=tmp_path / "scratch")
+        decls = 0
+        for s in srcs:
+            decls += Path(s).read_text().count("module user_project_wrapper ")
+        assert decls == 1, f"{decls} definitions survived: {srcs}"
+
+    def test_raw_paths_when_no_dedup_dir_is_given(self, tmp_path):
+        """Callers that only want paths (linting, reporting) get them back
+        unchanged -- deduping writes files, which a pure query must not do."""
+        top, pad = self._caravel_layout(tmp_path)
+        srcs = chip_rtl_sources(str(top), {"user_project_wrapper_io": str(pad)})
+        assert srcs == [str(top), str(pad)]

--- a/orchestrator/tests/test_drc_verdict.py
+++ b/orchestrator/tests/test_drc_verdict.py
@@ -1,0 +1,493 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""A DRC that produced NO REPORT is not a DRC failure.
+
+Two real macros in ``exp-raster-macro-20260727`` (``w32_d64``, ``w9_d512``)
+carry ``stages.drc = {"ok": false, "violations": -1}`` naming a
+``precheck_magic_drc.rpt`` that was never written -- Magic produced nothing.
+``-1`` meant "could not measure", but every consumer read the negative count and
+``ok: false`` as "this macro HAS DRC violations", so the macros were FAILed for
+a measurement that never happened (and the KLayout sibling did the mirror-image
+thing: a missing XML report counted as ``violation_count = 0`` = clean).
+
+These tests pin the four states apart -- report MISSING, report EMPTY, report
+with ZERO violations, report with N violations -- at both the classifier and the
+two producers, plus the precheck consumer that turns them into a signoff verdict.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.langgraph import tapeout_helpers as th
+from orchestrator.langgraph.drc_verdict import (
+    STATUS_FAIL,
+    STATUS_NOT_RUN,
+    STATUS_PASS,
+    classify_drc,
+    drc_stage,
+    drc_summary,
+    unmeasured_drc,
+)
+
+# Real ``drc listall why`` shapes (mirror of test_backend_helpers fixtures).
+REPORT_CLEAN = "Design: sram_flat\nDRC count: 0\n\n"
+REPORT_3 = (
+    "Design: sram_flat\n"
+    "DRC count: \n"
+    "{Local interconnect spacing < 0.17um (li.3)} "
+    "{{10961 96611 10977 96627} {10961 96611 10981 96627} "
+    "{28515 242879 28529 242899}}\n"
+)
+STDOUT_CLEAN = "DRC violations: 0\n"
+STDOUT_BLANK = "Total DRC errors found: 0\nDRC violations: \n"
+
+
+# ---------------------------------------------------------------------------
+# The classifier: the four states, kept distinct
+# ---------------------------------------------------------------------------
+
+class TestClassifyDrcFourStates:
+    def test_report_missing_is_not_run_not_failure(self, tmp_path):
+        """The raster bug, reproduced: no report on disk, -1 from the parser."""
+        rpt = tmp_path / "precheck_magic_drc.rpt"
+        v = classify_drc(violation_count=-1, report_path=str(rpt))
+
+        assert v["status"] == STATUS_NOT_RUN
+        assert v["measured"] is False
+        assert v["pass"] is False
+        # The lie was "-1 violations". There is NO count.
+        assert v["violation_count"] is None
+        assert "NO DRC report" in v["reason"]
+        assert str(rpt) in v["reason"]
+        assert "NOT a violation count" in v["reason"]
+
+    def test_report_present_but_empty_is_not_run(self, tmp_path):
+        rpt = tmp_path / "precheck_magic_drc.rpt"
+        rpt.write_text("")
+        v = classify_drc(violation_count=0, report_path=str(rpt))
+
+        assert v["status"] == STATUS_NOT_RUN
+        assert v["violation_count"] is None
+        assert "EMPTY" in v["reason"]
+
+    def test_report_present_but_whitespace_only_is_not_run(self, tmp_path):
+        rpt = tmp_path / "precheck_magic_drc.rpt"
+        rpt.write_text("\n \n")
+        assert classify_drc(violation_count=0,
+                            report_path=str(rpt))["status"] == STATUS_NOT_RUN
+
+    def test_zero_violations_with_a_real_report_is_a_pass(self, tmp_path):
+        rpt = tmp_path / "precheck_magic_drc.rpt"
+        rpt.write_text(REPORT_CLEAN)
+        v = classify_drc(violation_count=0, report_path=str(rpt))
+
+        assert v["status"] == STATUS_PASS
+        assert v["pass"] is True
+        assert v["measured"] is True
+        assert v["violation_count"] == 0
+
+    def test_n_violations_is_a_failure(self, tmp_path):
+        rpt = tmp_path / "precheck_magic_drc.rpt"
+        rpt.write_text(REPORT_3)
+        v = classify_drc(violation_count=3, report_path=str(rpt))
+
+        assert v["status"] == STATUS_FAIL
+        assert v["pass"] is False
+        assert v["measured"] is True
+        assert v["violation_count"] == 3
+
+
+class TestClassifyDrcEdges:
+    def test_tool_that_never_ran_is_not_run_with_the_tool_error(self, tmp_path):
+        rpt = tmp_path / "r.rpt"
+        rpt.write_text(REPORT_CLEAN)
+        v = classify_drc(violation_count=0, report_path=str(rpt),
+                         tool_ran=False, tool_error="magic: cannot load GDS")
+
+        assert v["status"] == STATUS_NOT_RUN
+        assert v["violation_count"] is None
+        assert "cannot load GDS" in v["reason"]
+
+    def test_measured_violations_survive_a_crashed_tool(self, tmp_path):
+        """A report full of rects is evidence even if the tool then died."""
+        rpt = tmp_path / "r.rpt"
+        rpt.write_text(REPORT_3)
+        v = classify_drc(violation_count=3, report_path=str(rpt),
+                         tool_ran=False, tool_error="segfault")
+
+        assert v["status"] == STATUS_FAIL
+        assert v["violation_count"] == 3
+
+    def test_report_without_a_parseable_count_is_not_run(self, tmp_path):
+        rpt = tmp_path / "r.rpt"
+        rpt.write_text("Design: sram_flat\n(magic said nothing else)\n")
+        v = classify_drc(violation_count=None, report_path=str(rpt))
+
+        assert v["status"] == STATUS_NOT_RUN
+        assert "no parseable violation count" in v["reason"]
+
+    def test_no_report_path_at_all_is_not_run(self):
+        v = classify_drc(violation_count=0, report_path="")
+        assert v["status"] == STATUS_NOT_RUN
+        assert "no DRC report path" in v["reason"]
+
+    @pytest.mark.parametrize("bad", [-1, -999, None, "", "abc", True, False])
+    def test_no_unmeasured_input_can_produce_a_pass_or_a_count(self, bad, tmp_path):
+        """Every "could not measure" input shape lands in not_run with no count."""
+        rpt = tmp_path / "missing.rpt"  # deliberately not created
+        v = classify_drc(violation_count=bad, report_path=str(rpt))
+        assert v["status"] == STATUS_NOT_RUN
+        assert v["pass"] is False
+        assert v["violation_count"] is None
+
+    def test_unmeasured_drc_always_carries_a_reason(self):
+        v = unmeasured_drc("openram never ran DRC", tool="OpenRAM")
+        assert v["status"] == STATUS_NOT_RUN
+        assert v["reason"] == "openram never ran DRC"
+        assert v["pass"] is False and v["violation_count"] is None
+        # `error` so readers that only print that field still say why.
+        assert v["error"] == v["reason"]
+
+
+class TestVerdictRendering:
+    def test_summary_words_are_distinct_per_state(self, tmp_path):
+        rpt = tmp_path / "r.rpt"
+        rpt.write_text(REPORT_CLEAN)
+        clean = drc_summary(classify_drc(violation_count=0, report_path=str(rpt)))
+        dirty = drc_summary(classify_drc(violation_count=7, report_path=str(rpt)))
+        unmeasured = drc_summary(unmeasured_drc("magic wrote nothing"))
+
+        assert "clean" in clean and "COULD NOT" not in clean
+        assert "7 violation(s)" in dirty
+        assert "COULD NOT BE MEASURED" in unmeasured
+        assert "magic wrote nothing" in unmeasured
+        # The unmeasured line must never read as a count or as clean.
+        assert "-1" not in unmeasured and "clean" not in unmeasured
+
+    def test_stage_ok_is_tri_state(self, tmp_path):
+        rpt = tmp_path / "r.rpt"
+        rpt.write_text(REPORT_CLEAN)
+
+        assert drc_stage(classify_drc(violation_count=0,
+                                      report_path=str(rpt)))["ok"] is True
+        assert drc_stage(classify_drc(violation_count=2,
+                                      report_path=str(rpt)))["ok"] is False
+        unmeasured = drc_stage(unmeasured_drc("no report"))
+        # NOT False (that claims violations were found) and NOT True.
+        assert unmeasured["ok"] is None
+        assert unmeasured["status"] == STATUS_NOT_RUN
+        assert unmeasured["violations"] is None
+        assert not unmeasured["ok"], "must never read as success"
+
+
+# ---------------------------------------------------------------------------
+# Producer: _run_magic_drc_on_gds (the gen_ram / precheck DRC stage)
+# ---------------------------------------------------------------------------
+
+def _fake_run_magic(monkeypatch, *, success=True, drc_count=0, stdout="",
+                    stderr="", writes: str | None = None, name="rpt"):
+    """Stand in for backend_helpers.run_magic; optionally write the report."""
+    import orchestrator.langgraph.backend_helpers as bh
+
+    def fake(tcl_script, block_name, step="drc", attempt=1, timeout=600):
+        if writes is not None:
+            (Path(tcl_script).parent / "precheck_magic_drc.rpt").write_text(writes)
+        return {
+            "success": success,
+            "drc_count": drc_count,
+            "stdout": stdout,
+            "stderr": stderr,
+            "log_path": "/tmp/fake.log",
+        }
+
+    monkeypatch.setattr(bh, "run_magic", fake)
+
+
+class TestRunMagicDrcOnGds:
+    @pytest.fixture
+    def gds(self, tmp_path):
+        p = tmp_path / "sram.gds"
+        p.write_bytes(b"\x00\x06\x00\x02\x00\x07")
+        return str(p)
+
+    def test_no_report_is_not_run_not_a_minus_one_failure(self, monkeypatch,
+                                                          tmp_path, gds):
+        """Exactly the raster case: magic ran, wrote no report, count -1."""
+        _fake_run_magic(monkeypatch, success=False, drc_count=-1,
+                        stderr="magic: no such layout")
+        v = th._run_magic_drc_on_gds(gds, str(tmp_path))
+
+        assert v["status"] == STATUS_NOT_RUN
+        assert v["violation_count"] is None
+        assert v["pass"] is False
+        assert v["reason"]
+        assert "precheck_magic_drc.rpt" in v["report_path"]
+
+    def test_tool_ok_but_report_absent_is_still_not_run(self, monkeypatch,
+                                                       tmp_path, gds):
+        _fake_run_magic(monkeypatch, success=True, drc_count=-1)
+        v = th._run_magic_drc_on_gds(gds, str(tmp_path))
+        assert v["status"] == STATUS_NOT_RUN
+        assert "NO DRC report" in v["reason"]
+
+    def test_empty_report_is_not_run(self, monkeypatch, tmp_path, gds):
+        _fake_run_magic(monkeypatch, success=True, drc_count=0, writes="")
+        v = th._run_magic_drc_on_gds(gds, str(tmp_path))
+        assert v["status"] == STATUS_NOT_RUN
+        assert "EMPTY" in v["reason"]
+        assert v["violation_count"] is None
+
+    def test_clean_report_still_passes(self, monkeypatch, tmp_path, gds):
+        _fake_run_magic(monkeypatch, success=True, drc_count=0,
+                        stdout=STDOUT_CLEAN, writes=REPORT_CLEAN)
+        v = th._run_magic_drc_on_gds(gds, str(tmp_path))
+        assert v["status"] == STATUS_PASS
+        assert v["pass"] is True
+        assert v["violation_count"] == 0
+
+    def test_violations_still_fail(self, monkeypatch, tmp_path, gds):
+        _fake_run_magic(monkeypatch, success=True, drc_count=12,
+                        stdout="DRC violations: 12\n", writes=REPORT_3)
+        v = th._run_magic_drc_on_gds(gds, str(tmp_path))
+        assert v["status"] == STATUS_FAIL
+        assert v["violation_count"] == 12
+
+    def test_blank_stdout_count_is_recounted_from_this_flows_report(
+            self, monkeypatch, tmp_path, gds):
+        """run_magic's recount only knows magic_drc.rpt, so the PRECHECK report
+        was never consulted -- a blank stdout count read as a clean 0 over a
+        report holding real rects."""
+        monkeypatch.delenv("CORESMITH_DRC_REPORT_FALLBACK", raising=False)
+        _fake_run_magic(monkeypatch, success=True, drc_count=0,
+                        stdout=STDOUT_BLANK, writes=REPORT_3)
+        v = th._run_magic_drc_on_gds(gds, str(tmp_path))
+        assert v["status"] == STATUS_FAIL
+        assert v["violation_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Producer: _run_klayout_drc (advisory sibling, mirror-image bug)
+# ---------------------------------------------------------------------------
+
+class TestRunKlayoutDrc:
+    @pytest.fixture
+    def gds(self, tmp_path):
+        p = tmp_path / "wrapper.gds"
+        p.write_bytes(b"\x00\x06\x00\x02\x00\x07")
+        return str(p)
+
+    def _fake_subprocess(self, monkeypatch, *, returncode=0,
+                         writes: str | None = None, out_dir: Path | None = None):
+        import subprocess as sp
+
+        class R:
+            def __init__(self):
+                self.returncode = returncode
+                self.stdout = ""
+                self.stderr = ""
+
+        def fake_run(cmd, **kw):
+            if writes is not None and out_dir is not None:
+                (out_dir / "klayout_drc.xml").write_text(writes)
+            return R()
+
+        monkeypatch.setattr(sp, "run", fake_run)
+        monkeypatch.setattr(th, "_write_step_log",
+                            lambda *a, **k: "/tmp/klayout.log")
+
+    def test_missing_report_no_longer_reads_as_clean(self, monkeypatch,
+                                                    tmp_path, gds):
+        """It returned violation_count=0 -> pass=True with NO report at all."""
+        self._fake_subprocess(monkeypatch)
+        v = th._run_klayout_drc(gds, str(tmp_path))
+        assert v["status"] == STATUS_NOT_RUN
+        assert v["pass"] is False
+        assert v["violation_count"] is None
+
+    def test_clean_xml_report_passes(self, monkeypatch, tmp_path, gds):
+        self._fake_subprocess(monkeypatch, writes="<report></report>\n",
+                              out_dir=tmp_path)
+        v = th._run_klayout_drc(gds, str(tmp_path))
+        assert v["status"] == STATUS_PASS
+        assert v["violation_count"] == 0
+
+    def test_items_in_xml_report_fail(self, monkeypatch, tmp_path, gds):
+        self._fake_subprocess(monkeypatch,
+                              writes="<report><item></item><item></item></report>\n",
+                              out_dir=tmp_path)
+        v = th._run_klayout_drc(gds, str(tmp_path))
+        assert v["status"] == STATUS_FAIL
+        assert v["violation_count"] == 2
+
+    def test_missing_binary_stays_skipped_and_unmeasured(self, monkeypatch,
+                                                        tmp_path, gds):
+        import subprocess as sp
+
+        def boom(cmd, **kw):
+            raise FileNotFoundError("klayout")
+
+        monkeypatch.setattr(sp, "run", boom)
+        v = th._run_klayout_drc(gds, str(tmp_path))
+        assert v["status"] == STATUS_NOT_RUN
+        assert v["skipped"] is True
+        # NOT the old fabricated 0 (which read as "clean").
+        assert v["violation_count"] is None
+
+
+# ---------------------------------------------------------------------------
+# Consumer: run_mpw_precheck_native
+# ---------------------------------------------------------------------------
+
+class TestPrecheckConsumer:
+    @pytest.fixture
+    def sub(self, monkeypatch, tmp_path):
+        """A submission dir whose non-DRC checks all pass."""
+        ok = {"pass": True, "errors": [], "warnings": []}
+        for fn in ("_check_submission_structure", "_check_and_generate_user_defines",
+                   "_check_wrapper_port_names"):
+            monkeypatch.setattr(th, fn, lambda *a, **k: dict(ok))
+        monkeypatch.setattr(th, "_check_gds_file", lambda *a, **k: dict(ok))
+        (tmp_path / "gds").mkdir()
+        (tmp_path / "gds" / "top.gds").write_bytes(b"\x00")
+        return tmp_path
+
+    def _run(self, monkeypatch, sub, *, magic, klayout=None):
+        if klayout is None:  # default: a clean, MEASURED advisory KLayout run
+            (sub / "k.xml").write_text("<report></report>")
+            klayout = classify_drc(violation_count=0,
+                                   report_path=str(sub / "k.xml"),
+                                   tool="KLayout")
+        monkeypatch.setattr(th, "_run_klayout_drc", lambda *a, **k: dict(klayout))
+        monkeypatch.setattr(th, "_run_magic_drc_on_gds", lambda *a, **k: dict(magic))
+        return th.run_mpw_precheck_native(str(sub))
+
+    def test_unmeasured_magic_drc_blocks_but_is_not_reported_as_violations(
+            self, monkeypatch, sub):
+        magic = unmeasured_drc(
+            "Magic left NO DRC report at /x/precheck_magic_drc.rpt",
+            report_path="/x/precheck_magic_drc.rpt")
+        res = self._run(monkeypatch, sub, magic=magic)
+
+        # Fail-closed: a shuttle submission is not signed off without a DRC
+        # MEASUREMENT ...
+        assert res["pass"] is False
+        joined = " ".join(res["errors"])
+        # ... but it is NOT described as a violation count.
+        assert "COULD NOT BE MEASURED" in joined
+        assert "-1 violations" not in joined
+        assert res["checks"]["magic_drc"]["status"] == STATUS_NOT_RUN
+        assert res["checks"]["magic_drc"]["violation_count"] is None
+
+    def test_measured_violations_still_reported_as_violations(self, monkeypatch,
+                                                             sub):
+        rpt = sub / "m.rpt"
+        rpt.write_text(REPORT_3)
+        magic = classify_drc(violation_count=5, report_path=str(rpt))
+        res = self._run(monkeypatch, sub, magic=magic)
+
+        assert res["pass"] is False
+        assert any("5 violation(s)" in e for e in res["errors"])
+
+    def test_clean_magic_drc_still_passes(self, monkeypatch, sub):
+        rpt = sub / "m.rpt"
+        rpt.write_text(REPORT_CLEAN)
+        magic = classify_drc(violation_count=0, report_path=str(rpt))
+        res = self._run(monkeypatch, sub, magic=magic)
+
+        assert res["pass"] is True, res["errors"]
+
+    def test_unmeasured_advisory_klayout_warns_without_blocking(self, monkeypatch,
+                                                                sub):
+        rpt = sub / "m.rpt"
+        rpt.write_text(REPORT_CLEAN)
+        res = self._run(
+            monkeypatch, sub,
+            magic=classify_drc(violation_count=0, report_path=str(rpt)),
+            klayout=unmeasured_drc("KLayout wrote no XML report",
+                                   tool="KLayout"))
+
+        # Advisory + unmeasured: warned, not a hard fail (same posture a
+        # missing binary always had).
+        assert res["pass"] is True, res["errors"]
+        assert any("COULD NOT BE MEASURED" in w for w in res["warnings"])
+
+    def test_measured_klayout_violations_still_block(self, monkeypatch, sub):
+        rpt = sub / "m.rpt"
+        rpt.write_text(REPORT_CLEAN)
+        krpt = sub / "k.xml"
+        krpt.write_text("<report><item></item></report>")
+        res = self._run(
+            monkeypatch, sub,
+            magic=classify_drc(violation_count=0, report_path=str(rpt)),
+            klayout=classify_drc(violation_count=1, report_path=str(krpt),
+                                 tool="KLayout"))
+
+        assert res["pass"] is False
+        assert any("1 violation(s)" in w for w in res["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Consumer: the tapeout diagnosis agent's context formatters
+# ---------------------------------------------------------------------------
+
+class TestDiagnosisFormatting:
+    """The diagnosis agent must not be told to hunt violations that were never
+    measured -- it renders the precheck checks and the DRC result for an LLM."""
+
+    def test_unmeasured_check_is_not_rendered_as_FAIL(self):
+        from orchestrator.architecture.specialists.tapeout_diagnosis import (
+            _format_precheck,
+        )
+        text = _format_precheck({
+            "pass": False,
+            "checks": {
+                "structure": {"pass": True},
+                "magic_drc": unmeasured_drc(
+                    "Magic left NO DRC report at /x/precheck_magic_drc.rpt"),
+            },
+            "errors": ["Magic DRC COULD NOT BE MEASURED: ..."],
+        })
+        assert "magic_drc: NOT MEASURED" in text
+        assert "magic_drc: FAIL" not in text
+        assert "NO DRC report" in text
+        assert "structure: PASS" in text
+
+    def test_measured_violation_check_still_renders_FAIL(self, tmp_path):
+        from orchestrator.architecture.specialists.tapeout_diagnosis import (
+            _format_precheck,
+        )
+        rpt = tmp_path / "m.rpt"
+        rpt.write_text(REPORT_3)
+        text = _format_precheck({
+            "pass": False,
+            "checks": {"magic_drc": classify_drc(violation_count=4,
+                                                 report_path=str(rpt))},
+        })
+        assert "magic_drc: FAIL" in text
+
+    def test_format_drc_unmeasured_says_no_count_exists(self, tmp_path):
+        from orchestrator.architecture.specialists.tapeout_diagnosis import (
+            _format_drc,
+        )
+        text = _format_drc(unmeasured_drc("magic wrote nothing"), tmp_path)
+        assert "COULD NOT BE MEASURED" in text
+        assert "NO violation count" in text
+        assert "-1" not in text
+
+    def test_format_drc_legacy_minus_one_is_labelled_not_measured(self, tmp_path):
+        from orchestrator.architecture.specialists.tapeout_diagnosis import (
+            _format_drc,
+        )
+        text = _format_drc({"clean": False, "violation_count": -1}, tmp_path)
+        assert "Violation count: NOT MEASURED" in text
+
+    def test_format_drc_measured_count_is_unchanged(self, tmp_path):
+        from orchestrator.architecture.specialists.tapeout_diagnosis import (
+            _format_drc,
+        )
+        text = _format_drc({"clean": False, "violation_count": 9}, tmp_path)
+        assert "Violation count: 9" in text

--- a/orchestrator/tests/test_gate_sim.py
+++ b/orchestrator/tests/test_gate_sim.py
@@ -6,10 +6,12 @@
 
 The gate replays the verified RTL's own port vectors through the SYNTHESIZED
 NETLIST and fails closed on divergence. These tests pin (a) both branches of the
-``CORESMITH_GATE_SIM`` env gate, (b) the netlist/VCD plumbing that has to be
-exactly right for the comparison to mean anything, and (c) every fail-closed
-path -- blank verdict, zero cycles, zero compared bits, vacuous stimulus,
-unmodelled macro, netlist that will not elaborate.
+``CORESMITH_GATE_SIM`` env gate and of the scope guard, (b) the netlist/VCD
+plumbing that has to be exactly right for the comparison to mean anything,
+(c) every fail-closed path -- blank verdict, zero cycles, zero compared bits,
+vacuous stimulus, unmodelled macro, netlist that will not elaborate, (d) that a
+generated hard-macro stand-in matches the REAL macro's declared interface, and
+(e) that a power-only tri-state boundary is judged while a signal one is not.
 
 The live Verilator build is exercised at the LOGIC level here via an injected
 runner: the mechanism and the fail semantics are what these tests pin, not the
@@ -39,7 +41,33 @@ module blk(clk, rst_n, en, q, valid);
 endmodule
 """
 
-_BLOCK = {"name": "blk"}
+# The same netlist with a Caravel-style POWER-ONLY bidirectional boundary.
+_NETLIST_RAILS = _NETLIST.replace(
+    "module blk(clk, rst_n, en, q, valid);",
+    "module blk(clk, rst_n, en, q, valid, vccd1, vssd1);",
+).replace(
+    "  sky130_fd_sc_hd__dfxtp_1",
+    "  inout vccd1;\n  wire vccd1;\n  inout vssd1;\n  wire vssd1;\n"
+    "  sky130_fd_sc_hd__dfxtp_1",
+)
+
+# The same netlist with a real bidirectional SIGNAL on the boundary.
+_NETLIST_TRISTATE = _NETLIST.replace(
+    "module blk(clk, rst_n, en, q, valid);",
+    "module blk(clk, rst_n, en, q, valid, sda);",
+).replace(
+    "  sky130_fd_sc_hd__dfxtp_1",
+    "  inout sda;\n  wire sda;\n  sky130_fd_sc_hd__dfxtp_1",
+)
+
+# The subject under test declares itself the chip top. The gate's DEFAULT SCOPE
+# is chip_top -- a per-block netlist is an intermediate whose stimulus is that
+# block's own testbench, not the artifact that becomes silicon -- so a subject
+# that is not marked would be `not_run` before any verdict logic ran, and these
+# tests are about the verdict logic. The leaf-block behaviour has its own test
+# (``test_leaf_block_is_not_run_under_the_default_scope``); it is deliberately
+# NOT worked around by weakening the guard.
+_BLOCK = {"name": "blk", "is_chip_top": True}
 
 
 # --------------------------------------------------------------------------- #
@@ -88,6 +116,73 @@ def test_enabled_gate_actually_evaluates_the_netlist(monkeypatch, tmp_path):
     assert "NO NETLIST" in res.reason
 
 
+# --------------------------------------------------------------------------- #
+# scope guard -- the gate judges chip_top by default
+# --------------------------------------------------------------------------- #
+def test_scope_defaults_to_chip_top(monkeypatch):
+    monkeypatch.delenv(gs.GATE_SIM_SCOPE_ENV, raising=False)
+    assert gs.gate_sim_scope() == "chip_top"
+    monkeypatch.setenv(gs.GATE_SIM_SCOPE_ENV, "block")
+    assert gs.gate_sim_scope() == "block"
+    monkeypatch.setenv(gs.GATE_SIM_SCOPE_ENV, "any")
+    assert gs.gate_sim_scope() == "any"
+    monkeypatch.setenv(gs.GATE_SIM_SCOPE_ENV, "nonsense")
+    assert gs.gate_sim_scope() == "chip_top", "an unknown scope must not widen it"
+
+
+@pytest.mark.parametrize("block", [
+    {"name": "blk", "is_chip_top": True},
+    {"name": "blk", "scope": "chip_top"},
+    {"name": "chip_top"},
+    {"name": "integration"},
+    {"name": "my_design_chip_top"},
+])
+def test_block_is_chip_top_recognises_the_top(block):
+    assert gs.block_is_chip_top(block) is True
+
+
+@pytest.mark.parametrize("block", [{"name": "blk"}, {"name": "fifo"}, {}])
+def test_block_is_chip_top_rejects_a_leaf(block):
+    assert gs.block_is_chip_top(block) is False
+
+
+def test_leaf_block_is_not_run_under_the_default_scope(monkeypatch, tmp_path):
+    """NEW BEHAVIOUR: with the default scope the gate judges the integrated
+    chip_top netlist only. A LEAF block is ``not_run`` -- never a pass and never
+    a failure -- and the reason has to say why and how to opt in, because a
+    silent skip is indistinguishable from a check that passed."""
+    monkeypatch.delenv(gs.GATE_SIM_ENV, raising=False)          # default ON
+    monkeypatch.delenv(gs.GATE_SIM_SCOPE_ENV, raising=False)    # default chip_top
+    net = tmp_path / "n.v"
+    net.write_text(_NETLIST)
+    res = gs.check_gate_sim({"name": "fifo"}, str(net), "r.v", "tb.py")
+    assert res.status == gs.STATUS_NOT_RUN
+    assert res.ran is False and res.blocking is False
+    assert "fifo" in res.reason and "chip_top" in res.reason
+    assert gs.GATE_SIM_SCOPE_ENV in res.reason
+
+
+def test_scope_block_admits_a_leaf_again(monkeypatch, tmp_path):
+    """The per-block replay is still available -- it is how a synthesis-side
+    stub scoring 143/144 line coverage was caught."""
+    monkeypatch.setenv(gs.GATE_SIM_ENV, "1")
+    monkeypatch.setenv(gs.GATE_SIM_SCOPE_ENV, "block")
+    monkeypatch.setattr(gs.shutil, "which", lambda _n: "/usr/bin/verilator")
+    res = gs.check_gate_sim({"name": "fifo"}, str(tmp_path / "gone.v"),
+                            "r.v", "tb.py")
+    assert res.status == gs.STATUS_NOT_RUN
+    assert "NO NETLIST" in res.reason, "reached the netlist check, not the guard"
+
+
+def test_disabled_outranks_out_of_scope(monkeypatch, tmp_path):
+    """A reader of a leaf block's report must be told the gate is OFF, not that
+    the subject was out of scope -- nothing would have run either way."""
+    monkeypatch.setenv(gs.GATE_SIM_ENV, "0")
+    monkeypatch.delenv(gs.GATE_SIM_SCOPE_ENV, raising=False)
+    res = gs.check_gate_sim({"name": "fifo"}, str(tmp_path / "n.v"), "r.v", "tb.py")
+    assert res.status == gs.STATUS_DISABLED
+
+
 def test_strict_gate_both_branches(monkeypatch):
     monkeypatch.delenv("CORESMITH_GATE_SIM_STRICT", raising=False)
     assert gs.gate_sim_strict() is False
@@ -111,6 +206,19 @@ def test_macro_model_mode_env(monkeypatch):
     assert gs.gate_sim_macro_model_mode() == "generated"
     monkeypatch.setenv("CORESMITH_GATE_SIM_MACRO_MODEL", "pdk")
     assert gs.gate_sim_macro_model_mode() == "pdk"
+
+
+def test_debug_env_both_branches(monkeypatch):
+    monkeypatch.delenv(gs.GATE_SIM_DEBUG_ENV, raising=False)
+    assert gs.gate_sim_debug() is False
+    monkeypatch.setenv(gs.GATE_SIM_DEBUG_ENV, "1")
+    assert gs.gate_sim_debug() is True
+    monkeypatch.delenv("CORESMITH_GATE_SIM_MAX_DIVERGENCES", raising=False)
+    assert gs.gate_sim_max_divergences() == 32
+    monkeypatch.setenv("CORESMITH_GATE_SIM_MAX_DIVERGENCES", "4")
+    assert gs.gate_sim_max_divergences() == 4
+    monkeypatch.setenv("CORESMITH_GATE_SIM_MAX_DIVERGENCES", "garbage")
+    assert gs.gate_sim_max_divergences() == 32
 
 
 # --------------------------------------------------------------------------- #
@@ -248,11 +356,114 @@ def test_cell_model_files_absent_pdk(tmp_path):
     assert gs.cell_model_files(tmp_path / "nothing", _NETLIST) == ([], ())
 
 
-def test_macro_model_source_1rw1r_geometry():
-    src = gs.macro_model_source("m8x1024", "1rw1r", 8, 1024, 8)
+# --------------------------------------------------------------------------- #
+# hard-macro stand-in: the interface is READ from the real macro, not guessed
+# --------------------------------------------------------------------------- #
+def _openram_model(tmp_path, name, *, data_bits, addr_bits, nmask=0, gran=8,
+                   extra_port=""):
+    """Write a structurally faithful OpenRAM sky130 1rw1r behavioural model.
+
+    Reproduces exactly the shape the PDK ships -- non-ANSI header, geometry
+    behind ``parameter``s, supplies behind ```ifdef USE_POWER_PINS``, and the
+    ``merge_write0`` function whose ``if (write_mask[i])`` arms are the ground
+    truth for which data bits each mask bit covers. ``nmask=0`` models the
+    ``word_size == write_size`` case, where OpenRAM omits ``wmask0`` ENTIRELY.
+    """
+    wm_hdr = "wmask0," if nmask else ""
+    wm_decl = ("  input [NUM_WMASKS-1:0]   wmask0; // write mask\n"
+               if nmask else "")
+    wm_arg = "    input [NUM_WMASKS-1:0] write_mask;\n" if nmask else ""
+    if nmask:
+        arms = "".join(
+            f"      if (write_mask[{i}])\n"
+            f"        merge_write0[{min((i + 1) * gran - 1, data_bits - 1)}:"
+            f"{i * gran}] = new_word[{min((i + 1) * gran - 1, data_bits - 1)}:"
+            f"{i * gran}];\n"
+            for i in range(nmask))
+    else:
+        arms = (f"      merge_write0[{data_bits - 1}:0] = "
+                f"new_word[{data_bits - 1}:0];\n")
+    src = f"""`timescale 1ns/1ps
+
+// OpenRAM SRAM model
+// Words: {1 << addr_bits}
+// Word size: {data_bits}
+
+module {name}(
+`ifdef USE_POWER_PINS
+    vccd1,
+    vssd1,
+`endif
+// Port 0: RW
+    clk0,csb0,web0,{wm_hdr}addr0,din0,dout0,
+// Port 1: R
+    clk1,csb1,addr1,dout1{"," + extra_port if extra_port else ""}
+  );
+
+  parameter NUM_WMASKS = {nmask} ;
+  parameter DATA_WIDTH = {data_bits} ;
+  parameter ADDR_WIDTH = {addr_bits} ;
+  parameter RAM_DEPTH = 1 << ADDR_WIDTH;
+  parameter T_HOLD = 1 ;
+
+`ifdef USE_POWER_PINS
+    inout vccd1;
+    inout vssd1;
+`endif
+  input  clk0; // clock
+  input   csb0; // active low chip select
+  input  web0; // active low write control
+{wm_decl}  input [ADDR_WIDTH-1:0]  addr0;
+  input [DATA_WIDTH-1:0]  din0;
+  output [DATA_WIDTH-1:0] dout0;
+  input  clk1; // clock
+  input   csb1; // active low chip select
+  input [ADDR_WIDTH-1:0]  addr1;
+  output [DATA_WIDTH-1:0] dout1;
+{"  input  " + extra_port + ";" if extra_port else ""}
+
+  reg [DATA_WIDTH-1:0]    mem [0:RAM_DEPTH-1];
+
+  function [DATA_WIDTH-1:0] merge_write0;
+    input [DATA_WIDTH-1:0] old_word;
+    input [DATA_WIDTH-1:0] new_word;
+{wm_arg}    begin
+      merge_write0 = old_word;
+{arms}    end
+  endfunction
+endmodule
+"""
+    p = tmp_path / f"{name}.v"
+    p.write_text(src)
+    return p
+
+
+def test_macro_interface_reads_the_real_declarations(tmp_path):
+    p = _openram_model(tmp_path, "m32x256", data_bits=32, addr_bits=8, nmask=4)
+    iface = gs.macro_interface("m32x256", p)
+    assert iface is not None
+    assert iface.order == ["clk0", "csb0", "web0", "wmask0", "addr0", "din0",
+                           "dout0", "clk1", "csb1", "addr1", "dout1"]
+    assert iface.widths["wmask0"] == 4
+    assert iface.widths["addr0"] == 8
+    assert iface.widths["din0"] == 32
+    # supplies are NOT functional ports; they stay behind the ifdef
+    assert iface.power_pins == ["vccd1", "vssd1"]
+    assert "vccd1" not in iface.order
+    # the merge function is the ground truth for the mask slicing
+    assert iface.mask_slices == [(7, 0), (15, 8), (23, 16), (31, 24)]
+
+
+def test_macro_stand_in_geometry_comes_from_the_declarations(tmp_path):
+    p = _openram_model(tmp_path, "m8x1024", data_bits=8, addr_bits=10, nmask=1)
+    src = gs.macro_model_source("m8x1024", "1rw1r", 8, 1024, 8,
+                                iface=gs.macro_interface("m8x1024", p))
     assert "module m8x1024" in src
     assert "input  wire [9:0] addr0;" in src
-    assert "output reg  [7:0] dout0;" in src
+    assert "output reg [7:0] dout0;" in src
+    # depth is `1 << ADDR_WIDTH`, exactly as the PDK model declares RAM_DEPTH --
+    # sizing from the registry's word count would leave an addressable index out
+    # of range on a non-power-of-two macro.
     assert "reg [7:0] mem [0:1023];" in src
     assert "always @(posedge clk1)" in src
     # a cycle-accurate model must not carry the PDK model's delays or tracing
@@ -260,13 +471,124 @@ def test_macro_model_source_1rw1r_geometry():
     assert "#(" not in code and "$display" not in code
 
 
-def test_macro_model_source_write_mask_slices():
-    src = gs.macro_model_source("m32x256", "1rw1r", 32, 256, 8)
+def test_macro_stand_in_write_mask_slices(tmp_path):
+    p = _openram_model(tmp_path, "m32x256", data_bits=32, addr_bits=8, nmask=4)
+    src = gs.macro_model_source("m32x256", "1rw1r", 32, 256, 8,
+                                iface=gs.macro_interface("m32x256", p))
+    assert "input  wire [3:0] wmask0;" in src
     assert "if (wmask0[3]) mem[addr0][31:24]" in src
 
 
-def test_macro_model_source_unknown_ports_is_empty():
+def test_macro_stand_in_omits_a_port_the_real_macro_does_not_declare(tmp_path):
+    """REGRESSION -- the false FAIL this file exists to prevent.
+
+    ``sram_1rw1r_8_4096_8`` has word_size == write_size == 8, so a single
+    whole-word mask bit IS the write enable and OpenRAM omits ``wmask0``
+    entirely. The old generator emitted it anyway and gated writes on
+    ``wmask0[0]``; the flat netlist correctly left the pin unconnected,
+    Verilator tied the floating input LOW, every write was suppressed, every
+    read returned zero, and a correctly synthesized netlist "failed" gate sim.
+    """
+    p = _openram_model(tmp_path, "m8x4096", data_bits=8, addr_bits=12, nmask=0)
+    iface = gs.macro_interface("m8x4096", p)
+    assert "wmask0" not in iface.order
+    src = gs.macro_model_source("m8x4096", "1rw1r", 8, 4096, 8, iface=iface)
+    assert "wmask0" not in src, "declared a pin the real macro does not have"
+    # ...and the write must not silently vanish with the mask
+    assert "if (!web0) begin\n        mem[addr0] <= din0;" in src
+
+
+def test_macro_stand_in_matches_a_declared_mask_width_exactly(tmp_path):
+    """REGRESSION -- the second, opposite instance of the same defect.
+
+    ``sram_1rw1r_9_4096_8`` DOES declare ``wmask0``, as ``[1:0]``
+    (NUM_WMASKS == ceil(9/8) == 2). The old generator computed ``9 // 8 == 1``
+    and declared ``[0:0]``, so the netlist drove ``2'h3`` into a 1-bit port --
+    harmless only because that mask happened to be a constant.
+    """
+    p = _openram_model(tmp_path, "m9x4096", data_bits=9, addr_bits=12, nmask=2)
+    src = gs.macro_model_source("m9x4096", "1rw1r", 9, 4096, 8,
+                                iface=gs.macro_interface("m9x4096", p))
+    assert "input  wire [1:0] wmask0;" in src
+    assert "[0:0] wmask0" not in src
+    # the partial final mask group covers exactly one bit, as the real
+    # merge_write0 says -- not a rounded-up byte
+    assert "if (wmask0[0]) mem[addr0][7:0] <= din0[7:0];" in src
+    assert "if (wmask0[1]) mem[addr0][8:8] <= din0[8:8];" in src
+
+
+def test_macro_stand_in_without_an_interface_is_unresolved():
+    """No macro source => no interface => UNRESOLVED, which the caller turns
+    into a FAIL. It must never fall back to arithmetic on registry metadata:
+    that guess is what shipped two wrong stand-ins."""
+    assert gs.macro_model_source("m8x1024", "1rw1r", 8, 1024, 8) == ""
     assert gs.macro_model_source("weird", "3q", 8, 16, 8) == ""
+
+
+def test_macro_interface_unreadable_source_is_none(tmp_path):
+    assert gs.macro_interface("gone", tmp_path / "absent.v") is None
+    assert gs.macro_interface("gone", "") is None
+    other = tmp_path / "other.v"
+    other.write_text("module something_else(input clk);\nendmodule\n")
+    assert gs.macro_interface("gone", other) is None
+
+
+def test_macro_interface_unresolvable_width_is_none(tmp_path):
+    """A width we cannot evaluate is UNKNOWN, not 1 and not a default."""
+    p = tmp_path / "m.v"
+    p.write_text(
+        "module m(clk0, csb0, web0, addr0, din0, dout0);\n"
+        "  parameter DATA_WIDTH = 8;\n"
+        "  input clk0;\n  input csb0;\n  input web0;\n"
+        "  input [$clog2(SOMETHING)-1:0] addr0;\n"
+        "  input [DATA_WIDTH-1:0] din0;\n"
+        "  output [DATA_WIDTH-1:0] dout0;\n"
+        "endmodule\n")
+    assert gs.macro_interface("m", p) is None
+
+
+def test_macro_stand_in_refuses_an_unrecognised_pin(tmp_path):
+    """A pin this generator does not understand means we do not understand this
+    macro. Declaring it as something plausible would be a guess with a verdict
+    attached to it."""
+    p = _openram_model(tmp_path, "mx", data_bits=8, addr_bits=8, nmask=1,
+                       extra_port="rdmode0")
+    iface = gs.macro_interface("mx", p)
+    assert "rdmode0" in iface.order
+    assert gs.macro_model_source("mx", "1rw1r", 8, 256, 8, iface=iface) == ""
+
+
+def test_macro_stand_in_reads_select_polarity_from_the_macro(tmp_path):
+    """OpenRAM SRAMs declare active-LOW ``csb0``; the OpenROM mask-ROM models
+    declare active-HIGH ``cs0``. Hard-coding either one inverts every access to
+    the other, which reads as plausible garbage rather than an obvious failure.
+    A read-only memory also has to load its contents or the stand-in models
+    hardware that was never simulated."""
+    data = tmp_path / "rom_data.bin"
+    data.write_text("00000000\n00000001\n")
+    p = tmp_path / "rom_1r_8_4_sky130.v"
+    p.write_text(
+        "module rom_1r_8_4_sky130(clk0, cs0, addr0, dout0);\n"
+        "  parameter DATA_WIDTH = 8 ;\n"
+        "  parameter ADDR_WIDTH = 2 ;\n"
+        "  input  clk0;\n"
+        "  input  cs0; // active high chip select\n"
+        "  input [ADDR_WIDTH-1:0] addr0;\n"
+        "  output [DATA_WIDTH-1:0] dout0;\n"
+        "  reg [DATA_WIDTH-1:0] mem [0:3];\n"
+        '  initial $readmemb("rom_data.bin", mem, 0, 3);\n'
+        "endmodule\n")
+    iface = gs.macro_interface("rom_1r_8_4_sky130", p)
+    src = gs.macro_model_source("rom_1r_8_4_sky130", "1r", 8, 4, 0, iface=iface)
+    assert "if (cs0) dout0 <= mem[addr0];" in src
+    assert "!cs0" not in src, "inverted an active-HIGH select"
+    assert f'$readmemb("{data}"' in src
+
+    # ...and a ROM whose contents are not on disk is UNRESOLVED, not a memory
+    # full of zeros with a verdict attached.
+    data.unlink()
+    assert gs.macro_model_source("rom_1r_8_4_sky130", "1r", 8, 4, 0,
+                                 iface=iface) == ""
 
 
 def test_render_driver_cpp_is_design_agnostic():
@@ -288,6 +610,161 @@ def test_render_driver_cpp_handles_wide_ports():
     cpp = gs.render_driver_cpp("blk", ports, "clk")
     assert "parse_wide(in_tok[0], w, 3)" in cpp
     assert "uint32_t w[5]; parse_wide" in cpp
+
+
+# --------------------------------------------------------------------------- #
+# power/ground boundary vs a real tri-state boundary
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name,level", [
+    ("vccd1", 1), ("vccd2", 1), ("vdda1", 1), ("vdda2", 1), ("vdd", 1),
+    ("vpwr", 1), ("vpb", 1), ("VCCD1", 1),
+    ("vssd1", 0), ("vssd2", 0), ("vssa1", 0), ("vssa2", 0), ("vss", 0),
+    ("vgnd", 0), ("vnb", 0), ("gnd", 0),
+])
+def test_power_inout_level_knows_the_rails(name, level):
+    assert gs.power_inout_level(name) == level
+
+
+@pytest.mark.parametrize("name", ["sda", "scl", "io_out", "gpio", "flash_io0",
+                                  "dq", "vddish", "my_vccd1", "data"])
+def test_power_inout_level_calls_anything_else_a_signal(name):
+    """Conservative on purpose: mis-classifying a tri-state SIGNAL as a rail
+    would tie it to a constant and then not compare it -- i.e. fabricate a
+    pass on the exact port the gate could not judge."""
+    assert gs.power_inout_level(name) is None
+
+
+def test_split_inouts_separates_rails_from_signals():
+    ports = [gs.Port("clk", "input"), gs.Port("vccd1", "inout"),
+             gs.Port("vssd1", "inout"), gs.Port("sda", "inout"),
+             gs.Port("q", "output", 8, 7, 0)]
+    rails, signals = gs.split_inouts(ports)
+    assert [p.name for p in rails] == ["vccd1", "vssd1"]
+    assert [p.name for p in signals] == ["sda"]
+
+
+def test_a_wide_inout_is_never_treated_as_a_rail():
+    """A supply is one bit. A bus that happens to share a rail's name is not a
+    rail we understand, so it stays a signal and still vetoes the gate."""
+    rails, signals = gs.split_inouts([gs.Port("vccd1", "inout", 8, 7, 0)])
+    assert rails == []
+    assert [p.name for p in signals] == ["vccd1"]
+
+
+def test_driver_ties_power_rails_and_never_compares_them():
+    ports = gs.parse_netlist_ports(_NETLIST_RAILS, "blk")
+    cpp = gs.render_driver_cpp("blk", ports, "clk")
+    assert "dut->vccd1 = 1;" in cpp
+    assert "dut->vssd1 = 0;" in cpp
+    # a rail carries no behaviour: it is never a recorded input nor a compared
+    # output
+    assert "dut->vccd1 = parse_scalar" not in cpp
+    assert 'record("vccd1"' not in cpp and 'record("vssd1"' not in cpp
+
+
+def test_power_only_boundary_is_judged_not_vetoed(monkeypatch, tmp_path):
+    """A Caravel ``user_project_wrapper``'s only inouts are the eight supplies,
+    and that wrapper is the artifact the external grader drives. Refusing on any
+    ``inout`` made the gate structurally unable to judge it -- a hole exactly
+    where the gate is supposed to be strongest."""
+    net, pdk = _stub_env(monkeypatch, tmp_path, netlist=_NETLIST_RAILS)
+    monkeypatch.setattr(
+        gs, "build_and_run_gate_sim",
+        lambda **_k: {"ok": True, "cycles_compared": 6,
+                      "output_bits_compared": 54, "diverged": False},
+    )
+    res = gs.check_gate_sim(_BLOCK, str(net), "r.v", "tb.py",
+                            sim_runner=_runner_for(_good_ref(tmp_path)),
+                            pdk_root=pdk, work_root=tmp_path / "work")
+    assert res.status == gs.STATUS_PASS
+    assert res.detail["power_rails_tied"] == ["vccd1", "vssd1"]
+
+
+def test_signal_tristate_boundary_still_has_no_honest_verdict(monkeypatch, tmp_path):
+    net, pdk = _stub_env(monkeypatch, tmp_path, netlist=_NETLIST_TRISTATE)
+    res = gs.check_gate_sim(_BLOCK, str(net), "r.v", "tb.py",
+                            sim_runner=_runner_for(_good_ref(tmp_path)),
+                            pdk_root=pdk, work_root=tmp_path / "work")
+    assert res.status == gs.STATUS_NOT_RUN
+    assert "sda" in res.reason and "tri-state" in res.reason
+    assert "vccd1" not in res.reason
+
+
+# --------------------------------------------------------------------------- #
+# debug mode -- see past the first divergence (opt-in, verdict unchanged)
+# --------------------------------------------------------------------------- #
+def test_default_driver_stops_at_the_first_divergence():
+    cpp = gs.render_driver_cpp("blk", _ports(), "clk", debug=False)
+    assert "if (div_cycle >= 0) break;" in cpp
+    # the default verdict JSON must carry nothing extra
+    assert "divergence_count" not in cpp
+    assert "div_all" not in cpp
+    # the verdict is still one JSON object with the two anti-blank counters and
+    # the single first_divergence record
+    assert "cycles_compared" in cpp and "output_bits_compared" in cpp
+    assert "first_divergence" in cpp
+
+
+def test_debug_driver_keeps_comparing_and_counts_them_all():
+    cpp = gs.render_driver_cpp("blk", _ports(), "clk", debug=True,
+                              max_divergences=5)
+    assert "if (div_cycle >= 0) break;" not in cpp, "must not stop early"
+    assert "div_count++;" in cpp
+    assert "DIV_LIMIT = 5" in cpp
+    assert "divergence_count" in cpp and "divergences" in cpp
+    # first_divergence is still recorded exactly once, so the default report
+    # text is unaffected
+    assert "if (div_cycle >= 0) return;" in cpp
+
+
+def test_debug_mode_is_read_from_the_env(monkeypatch):
+    monkeypatch.setenv(gs.GATE_SIM_DEBUG_ENV, "1")
+    monkeypatch.setenv("CORESMITH_GATE_SIM_MAX_DIVERGENCES", "7")
+    cpp = gs.render_driver_cpp("blk", _ports(), "clk")
+    assert "DIV_LIMIT = 7" in cpp
+    monkeypatch.setenv(gs.GATE_SIM_DEBUG_ENV, "0")
+    assert "DIV_LIMIT" not in gs.render_driver_cpp("blk", _ports(), "clk")
+
+
+def test_debug_divergence_totals_reach_the_result(monkeypatch, tmp_path):
+    net, pdk = _stub_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        gs, "build_and_run_gate_sim",
+        lambda **_k: {"ok": True, "cycles_compared": 200000,
+                      "output_bits_compared": 999, "diverged": True,
+                      "first_divergence": {"cycle": 5151, "port": "q",
+                                           "expected": "1010", "actual": "0000"},
+                      "divergence_count": 1234,
+                      "divergences": [{"cycle": 5151, "port": "q",
+                                       "expected": "1010", "actual": "0000"}]},
+    )
+    res = gs.check_gate_sim(_BLOCK, str(net), "r.v", "tb.py",
+                            sim_runner=_runner_for(_good_ref(tmp_path)),
+                            pdk_root=pdk, work_root=tmp_path / "work")
+    assert res.status == gs.STATUS_FAIL
+    assert res.cycles_compared == 200000, "debug compares the whole stimulus"
+    assert res.detail["divergence_count"] == 1234
+    assert len(res.detail["divergences"]) == 1
+    assert "1234 diverging port-cycles" in res.as_prev_error("blk")
+
+
+def test_default_result_carries_no_divergence_total(monkeypatch, tmp_path):
+    """Without debug the driver stopped at the first mismatch, so it does NOT
+    know a total -- and must not imply one."""
+    net, pdk = _stub_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        gs, "build_and_run_gate_sim",
+        lambda **_k: {"ok": True, "cycles_compared": 5151,
+                      "output_bits_compared": 999, "diverged": True,
+                      "first_divergence": {"cycle": 5151, "port": "q",
+                                           "expected": "1010", "actual": "0000"}},
+    )
+    res = gs.check_gate_sim(_BLOCK, str(net), "r.v", "tb.py",
+                            sim_runner=_runner_for(_good_ref(tmp_path)),
+                            pdk_root=pdk, work_root=tmp_path / "work")
+    assert res.status == gs.STATUS_FAIL
+    assert "divergence_count" not in res.detail
+    assert "diverging port-cycles" not in res.as_prev_error("blk")
 
 
 # --------------------------------------------------------------------------- #
@@ -331,11 +808,40 @@ def test_empty_netlist_fails_closed(monkeypatch, tmp_path):
 
 
 def test_wrong_top_in_netlist_fails_closed(monkeypatch, tmp_path):
+    """A top the netlist does not declare is a FAIL, not a skip: there is an
+    artifact on disk and it is not the design under test.
+
+    The top is otherwise resolved from the netlist's STRUCTURE (the one module
+    nothing instantiates), so the only way to name a missing top is an explicit
+    ``block["top"]`` override -- which is exactly what this pins."""
     net, pdk = _stub_env(monkeypatch, tmp_path)
-    res = gs.check_gate_sim({"name": "other"}, str(net), "r.v", "tb.py",
+    res = gs.check_gate_sim({"name": "other", "top": "other",
+                             "is_chip_top": True},
+                            str(net), "r.v", "tb.py",
                             pdk_root=pdk, work_root=tmp_path / "work")
     assert res.status == gs.STATUS_FAIL
     assert "not found" in res.reason
+
+
+def test_top_is_resolved_from_netlist_structure_not_the_block_name(monkeypatch,
+                                                                  tmp_path):
+    """The block's architectural name is not a stable key -- an external
+    contract (a Caravel ``user_project_wrapper``) fixes the module name while the
+    block keeps its own. Keying the gate off the block name made it FAIL CLOSED
+    on a correctly synthesized netlist."""
+    assert gs.resolve_netlist_top(_NETLIST) == "blk"
+    net, pdk = _stub_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        gs, "build_and_run_gate_sim",
+        lambda **_k: {"ok": True, "cycles_compared": 6,
+                      "output_bits_compared": 54, "diverged": False},
+    )
+    res = gs.check_gate_sim({"name": "totally_different_name",
+                             "is_chip_top": True},
+                            str(net), "r.v", "tb.py",
+                            sim_runner=_runner_for(_good_ref(tmp_path)),
+                            pdk_root=pdk, work_root=tmp_path / "work")
+    assert res.status == gs.STATUS_PASS
 
 
 def test_toolchain_check_precedes_the_netlist_verdict(monkeypatch, tmp_path):

--- a/orchestrator/tests/test_gen_ram_cli.py
+++ b/orchestrator/tests/test_gen_ram_cli.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
+import json
 from pathlib import Path
 
 import pytest
@@ -110,6 +111,75 @@ class TestHonestVerdicts:
     def test_liberty_missing_file_fails(self, gen_ram):
         ok, detail, cyc = gen_ram.check_liberty(Path("/nonexistent/x.lib"))
         assert not ok and cyc is None
+
+
+class TestUnmeasuredStagesAreNotFailures:
+    """A stage the tool never measured must not be rendered as a result.
+
+    The macro DRC stage used to emit ``{"ok": false, "violations": -1}`` for a
+    DRC that produced no report at all (see the ``exp-raster-macro-20260727``
+    w32_d64 / w9_d512 reports, whose named precheck_magic_drc.rpt was never
+    written): every consumer read that as "this macro HAS DRC violations". The
+    emitted report must instead carry the engine's three-state vocabulary --
+    ``status: not_run`` + a ``reason``, ``ok: null``, ``violations: null``.
+    """
+
+    def _emit_report(self, gen_ram, monkeypatch, tmp_path):
+        lib = tmp_path / "fake.lib"
+        lib.write_text("library (fake) { }\n")
+        monkeypatch.setattr(gen_ram, "stage_patch",
+                            lambda check_only: (True, "patched"))
+        monkeypatch.setattr(
+            gen_ram, "stage_generate",
+            lambda width, depth, ports, out, timeout: (
+                True, "generated", {"name": "fake_macro", "lib": str(lib)}))
+        monkeypatch.setattr(gen_ram, "check_liberty",
+                            lambda p: (True, "minimum_period 2.0000 ns", 2.0))
+
+        rc = gen_ram.main(["--width", "16", "--depth", "128",
+                           "--out", str(tmp_path)])
+        report = json.loads((tmp_path / "gen_ram_report.json").read_text())
+        return rc, report
+
+    def test_drc_stage_is_not_run_with_a_reason(self, gen_ram, monkeypatch,
+                                               tmp_path):
+        rc, report = self._emit_report(gen_ram, monkeypatch, tmp_path)
+        assert rc == 0 and report["verdict"] == "PASS"
+
+        drc = report["stages"]["drc"]
+        assert drc["status"] == "not_run"
+        # NOT False -- False claims a measured violation count.
+        assert drc["ok"] is None
+        # NOT -1 and NOT 0 -- there is no count.
+        assert drc["violations"] is None
+        assert drc["measured"] is False
+        assert "check_lvs=False" in drc["reason"]
+        assert "-1" not in json.dumps(drc)
+
+    def test_lvs_stage_uses_the_same_vocabulary(self, gen_ram, monkeypatch,
+                                               tmp_path):
+        _, report = self._emit_report(gen_ram, monkeypatch, tmp_path)
+        lvs = report["stages"]["lvs"]
+        assert lvs["status"] == "not_run" and lvs["ok"] is None
+
+    def test_unmeasured_stages_are_named_next_to_the_verdict(
+            self, gen_ram, monkeypatch, tmp_path):
+        """`verdict: PASS` must not be readable as "DRC/LVS clean"."""
+        _, report = self._emit_report(gen_ram, monkeypatch, tmp_path)
+        assert report["unmeasured"] == ["drc", "lvs"]
+
+    def test_measured_stages_keep_their_boolean_verdicts(self, gen_ram,
+                                                        monkeypatch, tmp_path):
+        """Only the unmeasured case changed: a real failure still fails."""
+        monkeypatch.setattr(gen_ram, "stage_patch",
+                            lambda check_only: (False, "patcher raised: boom"))
+        rc = gen_ram.main(["--width", "16", "--depth", "128",
+                           "--out", str(tmp_path)])
+        report = json.loads((tmp_path / "gen_ram_report.json").read_text())
+        assert rc == 1
+        assert report["verdict"] == "FAIL"
+        assert report["stages"]["patch"]["ok"] is False
+        assert report["unmeasured"] == []
 
 
 class TestOpenramAvailability:

--- a/orchestrator/tests/test_integration_block_rtl_gate.py
+++ b/orchestrator/tests/test_integration_block_rtl_gate.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""``integration_check_node`` must refuse to assemble a chip missing a block.
+
+Root cause behind the raster run's missing GPIO boundary: ``discover_block_rtl``
+resolved a block only from its result ``rtl_path`` or the ``<block_name>.v``
+filename convention, so the ONE block whose file is not named after it -- the
+Caravel pad adapter, whose module name is locked to ``user_project_wrapper`` by
+an interface contract and whose spec carries
+``rtl_target='rtl/user_project_wrapper.v'`` -- resolved to nothing and was
+dropped from the returned dict with no error. 7 of 8 blocks reached ``modules``,
+``detect_wrapper_block`` returned None, the default-ON deterministic Caravel
+assembler never ran, and the assembled top carried no io_in/io_out/io_oeb at
+all while integration DV reported PASS on a co-tuned BFM.
+
+Discovery is fixed in ``integration_helpers``; this pins the CALLER: an eligible
+block whose RTL cannot be located is an assembly blocker that parks the existing
+``integration_failure`` interrupt BEFORE the Integration Lead call, with
+``override``/``abort`` and a single fail-closed re-check on ``retry`` -- the same
+shape as the contract-staleness preflight beside it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.langgraph import pipeline_graph
+from orchestrator.langgraph.integration_helpers import VerilogModule, VerilogPort
+
+
+def _state(tmp_path, *, write_missing_rtl: bool = False):
+    """Two passed blocks; `pad_adapter` resolves only via its spec rtl_target."""
+    (tmp_path / "rtl").mkdir(parents=True, exist_ok=True)
+    found = tmp_path / "rtl" / "core.v"
+    found.write_text("module core(input clk); endmodule\n")
+    if write_missing_rtl:
+        # the pad adapter's REAL file: named after its locked module, not the block
+        (tmp_path / "rtl" / "user_project_wrapper.v").write_text(
+            "module user_project_wrapper(input clk); endmodule\n"
+        )
+    return {
+        "project_root": str(tmp_path),
+        "completed_blocks": [
+            {"name": "core", "success": True, "rtl_path": str(found)},
+            {"name": "pad_adapter", "success": True},
+        ],
+        "block_queue": [{"name": "core"}, {"name": "pad_adapter"}],
+    }
+
+
+def _seams(monkeypatch, *, rtl_target: str = ""):
+    monkeypatch.setattr(
+        pipeline_graph, "load_architecture_connections", lambda pr: ([{"a": 1}], "chip"))
+    monkeypatch.setattr(
+        pipeline_graph, "parse_verilog_ports",
+        lambda p: VerilogModule(name="core", ports=[VerilogPort("clk", "input")]))
+    monkeypatch.setattr(pipeline_graph, "write_graph_event", lambda *a, **k: None)
+
+    # discover_block_rtl / unresolved_block_rtl read the block spec for
+    # rtl_target; stub the spec loader seam by patching the helpers' own reader.
+    import orchestrator.langgraph.integration_helpers as ih
+
+    real_discover = ih.discover_block_rtl
+
+    def _discover(project_root, completed_blocks):
+        blocks = []
+        for b in completed_blocks:
+            b = dict(b)
+            if b.get("name") == "pad_adapter" and rtl_target:
+                b["rtl_target"] = rtl_target
+            blocks.append(b)
+        return real_discover(project_root, blocks)
+
+    monkeypatch.setattr(ih, "discover_block_rtl", _discover)
+    monkeypatch.setattr(pipeline_graph, "discover_block_rtl", _discover)
+    return ih
+
+
+def test_block_rtl_complete_gate_default_on(monkeypatch):
+    monkeypatch.delenv("CORESMITH_BLOCK_RTL_COMPLETE_GATE", raising=False)
+    assert pipeline_graph._block_rtl_complete_gate_enabled() is True
+    monkeypatch.setenv("CORESMITH_BLOCK_RTL_COMPLETE_GATE", "0")
+    assert pipeline_graph._block_rtl_complete_gate_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_missing_block_rtl_parks_before_assembly(monkeypatch, tmp_path):
+    monkeypatch.delenv("CORESMITH_BLOCK_RTL_COMPLETE_GATE", raising=False)
+    _seams(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(
+        pipeline_graph, "interrupt",
+        lambda p: (captured.update(p), {"action": "abort"})[1])
+
+    result = await pipeline_graph.integration_check_node(_state(tmp_path))
+
+    assert captured.get("error_kind") == "unresolved_block_rtl"
+    assert captured.get("missing_block_rtl") == ["pad_adapter"]
+    assert "override" in captured.get("supported_actions", [])
+    ir = result["integration_result"]
+    assert ir["aborted"] is True
+    assert ir["missing_blocks"] == ["pad_adapter"]
+    # no top-level RTL was written -- the gate parks BEFORE assembly
+    assert not (tmp_path / "rtl" / "integration").exists()
+
+
+@pytest.mark.asyncio
+async def test_retry_that_does_not_resolve_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.delenv("CORESMITH_BLOCK_RTL_COMPLETE_GATE", raising=False)
+    _seams(monkeypatch)
+    monkeypatch.setattr(pipeline_graph, "interrupt", lambda p: {"action": "retry"})
+
+    result = await pipeline_graph.integration_check_node(_state(tmp_path))
+    ir = result["integration_result"]
+    assert ir["aborted"] is True
+    assert "unresolved after retry" in ir["reason"]
+
+
+@pytest.mark.asyncio
+async def test_rtl_target_resolution_clears_the_gate(monkeypatch, tmp_path):
+    """The fixed discovery path: rtl_target resolves the locked pad adapter."""
+    monkeypatch.delenv("CORESMITH_BLOCK_RTL_COMPLETE_GATE", raising=False)
+    _seams(monkeypatch, rtl_target="rtl/user_project_wrapper.v")
+    monkeypatch.setattr(
+        pipeline_graph, "interrupt",
+        lambda p: (_ for _ in ()).throw(AssertionError("gate must not park")))
+    # stop the node right after the gate so no LLM/assembly runs
+    monkeypatch.setattr(
+        pipeline_graph, "parse_verilog_ports",
+        lambda p: VerilogModule(name="", ports=[]))
+
+    result = await pipeline_graph.integration_check_node(
+        _state(tmp_path, write_missing_rtl=True))
+    # both blocks resolved -> the gate passed; the node then stops on the
+    # unparsable-RTL guard rather than on a missing block
+    assert result["integration_result"]["reason"] == "No block RTL could be parsed"
+
+
+@pytest.mark.asyncio
+async def test_total_absence_of_rtl_is_left_to_the_existing_skip(
+    monkeypatch, tmp_path
+):
+    """Nothing resolved at all -> no chip to assemble; the existing skip reports it.
+
+    The gate is about a chip assembled AROUND a missing block, not about an empty
+    discovery (which the "No block RTL could be parsed" return already surfaces).
+    """
+    monkeypatch.delenv("CORESMITH_BLOCK_RTL_COMPLETE_GATE", raising=False)
+    monkeypatch.setattr(
+        pipeline_graph, "load_architecture_connections", lambda pr: ([{"a": 1}], "chip"))
+    monkeypatch.setattr(pipeline_graph, "write_graph_event", lambda *a, **k: None)
+    monkeypatch.setattr(
+        pipeline_graph, "interrupt",
+        lambda p: (_ for _ in ()).throw(AssertionError("gate must not park")))
+    state = {
+        "project_root": str(tmp_path),
+        "completed_blocks": [
+            {"name": "core", "success": True},
+            {"name": "pad_adapter", "success": True},
+        ],
+        "block_queue": [{"name": "core"}, {"name": "pad_adapter"}],
+    }
+    result = await pipeline_graph.integration_check_node(state)
+    assert result["integration_result"]["reason"] == "No block RTL could be parsed"
+
+
+@pytest.mark.asyncio
+async def test_gate_off_restores_drop_and_continue(monkeypatch, tmp_path):
+    monkeypatch.setenv("CORESMITH_BLOCK_RTL_COMPLETE_GATE", "0")
+    _seams(monkeypatch)
+    monkeypatch.setattr(
+        pipeline_graph, "interrupt",
+        lambda p: (_ for _ in ()).throw(AssertionError("gate must not park")))
+    monkeypatch.setattr(
+        pipeline_graph, "parse_verilog_ports",
+        lambda p: VerilogModule(name="", ports=[]))
+
+    result = await pipeline_graph.integration_check_node(_state(tmp_path))
+    # unchanged legacy behavior: the missing block is simply absent
+    assert result["integration_result"]["reason"] == "No block RTL could be parsed"
+
+
+@pytest.mark.asyncio
+async def test_override_assembles_without_the_block(monkeypatch, tmp_path):
+    monkeypatch.delenv("CORESMITH_BLOCK_RTL_COMPLETE_GATE", raising=False)
+    _seams(monkeypatch)
+    monkeypatch.setattr(pipeline_graph, "interrupt", lambda p: {"action": "override"})
+    monkeypatch.setattr(
+        pipeline_graph, "parse_verilog_ports",
+        lambda p: VerilogModule(name="", ports=[]))
+
+    result = await pipeline_graph.integration_check_node(_state(tmp_path))
+    assert result["integration_result"]["reason"] == "No block RTL could be parsed"

--- a/orchestrator/tests/test_macro_prebind.py
+++ b/orchestrator/tests/test_macro_prebind.py
@@ -1,0 +1,431 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Pre-synthesis macro binding: the shell must carry a real memory.
+
+The bug these guard against: cs_mem_macro_shell hard-assigns zero, synthesis
+preserves the tie-off, and a gate-sim of the flat netlist diverges on the first
+read of real data -- while every upstream RTL gate passes, because RTL uses the
+BEHAV arm.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from orchestrator.langgraph.macro_prebind import (
+    UNBOUND_SENTINEL,
+    PrebindResult,
+    emit_bound_shell,
+)
+
+
+@dataclass
+class FakeSpec:
+    width: int
+    depth: int
+    nport: int = 2
+
+    def describe(self) -> str:
+        return f"sram {self.width}b x {self.depth}"
+
+
+@dataclass
+class FakeMacro:
+    name: str
+    verilog: str = "/pdk/verilog/m.v"
+    mask_bits: int = 0
+
+
+def _bound(*pairs) -> PrebindResult:
+    return PrebindResult(bindings=list(pairs))
+
+
+class TestActiveLowPolarity:
+    """OpenRAM csb0/web0 are active LOW; the shell's ce0/we0 are active high.
+
+    Dropping the inversion gives a memory selected exactly when it should be
+    idle -- plausible garbage rather than an obvious failure.
+    """
+
+    def test_chip_select_and_write_enable_are_inverted(self):
+        v = emit_bound_shell(_bound((FakeSpec(8, 4096), FakeMacro("sram_a"))))
+        assert ".csb0(~ce0)" in v
+        assert ".web0(~we0)" in v
+        assert ".csb0(ce0)" not in v, "active-low port driven with active-high signal"
+        assert ".web0(we0)" not in v
+
+    def test_second_read_port_select_also_inverted(self):
+        v = emit_bound_shell(_bound((FakeSpec(8, 4096, nport=2), FakeMacro("sram_a"))))
+        assert ".csb1(~ce1)" in v
+
+
+class TestUnboundIsLoudNotZero:
+    def test_fallback_references_an_undefined_module(self):
+        """The old behaviour read zeros. Anything that still elaborates is a
+        regression, so the fallback must name a module no tool can resolve."""
+        v = emit_bound_shell(_bound((FakeSpec(8, 4096), FakeMacro("sram_a"))))
+        assert UNBOUND_SENTINEL in v
+        assert "u_unbound_geometry" in v
+
+    def test_no_zero_tieoff_anywhere(self):
+        v = emit_bound_shell(_bound((FakeSpec(8, 4096), FakeMacro("sram_a"))))
+        assert "{WIDTH{1'b0}}" not in v, "reintroduced the zero-read tie-off"
+
+    def test_empty_bindings_still_emit_the_loud_fallback(self):
+        """No resolved macro at all must not produce a permissive shell."""
+        v = emit_bound_shell(PrebindResult())
+        assert UNBOUND_SENTINEL in v
+        assert "{WIDTH{1'b0}}" not in v
+
+
+class TestGeometryDispatch:
+    def test_each_geometry_gets_its_own_guarded_arm(self):
+        v = emit_bound_shell(
+            (_bound((FakeSpec(8, 4096), FakeMacro("sram_8x4096")),
+                    (FakeSpec(9, 4096), FakeMacro("sram_9x4096")))))
+        assert "WIDTH == 8 && DEPTH == 4096 && NPORT == 2" in v
+        assert "WIDTH == 9 && DEPTH == 4096 && NPORT == 2" in v
+        assert "sram_8x4096 u_macro" in v
+        assert "sram_9x4096 u_macro" in v
+        # one `if`, the rest chained -- not independent ifs that could both match
+        assert v.count("    if (") == 1
+        assert v.count("    else if (") == 1
+
+    def test_single_port_macro_has_no_port1_connections(self):
+        v = emit_bound_shell(_bound((FakeSpec(32, 512, nport=1), FakeMacro("sram_1rw"))))
+        assert ".clk1(" not in v and ".csb1(" not in v and ".dout1(" not in v
+        # the shell still exposes rdata1, so it must be driven from port 0
+        assert "assign rdata1 = rdata0;" in v
+
+    def test_write_mask_connected_only_when_the_model_declares_it(self, tmp_path):
+        """Connect pins the MODEL has, not pins the registry claims.
+
+        MacroInfo.mask_bits was non-zero for sram_1rw1r_8_4096_8_sky130, whose
+        .v has no wmask0 port -- connecting it was a hard elaboration error.
+        """
+        masked = tmp_path / "masked.v"
+        masked.write_text(
+            "module m(clk0, csb0, web0, wmask0, addr0, din0, dout0);\n"
+            "  input clk0; input csb0; input web0; input [3:0] wmask0;\n"
+            "  input [8:0] addr0; input [31:0] din0; output [31:0] dout0;\n"
+            "endmodule\n")
+        v = emit_bound_shell(_bound(
+            (FakeSpec(32, 512, nport=1), FakeMacro("m", str(masked), mask_bits=4))))
+        assert ".wmask0({4{1'b1}})" in v
+
+        plain = tmp_path / "plain.v"
+        plain.write_text(
+            "module p(clk0, csb0, web0, addr0, din0, dout0);\n"
+            "  input clk0; input csb0; input web0; input [11:0] addr0;\n"
+            "  input [7:0] din0; output [7:0] dout0;\n"
+            "endmodule\n")
+        v2 = emit_bound_shell(_bound(
+            (FakeSpec(8, 4096, nport=1), FakeMacro("p", str(plain), mask_bits=1))))
+        assert "wmask0" not in v2, "connected a pin the model does not declare"
+
+
+def _maskless_env(tmp_path, monkeypatch, width, nb_expected):
+    """Wire resolve_prebindings to a maskless macro for the given RTL width."""
+    from orchestrator.langgraph import macro_prebind as mp
+    import orchestrator.langgraph.macro_registry as reg
+
+    rtl = tmp_path / "blk.v"
+    rtl.write_text(
+        f"module blk; cs_sram_1rw1r #(.WIDTH({width}), .DEPTH(4096), "
+        ".USE_WMASK(1), .WMASK_GRAN(8)) u (); endmodule\n")
+
+    class Spec:
+        kind, width_, depth, nport = "sram", width, 4096, 2
+
+        def __init__(self, **kw):
+            self.width = kw.get("width", width)
+            self.depth = kw.get("depth", 4096)
+            self.nport = kw.get("nport", 2)
+
+        def describe(self):
+            return f"sram shell {self.width}b x {self.depth}"
+
+    monkeypatch.setattr(mp, "macro_ports",
+                        lambda p: {"clk0", "csb0", "web0", "addr0",
+                                   "din0", "dout0"})
+    monkeypatch.setattr(reg, "detect_macro_shells", lambda t: [])
+    monkeypatch.setattr(reg, "discover_macros", lambda: {})
+    monkeypatch.setattr(reg, "ShellSpec", Spec, raising=False)
+    monkeypatch.setattr(reg, "resolve_shell",
+                        lambda s, **kw: FakeMacro("nm", "/p/nm.v", nb_expected))
+    return mp, str(rtl)
+
+
+class TestMaskMismatchIsRefused:
+    """A real per-byte mask cannot be expressed by a single write enable.
+
+    Tying wmask high turns a masked write into a full-word write, clobbering
+    neighbouring bytes. RTL DV passes (the BEHAV arm honours the mask), so the
+    corruption only appears in the macro-backed design.
+    """
+
+    def test_multibit_mask_against_maskless_macro_is_refused(self, tmp_path, monkeypatch):
+        # WIDTH=32 / GRAN=8 -> 4 mask bits: genuinely per-byte.
+        mp, rtl = _maskless_env(tmp_path, monkeypatch, 32, 4)
+        res = mp.resolve_prebindings([rtl], allow_generate=False)
+        assert res.ok is False
+        assert res.unresolved, "maskless macro silently accepted for masked RTL"
+        assert any("wmask0" in e for e in res.errors)
+        assert any("full-word writes" in e for e in res.errors)
+
+    def test_whole_word_mask_binds_but_warns(self, tmp_path, monkeypatch):
+        """WIDTH=8 / GRAN=8 -> 1 mask bit spanning the word, which is exactly
+        what the write enable already expresses -- and why OpenRAM omits the
+        port. Bind, but say the fold into we0 is required."""
+        mp, rtl = _maskless_env(tmp_path, monkeypatch, 8, 1)
+        res = mp.resolve_prebindings([rtl], allow_generate=False)
+        assert res.bindings, "refused a mask that is equivalent to we0"
+        assert not res.unresolved and not res.errors
+        assert res.ok is True
+        assert any("fold" in w and "we0" in w for w in res.warnings)
+
+    def test_multibit_mask_against_a_MASK_CAPABLE_macro_is_also_refused(
+        self, tmp_path, monkeypatch
+    ):
+        """The hole the maskless test could not see.
+
+        Resolving to a byte-write-enable macro is NECESSARY but not SUFFICIENT:
+        ``emit_bound_shell``'s ``cs_mem_macro_shell`` declares no mask pins and
+        ``_ports_for`` hardwires the macro's ``wmask0`` to all-ones, so the RTL's
+        dynamic mask is discarded even though the macro could have honoured it.
+
+        Two of the three memories in exp-raster-macro-20260727 were in exactly
+        this state, both driving a genuinely dynamic mask:
+        triangle_store (WIDTH=64, 8 mask bits, macro sram_1rw1r_64_64_8_sky130
+        tied 8'hff) and zbuffer_sram (WIDTH=9, 2 mask bits, macro
+        sram_1rw1r_9_4096_8_sky130 tied 2'h3). Both bound cleanly and both lost
+        the mask.
+        """
+        mp, rtl = _maskless_env(tmp_path, monkeypatch, 64, 8)
+        # Unlike _maskless_env's default, this macro DOES declare wmask0.
+        monkeypatch.setattr(mp, "macro_ports",
+                            lambda p: {"clk0", "csb0", "web0", "wmask0",
+                                       "addr0", "din0", "dout0"})
+        res = mp.resolve_prebindings([rtl], allow_generate=False)
+        assert res.ok is False, "bound a masked geometry the shell cannot route"
+        assert res.unresolved
+        # The diagnosis must name the SHELL, not blame the macro -- otherwise the
+        # reader regenerates a macro that already had the port.
+        joined = " ".join(res.errors)
+        assert "cs_mem_macro_shell" in joined
+        assert "HAS a wmask0 port" in joined
+        assert "full-word writes" in joined
+
+    def test_the_two_refusals_give_DIFFERENT_diagnoses(self, tmp_path, monkeypatch):
+        """Same symptom, opposite fixes: regenerate the macro vs route the pin
+        through the shell. A single shared message would send half the readers
+        to the wrong repair."""
+        mp, rtl = _maskless_env(tmp_path, monkeypatch, 32, 4)
+        maskless = " ".join(
+            mp.resolve_prebindings([rtl], allow_generate=False).errors)
+        monkeypatch.setattr(mp, "macro_ports",
+                            lambda p: {"clk0", "csb0", "web0", "wmask0",
+                                       "addr0", "din0", "dout0"})
+        capable = " ".join(
+            mp.resolve_prebindings([rtl], allow_generate=False).errors)
+        assert "no wmask0 port at all" in maskless
+        assert "write_size" in maskless          # regenerate the macro
+        assert "cs_mem_macro_shell" in capable   # route the pin
+        assert maskless != capable
+
+
+class TestStructure:
+    def test_generate_block_is_balanced(self):
+        v = emit_bound_shell(_bound((FakeSpec(8, 4096), FakeMacro("sram_a"))))
+        # "generate" is a substring of "endgenerate", so count the opener by
+        # excluding the closer rather than by naive substring count.
+        assert v.count("endgenerate") == 1
+        assert v.count("generate") - v.count("endgenerate") == 1
+        assert v.count("endmodule") == 1
+        assert len([ln for ln in v.split("\n")
+                    if ln.startswith("module ")]) == 1
+
+    def test_marked_generated(self):
+        v = emit_bound_shell(_bound((FakeSpec(8, 4096), FakeMacro("sram_a"))))
+        assert "GENERATED" in v and "do not edit" in v
+
+
+class TestResultContract:
+    def test_ok_is_false_when_anything_is_unresolved(self):
+        r = PrebindResult(bindings=[(FakeSpec(8, 4096), FakeMacro("a"))],
+                          unresolved=[FakeSpec(9, 4096)])
+        assert r.ok is False
+
+    def test_ok_is_false_on_errors_even_with_bindings(self):
+        r = PrebindResult(bindings=[(FakeSpec(8, 4096), FakeMacro("a"))],
+                          errors=["boom"])
+        assert r.ok is False
+
+    def test_ok_true_only_when_clean(self):
+        assert PrebindResult(bindings=[(FakeSpec(8, 4096), FakeMacro("a"))]).ok is True
+
+    def test_model_paths_dedupes_and_keeps_order(self):
+        r = _bound((FakeSpec(8, 4096), FakeMacro("a", verilog="/p/a.v")),
+                   (FakeSpec(9, 4096), FakeMacro("b", verilog="/p/b.v")),
+                   (FakeSpec(8, 64), FakeMacro("c", verilog="/p/a.v")))
+        assert r.model_paths() == ["/p/a.v", "/p/b.v"]
+
+    def test_model_paths_skips_macros_without_a_model(self):
+        r = _bound((FakeSpec(8, 4096), FakeMacro("a", verilog="")))
+        assert r.model_paths() == []
+
+
+class TestSynthSourcePreparation:
+    """Reading the original library AND the bound shell would be a duplicate
+    definition of cs_mem_macro_shell, so the strip is load-bearing."""
+
+    def test_strip_removes_the_zero_driving_shell_only(self):
+        from orchestrator.langgraph.macro_prebind import strip_module
+        text = ("module keep_me; endmodule\n"
+                "module cs_mem_macro_shell #(parameter W=1)(input a);\n"
+                "  assign x = {W{1'b0}};\n"
+                "endmodule\n"
+                "module also_keep; endmodule\n")
+        out, n = strip_module(text, "cs_mem_macro_shell")
+        assert n == 1
+        assert "cs_mem_macro_shell" not in out
+        assert "module keep_me" in out and "module also_keep" in out
+
+    def test_shared_library_file_is_never_modified(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import prepare_synth_sources
+        lib = tmp_path / "cs_sram.v"
+        original = ("module cs_mem_1rw1r; endmodule\n"
+                    "module cs_mem_macro_shell; assign r = 0; endmodule\n")
+        lib.write_text(original)
+        res = _bound((FakeSpec(8, 4096), FakeMacro("m", "/p/m.v")))
+
+        got = prepare_synth_sources(str(lib), res, tmp_path / "work")
+
+        assert lib.read_text() == original, "mutated the shared wrapper library"
+        assert got["wrapper_lib"] != str(lib), "did not substitute a filtered copy"
+        filtered = Path(got["wrapper_lib"]).read_text()
+        # The name still appears in the generated header comment; what must be
+        # gone is the DEFINITION, which is what would collide.
+        assert "module cs_mem_macro_shell" not in filtered
+        assert "cs_mem_1rw1r" in filtered
+
+    def test_bound_shell_and_models_are_returned(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import prepare_synth_sources
+        lib = tmp_path / "cs_sram.v"
+        lib.write_text("module cs_mem_macro_shell; endmodule\n")
+        res = _bound((FakeSpec(8, 4096), FakeMacro("m8", "/p/a.v")),
+                     (FakeSpec(9, 4096), FakeMacro("m9", "/p/b.v")))
+        got = prepare_synth_sources(str(lib), res, tmp_path / "w")
+        assert Path(got["bound_shell"]).is_file()
+        assert "m8 u_macro" in Path(got["bound_shell"]).read_text()
+        assert got["models"] == ["/p/a.v", "/p/b.v"]
+
+    def test_no_bindings_leaves_everything_untouched(self, tmp_path):
+        """Nothing resolved => do not strip the shell and silently remove the
+        only definition, leaving an undefined module."""
+        from orchestrator.langgraph.macro_prebind import prepare_synth_sources
+        lib = tmp_path / "cs_sram.v"
+        lib.write_text("module cs_mem_macro_shell; endmodule\n")
+        got = prepare_synth_sources(str(lib), PrebindResult(), tmp_path / "w")
+        assert got["wrapper_lib"] == str(lib)
+        assert got["bound_shell"] == "" and got["models"] == []
+
+
+class TestResolveNeedsSources:
+    def test_no_readable_sources_is_an_error_not_a_silent_pass(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import resolve_prebindings
+        r = resolve_prebindings([str(tmp_path / "missing.v")])
+        assert r.ok is False and r.errors
+
+
+class TestMacroPortsNeverFailsByOmission:
+    """A missing name here is read as "the macro has no such pin", so
+    ``_ports_for`` leaves it UNCONNECTED and it floats low. That is not a
+    degraded answer, it is a wrong one: a dropped ``addr0`` is a memory stuck at
+    word zero, and a dropped ``wmask0`` is what suppressed every framebuffer
+    write in exp-raster-macro-20260727.
+    """
+
+    def _v(self, tmp_path, body):
+        f = tmp_path / "m.v"
+        f.write_text(body)
+        return f
+
+    def test_range_containing_parens(self, tmp_path):
+        """THE regression. The old regex was `[^;)]*`, which cannot cross the
+        `)` inside `$clog2(`, so `addr0` was never seen."""
+        from orchestrator.langgraph.macro_prebind import macro_ports
+        f = self._v(tmp_path,
+                    "module m(clk0, addr0);\n"
+                    "  input clk0;\n"
+                    "  input [$clog2(DEPTH)-1:0] addr0;\n"
+                    "endmodule\n")
+        assert {"clk0", "addr0"} <= macro_ports(f)
+
+    def test_nested_parens_in_a_range(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import macro_ports
+        f = self._v(tmp_path,
+                    "module m(dout0);\n"
+                    "  output [((WIDTH*2)-1):0] dout0;\n"
+                    "endmodule\n")
+        assert "dout0" in macro_ports(f)
+
+    def test_several_names_in_one_declaration(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import macro_ports
+        f = self._v(tmp_path,
+                    "module m(a, b, c);\n  input a, b, c;\nendmodule\n")
+        assert {"a", "b", "c"} <= macro_ports(f)
+
+    def test_ansi_header(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import macro_ports
+        f = self._v(tmp_path,
+                    "module m(\n"
+                    "  input wire clk0,\n"
+                    "  input wire [$clog2(N)-1:0] addr0,\n"
+                    "  output reg [7:0] dout0\n"
+                    ");\nendmodule\n")
+        assert {"clk0", "addr0", "dout0"} <= macro_ports(f)
+
+    def test_type_keywords_are_not_ports(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import macro_ports
+        f = self._v(tmp_path,
+                    "module m(a);\n  input wire signed [3:0] a;\nendmodule\n")
+        got = macro_ports(f)
+        assert "a" in got
+        assert not ({"wire", "signed", "input"} & got)
+
+    def test_comments_do_not_contribute_ports(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import macro_ports
+        f = self._v(tmp_path,
+                    "module m(a);\n"
+                    "  // input phantom_pin;\n"
+                    "  /* inout other_phantom; */\n"
+                    "  input a;\n"
+                    "endmodule\n")
+        got = macro_ports(f)
+        assert "a" in got
+        assert "phantom_pin" not in got and "other_phantom" not in got
+
+    def test_unreadable_file_is_empty_not_an_exception(self, tmp_path):
+        from orchestrator.langgraph.macro_prebind import macro_ports
+        assert macro_ports(tmp_path / "absent.v") == set()
+
+    def test_the_real_maskless_macro_still_reports_no_wmask0(self, tmp_path):
+        """The scanner must not "fix" the 8x4096 macro into having a mask --
+        it genuinely has none, and that is what the binder must see."""
+        from orchestrator.langgraph.macro_prebind import macro_ports
+        f = self._v(tmp_path,
+                    "module sram_1rw1r_8_4096_8_sky130(clk0, csb0, web0, addr0,"
+                    " din0, dout0, clk1, csb1, addr1, dout1);\n"
+                    "  parameter ADDR_WIDTH = 12;\n"
+                    "  input clk0;\n  input csb0;\n  input web0;\n"
+                    "  input [ADDR_WIDTH-1:0] addr0;\n"
+                    "  input [7:0] din0;\n  output [7:0] dout0;\n"
+                    "endmodule\n")
+        got = macro_ports(f)
+        assert "addr0" in got and "din0" in got
+        assert "wmask0" not in got

--- a/orchestrator/tests/test_patch_openram.py
+++ b/orchestrator/tests/test_patch_openram.py
@@ -275,6 +275,14 @@ def test_idempotent_second_run_is_noop(tmp_path, monkeypatch):
         "sky130-width-model",
         "maglef-mag-alias",
         "spice-micron-units",
+        # repair (10): only freepdk45 ships nand4_leakage; gf180mcu and
+        # scn3me_subm still omit it (sky130 was fixed upstream in 3f1f580, but
+        # the pinned 1.2.48 wheel predates that). This fixture package carries
+        # no technology tech.py at all, so the repair reports it had nothing to
+        # act on instead of claiming a patch it never made -- which is why the
+        # name here is the -unavailable variant and why r.applied (asserted in
+        # test_applies_both_fixes) is deliberately unchanged.
+        "nand4-leakage-unavailable",
     }
 
 

--- a/orchestrator/tests/test_qspi_pin_boundary_gate.py
+++ b/orchestrator/tests/test_qspi_pin_boundary_gate.py
@@ -1,0 +1,479 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The QSPI PIN-BOUNDARY gate: integration DV must drive the GRADED boundary.
+
+The fail-open this pins closed (observed on ``exp-raster-macro-20260727``): the
+assembled integration top declared ``qspi_csn/qspi_sck/qspi_io_in[3:0]/
+qspi_io_out[3:0]/qspi_drive_en/irq_level`` -- a design-prefixed pin group, not
+the locked Caravel ``io_in``/``io_out``/``io_oeb`` the external grader drives.
+The classifier concluded "not a QSPI-slave bus", the caller logged a RED
+advisory ("THIS RUN'S INTEGRATION DV IS NOT CONTRACT-ENFORCING") and PROCEEDED
+on the LLM-authored, DUT-co-tuned BFM. The run then reported "INTEGRATION DV
+PASSED" -- while ``rtl/user_project_wrapper.v`` (which DID declare all three pad
+busses and mapped ``qspi_io_out`` -> ``io_out[5:2]``) was never driven.
+
+Three outcomes are pinned here:
+
+* the graded boundary is on the module the sim elaborates -> contract-enforcing;
+* the boundary exists but on another module (the wrapper) / nowhere at all while
+  the spec says QSPI -> FAIL CLOSED through the run's normal tb_generation
+  interrupt, and the co-tuned LLM generator is never reached;
+* a genuinely non-QSPI design -> still classified not-QSPI, no error, LLM BFM
+  kept with the historical advisory.
+
+Hermetic: no EDA, no LLM (the testbench generator is monkeypatched and asserted
+NOT to run on the fail-closed path).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orchestrator.langgraph import pipeline_graph
+from orchestrator.langgraph import bfm_lib
+from orchestrator.langgraph.bfm_lib import (
+    STATUS_BOUNDARY_OFF_TOP,
+    STATUS_CONTRADICTION,
+    STATUS_NOT_QSPI,
+    STATUS_QSPI_TOP,
+    boundary_gate_enabled,
+    classify_bus_verdict,
+    classify_chip_bus,
+    find_pin_boundary,
+)
+from orchestrator.langgraph.bfm_lib.classifier import (
+    _top_has_gpio_pin_boundary,
+    declared_pad_ports,
+)
+from orchestrator.langgraph.integration_helpers import VerilogModule, VerilogPort
+
+# ---------------------------------------------------------------------------
+# RTL fixtures (shapes taken from the real raster run)
+# ---------------------------------------------------------------------------
+
+# The assembled integration top of exp-raster-macro-20260727: a QSPI-slave
+# chassis whose OWN pins are design-prefixed. `qspi_io_in` is deliberately NOT
+# `io_in` -- it is a different pin on a different module.
+_PREFIXED_PIN_TOP = """
+module raster_top (
+    input  wire       wb_clk_i,
+    input  wire       wb_rst_i,
+    input  wire       qspi_csn,
+    input  wire       qspi_sck,
+    input  wire [3:0] qspi_io_in,
+    output wire [3:0] qspi_io_out,
+    output wire       qspi_drive_en,
+    output wire       irq_level
+);
+    wire [3:0] w_user_project_wrapper_io_qspi_io_in_to_frontend_qspi_io_in;
+    assign w_user_project_wrapper_io_qspi_io_in_to_frontend_qspi_io_in = qspi_io_in;
+endmodule
+"""
+
+# The graded boundary as the raster run really wrote it: a doc comment naming
+# the pads (which must NOT count as evidence) plus real port declarations.
+_CARAVEL_WRAPPER = """
+/*
+ * Block: user_project_wrapper
+ * I/O ports:
+ *   io_in, io_out, io_oeb    - 38-bit Caravel digital GPIO interface
+ */
+(* top = 1 *)
+module user_project_wrapper (
+    input  wire         wb_clk_i,
+    input  wire         wb_rst_i,
+    input  wire [127:0] la_data_in,
+    input  wire [37:0]  io_in,
+    output wire [37:0]  io_out,
+    output wire [37:0]  io_oeb
+);
+    wire [3:0] qspi_io_out;
+    assign io_out = {{31{1'b0}}, qspi_io_out, 2'b00};
+endmodule
+"""
+
+# Same file, but the pads exist ONLY in prose -- not evidence of a boundary.
+_COMMENT_ONLY_WRAPPER = """
+/*
+ * Maps io_in, io_out and io_oeb onto the QSPI pads.
+ */
+module pad_notes (
+    input  wire       wb_clk_i,
+    input  wire [3:0] qspi_io_in,
+    output wire [3:0] qspi_io_out
+);
+    // io_oeb is driven by the parent
+    wire [37:0] io_oeb;
+endmodule
+"""
+
+_GPIO_TOP = """
+module chip_top (
+    input  wire        wb_clk_i,
+    input  wire        wb_rst_i,
+    input  wire [37:0] io_in,
+    output wire [37:0] io_out,
+    output wire [37:0] io_oeb
+);
+endmodule
+"""
+
+_NON_QSPI_TOP = """
+module chip_top (
+    input  wire        clk,
+    input  wire        rst,
+    input  wire [31:0] s_axis_tdata,
+    input  wire        s_axis_tvalid,
+    output wire        s_axis_tready
+);
+endmodule
+"""
+
+
+def _make_run(tmp_path, *, qspi: bool = True, wrapper: str = "",
+              top_src: str = _PREFIXED_PIN_TOP, top_name: str = "raster_top"):
+    """A minimal run dir: spec + assembled top (+ optional wrapper file)."""
+    root = tmp_path / "run"
+    (root / ".coresmith").mkdir(parents=True, exist_ok=True)
+    # The raster run's real shape: prd bus_protocol="custom", ERS naming QSPI.
+    proto = (
+        "asynchronous dedicated-pin quad QSPI mode 0 externally"
+        if qspi
+        else "AXI-Stream"
+    )
+    (root / ".coresmith" / "prd_spec.json").write_text(
+        json.dumps({"prd": {"dataflow": {"bus_protocol": "custom"}}})
+    )
+    (root / ".coresmith" / "ers_spec.json").write_text(
+        json.dumps({"ers": {"dataflow": {"bus_protocol": proto}}})
+    )
+    top = root / "rtl" / "integration" / f"{top_name}.v"
+    top.parent.mkdir(parents=True, exist_ok=True)
+    top.write_text(top_src)
+    if wrapper:
+        (root / "rtl").mkdir(parents=True, exist_ok=True)
+        (root / "rtl" / "user_project_wrapper.v").write_text(wrapper)
+    return root, top
+
+
+# ---------------------------------------------------------------------------
+# evidence: what counts as the graded boundary
+# ---------------------------------------------------------------------------
+
+def test_prefixed_pin_group_is_not_the_graded_boundary():
+    """`qspi_io_in` must NOT be read as `io_in` (loosening = drive wrong pins)."""
+    assert _top_has_gpio_pin_boundary(_PREFIXED_PIN_TOP) is False
+    assert declared_pad_ports(_PREFIXED_PIN_TOP) == {}
+
+
+def test_real_port_declarations_are_evidence():
+    pads = declared_pad_ports(_CARAVEL_WRAPPER)
+    assert pads == {"io_in": "input", "io_out": "output", "io_oeb": "output"}
+    assert _top_has_gpio_pin_boundary(_CARAVEL_WRAPPER) is True
+    assert _top_has_gpio_pin_boundary(_GPIO_TOP) is True
+
+
+def test_prose_and_internal_nets_are_not_evidence():
+    """A doc comment naming the pads + an internal `wire io_oeb` is not a boundary."""
+    assert _top_has_gpio_pin_boundary(_COMMENT_ONLY_WRAPPER) is False
+
+
+# ---------------------------------------------------------------------------
+# case 1: the wrapper IS found when the assembled top is not the boundary
+# ---------------------------------------------------------------------------
+
+def test_wrapper_is_found_when_top_is_not_the_boundary(tmp_path):
+    run, top = _make_run(tmp_path, qspi=True, wrapper=_CARAVEL_WRAPPER)
+    b = find_pin_boundary(
+        str(run), _PREFIXED_PIN_TOP,
+        top_module="raster_top", top_rtl_path=str(top),
+    )
+    assert b is not None, "the graded wrapper must be found, not ignored"
+    assert b.module == "user_project_wrapper"
+    assert b.path.endswith("rtl/user_project_wrapper.v")
+    assert b.ports == ("io_in", "io_oeb", "io_out")
+    assert b.in_top_source is False
+    # ... but it is NOT the module the integration sim elaborates
+    assert b.is_simulated_top is False
+
+    v = classify_bus_verdict(
+        str(run), _PREFIXED_PIN_TOP, None, "raster_top", str(top)
+    )
+    assert v.status == STATUS_BOUNDARY_OFF_TOP
+    assert v.contract is not None, "this IS a QSPI-slave chassis"
+    assert v.contract_enforcing is False
+    assert v.fails_closed is True
+    assert v.simulated_top == "raster_top"
+    assert "user_project_wrapper.v" in v.reason
+    assert "qspi_io_in" in v.reason        # names the pins DV would have driven
+    assert "CORESMITH_QSPI_BOUNDARY_GATE=0" in v.reason
+    # the same discovery through the contract-or-None API
+    assert classify_chip_bus(
+        str(run), _PREFIXED_PIN_TOP, None, "raster_top", str(top)
+    ) is not None
+
+
+def test_wrapper_that_only_mentions_pads_in_prose_is_not_counted(tmp_path):
+    """Evidence-based, not guessing: a wrapper must really declare the pads."""
+    run, top = _make_run(tmp_path, qspi=True, wrapper=_COMMENT_ONLY_WRAPPER)
+    assert find_pin_boundary(
+        str(run), _PREFIXED_PIN_TOP,
+        top_module="raster_top", top_rtl_path=str(top),
+    ) is None
+    v = classify_bus_verdict(
+        str(run), _PREFIXED_PIN_TOP, None, "raster_top", str(top)
+    )
+    assert v.status == STATUS_CONTRADICTION
+
+
+def test_boundary_on_the_simulated_top_is_contract_enforcing(tmp_path):
+    run, top = _make_run(
+        tmp_path, qspi=True, top_src=_GPIO_TOP, top_name="chip_top"
+    )
+    v = classify_bus_verdict(str(run), _GPIO_TOP, None, "chip_top", str(top))
+    assert v.status == STATUS_QSPI_TOP
+    assert v.contract_enforcing is True
+    assert v.fails_closed is False
+    assert v.boundary is not None and v.boundary.is_simulated_top is True
+
+
+def test_wrapper_found_and_it_is_the_simulated_top(tmp_path):
+    """When the graded wrapper IS the integration top, DV can enforce the contract."""
+    run, top = _make_run(
+        tmp_path, qspi=True, top_src=_CARAVEL_WRAPPER,
+        top_name="user_project_wrapper",
+    )
+    v = classify_bus_verdict(
+        str(run), _CARAVEL_WRAPPER, None, "user_project_wrapper", str(top)
+    )
+    assert v.status == STATUS_QSPI_TOP
+    assert v.contract_enforcing is True
+
+
+def test_plan_deterministic_dv_gives_no_plan_for_an_off_top_boundary(tmp_path):
+    """The deterministic host-flow must not be built against the wrong toplevel."""
+    run, top = _make_run(tmp_path, qspi=True, wrapper=_CARAVEL_WRAPPER)
+    contract, plan = bfm_lib.plan_deterministic_dv(
+        str(run), _PREFIXED_PIN_TOP, None, "raster_top", str(top)
+    )
+    assert (contract, plan) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# case 2: a genuinely non-QSPI design still classifies as not-QSPI
+# ---------------------------------------------------------------------------
+
+def test_genuine_non_qspi_design_is_not_qspi_and_does_not_error(tmp_path):
+    run, top = _make_run(
+        tmp_path, qspi=False, top_src=_NON_QSPI_TOP, top_name="chip_top"
+    )
+    v = classify_bus_verdict(str(run), _NON_QSPI_TOP, None, "chip_top", str(top))
+    assert v.status == STATUS_NOT_QSPI
+    assert v.contract is None
+    assert v.fails_closed is False, "an AXI-Stream design must not fail the run"
+    assert classify_chip_bus(str(run), _NON_QSPI_TOP, None, "chip_top", str(top)) is None
+
+
+def test_pad_boundary_without_qspi_corroboration_is_not_qspi(tmp_path):
+    """Pads present but nothing claims QSPI -> unchanged: not classified."""
+    run, top = _make_run(
+        tmp_path, qspi=False, top_src=_GPIO_TOP, top_name="chip_top"
+    )
+    v = classify_bus_verdict(str(run), _GPIO_TOP, None, "chip_top", str(top))
+    assert v.status == STATUS_NOT_QSPI
+    assert v.contract is None
+    assert v.fails_closed is False
+
+
+# ---------------------------------------------------------------------------
+# case 3: spec says QSPI, no boundary anywhere -> contradiction, fail closed
+# ---------------------------------------------------------------------------
+
+def test_spec_says_qspi_but_no_boundary_anywhere_is_a_contradiction(tmp_path):
+    run, top = _make_run(tmp_path, qspi=True)          # no wrapper file at all
+    v = classify_bus_verdict(
+        str(run), _PREFIXED_PIN_TOP, None, "raster_top", str(top)
+    )
+    assert v.status == STATUS_CONTRADICTION
+    assert v.contract is None
+    assert v.fails_closed is True
+    assert v.spec_says_qspi is True
+    assert "CONTRADICTION" in v.reason
+    assert "raster_top" in v.reason
+
+
+def test_connections_alone_can_corroborate_qspi(tmp_path):
+    run, top = _make_run(tmp_path, qspi=False)
+    conns = [{"interface": "qspi_pin_sample", "from_block": "wrapper"}]
+    v = classify_bus_verdict(
+        str(run), _PREFIXED_PIN_TOP, conns, "raster_top", str(top)
+    )
+    assert v.status == STATUS_CONTRADICTION
+    assert v.connections_say_qspi is True
+    assert v.fails_closed is True
+
+
+# ---------------------------------------------------------------------------
+# the gate flag: both branches
+# ---------------------------------------------------------------------------
+
+def test_boundary_gate_default_on(monkeypatch):
+    monkeypatch.delenv("CORESMITH_QSPI_BOUNDARY_GATE", raising=False)
+    monkeypatch.delenv("CORESMITH_GATE_FAIL_OPEN", raising=False)
+    assert boundary_gate_enabled() is True
+
+
+def test_boundary_gate_env_off(monkeypatch):
+    monkeypatch.delenv("CORESMITH_GATE_FAIL_OPEN", raising=False)
+    monkeypatch.setenv("CORESMITH_QSPI_BOUNDARY_GATE", "0")
+    assert boundary_gate_enabled() is False
+
+
+def test_boundary_gate_honors_global_fail_open(monkeypatch):
+    monkeypatch.delenv("CORESMITH_QSPI_BOUNDARY_GATE", raising=False)
+    monkeypatch.setenv("CORESMITH_GATE_FAIL_OPEN", "1")
+    assert boundary_gate_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# integration_dv_node wiring: the co-tuned BFM must be unreachable
+# ---------------------------------------------------------------------------
+
+def _setup_node(monkeypatch, tmp_path, *, wrapper: str = "", qspi: bool = True):
+    """Wire integration_dv_node for a FRESH (LLM) testbench-generation run."""
+    run, top = _make_run(tmp_path, qspi=qspi, wrapper=wrapper)
+    blk = run / "rtl" / "a.v"
+    blk.write_text("module a(input clk); endmodule\n")
+
+    monkeypatch.setenv("CORESMITH_QSPI_CONFORMANCE", "1")
+    monkeypatch.setattr(
+        pipeline_graph, "load_architecture_connections", lambda pr: ([], "chip"))
+    monkeypatch.setattr(
+        pipeline_graph, "parse_verilog_ports",
+        lambda p: VerilogModule(name="a", ports=[VerilogPort("clk", "input")]))
+    monkeypatch.setattr(
+        pipeline_graph, "run_integration_simulation",
+        lambda *a, **k: {"passed": True, "log": "sim ran", "log_path": ""})
+    monkeypatch.setattr(pipeline_graph, "_maybe_run_chip_equiv", lambda *a, **k: None)
+
+    async def _fake_audit(**kw):
+        return {"category": "TESTBENCH", "outer_agent_summary": "x", "audit_path": ""}
+    monkeypatch.setattr(pipeline_graph, "_run_top_level_contract_audit", _fake_audit)
+    monkeypatch.setattr(pipeline_graph, "write_graph_event", lambda *a, **k: None)
+
+    state = {
+        "project_root": str(run),
+        "integration_result": {
+            "top_rtl_path": str(top),
+            "design_name": "raster_top",
+            "block_rtl_paths": {"a": str(blk)},
+        },
+    }
+    return run, state
+
+
+@pytest.mark.asyncio
+async def test_off_top_boundary_fails_closed_and_never_reaches_the_llm_bfm(
+    monkeypatch, tmp_path
+):
+    """The load-bearing test: keeping the co-tuned BFM must be impossible."""
+    monkeypatch.delenv("CORESMITH_QSPI_BOUNDARY_GATE", raising=False)
+    monkeypatch.delenv("CORESMITH_GATE_FAIL_OPEN", raising=False)
+    run, state = _setup_node(monkeypatch, tmp_path, wrapper=_CARAVEL_WRAPPER)
+
+    async def _must_not_run(**kw):
+        raise AssertionError(
+            "the LLM-authored (DUT-co-tuned) BFM must not be generated once the "
+            "pin-boundary gate has failed closed"
+        )
+    monkeypatch.setattr(
+        pipeline_graph, "generate_integration_testbench", _must_not_run)
+
+    captured = {}
+
+    def fake_interrupt(payload):
+        captured.update(payload)
+        return {"action": "abort"}
+    monkeypatch.setattr(pipeline_graph, "interrupt", fake_interrupt)
+
+    result = await pipeline_graph.integration_dv_node(state)
+
+    assert captured.get("type") == "integration_dv_failure"
+    assert captured.get("phase") == "tb_generation"
+    assert "QSPI pin-boundary gate" in captured.get("sim_log", "")
+    assert "user_project_wrapper.v" in captured.get("sim_log", "")
+    dv = result["integration_dv_result"]
+    assert dv["passed"] is False
+    assert result["pipeline_done"] is False
+
+
+@pytest.mark.asyncio
+async def test_contradiction_fails_closed(monkeypatch, tmp_path):
+    """Spec says QSPI, no pin boundary anywhere -> same fail-closed interrupt."""
+    monkeypatch.delenv("CORESMITH_QSPI_BOUNDARY_GATE", raising=False)
+    monkeypatch.delenv("CORESMITH_GATE_FAIL_OPEN", raising=False)
+    run, state = _setup_node(monkeypatch, tmp_path, wrapper="")
+
+    async def _must_not_run(**kw):
+        raise AssertionError("LLM BFM must not be generated")
+    monkeypatch.setattr(
+        pipeline_graph, "generate_integration_testbench", _must_not_run)
+    captured = {}
+    monkeypatch.setattr(
+        pipeline_graph, "interrupt",
+        lambda p: (captured.update(p), {"action": "retry"})[1])
+
+    await pipeline_graph.integration_dv_node(state)
+    assert captured.get("type") == "integration_dv_failure"
+    assert "CONTRADICTION" in captured.get("sim_log", "")
+
+
+@pytest.mark.asyncio
+async def test_gate_off_restores_the_llm_bfm_but_records_a_defect(
+    monkeypatch, tmp_path
+):
+    """Flag-off branch: old behavior, and the bypass is NOT silent."""
+    monkeypatch.setenv("CORESMITH_QSPI_BOUNDARY_GATE", "0")
+    run, state = _setup_node(monkeypatch, tmp_path, wrapper=_CARAVEL_WRAPPER)
+    tb = run / "tb" / "integration" / "test_raster_top.py"
+    tb.parent.mkdir(parents=True, exist_ok=True)
+    tb.write_text("# llm tb\n")
+
+    async def _llm_tb(**kw):
+        return {"testbench_path": str(tb), "tb_path": str(tb), "test_count": 3}
+    monkeypatch.setattr(pipeline_graph, "generate_integration_testbench", _llm_tb)
+    monkeypatch.setattr(
+        pipeline_graph, "interrupt",
+        lambda p: (_ for _ in ()).throw(AssertionError("no interrupt expected")))
+
+    result = await pipeline_graph.integration_dv_node(state)
+    assert result["integration_dv_result"]["passed"] is True
+    defects = pipeline_graph.read_carried_forward_defects(str(run))
+    assert any(d.get("gate") == "qspi_pin_boundary" for d in defects), defects
+    assert any("io_oeb" in str(d.get("unmodeled", "")) for d in defects)
+
+
+@pytest.mark.asyncio
+async def test_non_qspi_design_still_uses_the_llm_bfm(monkeypatch, tmp_path):
+    """A genuinely non-QSPI design is untouched by the gate."""
+    monkeypatch.delenv("CORESMITH_QSPI_BOUNDARY_GATE", raising=False)
+    run, state = _setup_node(monkeypatch, tmp_path, wrapper="", qspi=False)
+    tb = run / "tb" / "integration" / "test_raster_top.py"
+    tb.parent.mkdir(parents=True, exist_ok=True)
+    tb.write_text("# llm tb\n")
+
+    async def _llm_tb(**kw):
+        return {"testbench_path": str(tb), "tb_path": str(tb), "test_count": 2}
+    monkeypatch.setattr(pipeline_graph, "generate_integration_testbench", _llm_tb)
+    monkeypatch.setattr(
+        pipeline_graph, "interrupt",
+        lambda p: (_ for _ in ()).throw(AssertionError("no interrupt expected")))
+
+    result = await pipeline_graph.integration_dv_node(state)
+    assert result["integration_dv_result"]["passed"] is True
+    defects = pipeline_graph.read_carried_forward_defects(str(run))
+    assert not any(d.get("gate") == "qspi_pin_boundary" for d in defects)

--- a/scripts/check_test_baseline.py
+++ b/scripts/check_test_baseline.py
@@ -1,0 +1,443 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Test-baseline guard: make a NEW test failure visible against a red suite.
+
+``orchestrator/tests`` has been red for a long time with failures that predate
+current work.  With ~100 pre-existing red tests nobody can tell whether their
+change added the next one, so every session re-litigates "is this failure
+mine?".  This script answers that mechanically:
+
+    orchestrator/tests/baseline_failures.txt   the ledger of ALREADY-red tests
+    scripts/check_test_baseline.py             runs the suite, diffs it
+
+Exit codes (same convention as ``bin/coresmith``: 0 ok, 1 verdict-fail,
+2 could-not-judge):
+
+    0   no test is failing that is not already in the baseline
+    1   REGRESSION -- at least one node ID fails that the baseline does not list
+    2   the guard itself could not run (pytest crashed, baseline missing, ...)
+
+Tests in the baseline that now PASS are reported but never fail the guard --
+they are progress, and the message tells you to prune them.  Baseline entries
+that no longer exist (renamed, deleted, deselected by a marker filter) are
+reported as stale, not crashed on.
+
+Usage::
+
+    # the gate: did I add the next failure?
+    python scripts/check_test_baseline.py
+
+    # deliberate refresh after paying debt down (or after a rename)
+    python scripts/check_test_baseline.py --refresh
+
+    # judge a dump you already have, without paying for another ~200s run
+    python scripts/check_test_baseline.py --from-json /tmp/run.json
+
+Why a script and not a pytest test: the guard has to run the WHOLE suite as a
+subprocess.  A pytest test that does that would collect itself inside its own
+child run and re-spawn the suite recursively.  It is also a CI/pre-push gate
+whose product is an exit code, which is exactly what ``scripts/nightly_canary.py``
+and ``scripts/triage_escalation.py`` already are.
+
+See ``docs/TEST-BASELINE.md`` for the refresh policy.  The baseline is a debt
+ledger to shrink, not a permanent excuse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BASELINE = REPO_ROOT / "orchestrator" / "tests" / "baseline_failures.txt"
+
+# The invocation the baseline is measured with. Deliberately NOT marker-filtered:
+# the baseline records the whole suite as it actually behaves on this machine, so
+# a run that filters markers is a DIFFERENT population and is flagged as such.
+PYTEST_ARGS = [
+    "-m",
+    "pytest",
+    "orchestrator/tests",
+    "-q",
+    "--no-header",
+    "-p",
+    "no:cacheprovider",
+]
+
+# Written to a temp dir and loaded with `-p`. Parsing pytest's `-rf` short
+# summary instead would be ambiguous: the summary line is "FAILED <nodeid> - <msg>"
+# and a parametrized node ID may itself contain " - ".
+_COLLECTOR_PLUGIN = '''
+"""Dump this run's per-test outcomes as JSON. Written by check_test_baseline.py."""
+import json
+import os
+
+_outcomes = {}
+_collected = set()
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        _collected.add(item.nodeid)
+
+
+def pytest_collectreport(report):
+    # A module that fails to import yields a collect error whose nodeid is the
+    # file path, and never produces items -- count it as both seen and failed.
+    if report.failed:
+        _collected.add(report.nodeid)
+        _outcomes[report.nodeid] = "failed"
+
+
+def pytest_runtest_logreport(report):
+    nodeid = report.nodeid
+    _collected.add(nodeid)
+    if report.failed:
+        _outcomes[nodeid] = "failed"
+    elif report.skipped:
+        if _outcomes.get(nodeid) != "failed":
+            _outcomes[nodeid] = "xfailed" if hasattr(report, "wasxfail") else "skipped"
+    elif report.when == "call" and nodeid not in _outcomes:
+        _outcomes[nodeid] = "xpassed" if hasattr(report, "wasxfail") else "passed"
+
+
+def pytest_sessionfinish(session, exitstatus):
+    counts = {}
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        for key, reports in reporter.stats.items():
+            if key:
+                counts[key] = len(reports)
+    payload = {
+        "outcomes": _outcomes,
+        "collected": sorted(_collected),
+        "counts": counts,
+        "exitstatus": int(exitstatus),
+    }
+    with open(os.environ["CS_BASELINE_DUMP"], "w") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+'''
+
+_HEADER_PREAMBLE = """\
+# CoreSmith test-suite failure baseline.
+#
+# THIS IS A DEBT LEDGER, NOT A PERMANENT EXCUSE. Every node ID below is a test
+# that was ALREADY failing before the current work started. The list exists for
+# exactly one reason: so that failure number N+1 -- the one YOU just added -- is
+# visible against a suite that is already red.
+#
+# Rules:
+#   * Never add a line to this file to make your own change go green. Adding a
+#     line is admitting a regression. Fix the test or fix the code.
+#   * Deleting lines is the point. When a test here starts passing, prune it:
+#       python scripts/check_test_baseline.py --refresh
+#   * The guard reads only the node IDs. Header fields are provenance.
+#
+# The failing set depends on the TOOLCHAIN, not only the code -- see the
+# `environment:` field below. On the first measurement 50 of 75 entries failed
+# only because the `claude` binary was off PATH. Put the toolchain back before
+# you believe a big diff.
+#
+# Check a change against it:   python scripts/check_test_baseline.py
+# Full policy:                 docs/TEST-BASELINE.md
+#
+"""
+
+
+# --------------------------------------------------------------------------- #
+# baseline file I/O
+# --------------------------------------------------------------------------- #
+
+
+def parse_baseline(path: Path) -> tuple[set[str], dict[str, str]]:
+    """Return ``(node_ids, header_fields)`` from a baseline file.
+
+    Lines starting with ``#`` are comments; ``# key: value`` comments are also
+    harvested as provenance fields. Blank lines are ignored.
+    """
+    node_ids: set[str] = set()
+    header: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            match = re.match(r"^#\s*([a-z][a-z0-9-]*)\s*:\s*(.*)$", line)
+            if match:
+                header[match.group(1)] = match.group(2).strip()
+            continue
+        node_ids.add(line)
+    return node_ids, header
+
+
+def probe_environment() -> str:
+    """Record the environment facts that move whole BLOCKS of this suite.
+
+    Two thirds of the failures in the first baseline were not code at all: 50
+    tests failed with "Claude CLI not found" because ``claude`` was not on PATH,
+    and the PDK tests failed because ``.pdk/`` was absent. A ledger that does not
+    say which tools were present invites a future reader to mistake a PATH change
+    for fifty regressions (or fifty repairs).
+    """
+    pdk_root = os.environ.get("PDK_ROOT") or str(REPO_ROOT / ".pdk")
+    facts = [
+        ("claude", bool(shutil.which("claude"))),
+        ("pdk", Path(pdk_root).is_dir()),
+    ]
+    facts += [(tool, bool(shutil.which(tool)))
+              for tool in ("yosys", "verilator", "openroad", "magic", "iverilog")]
+    return " ".join(f"{name}={'yes' if ok else 'NO'}" for name, ok in facts)
+
+
+def render_baseline(failures: set[str], counts: dict[str, int], commit: str,
+                    invocation: str) -> str:
+    """Render a baseline file body (header + sorted, de-duplicated node IDs)."""
+    ordered = ("failed", "passed", "skipped", "xfailed", "xpassed", "error")
+    shown = [f"{key}={counts[key]}" for key in ordered if counts.get(key)]
+    extra = [f"{k}={v}" for k, v in sorted(counts.items())
+             if k not in ordered and isinstance(v, int)]
+    lines = [_HEADER_PREAMBLE.rstrip("\n")]
+    lines.append(f"# measured-at-commit: {commit}")
+    lines.append(f"# measured-on: {date.today().isoformat()}")
+    lines.append(f"# pytest-invocation: {invocation}")
+    lines.append(f"# environment: {probe_environment()}")
+    lines.append(f"# counts: {' '.join(shown + extra)}")
+    lines.append(f"# baseline-failures: {len(failures)}")
+    lines.append("#")
+    lines.extend(sorted(failures))
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# running the suite
+# --------------------------------------------------------------------------- #
+
+
+def describe_invocation(extra_args: list[str]) -> str:
+    return " ".join(["python", *PYTEST_ARGS, *extra_args])
+
+
+def run_suite(extra_args: list[str], keep_json: Path | None) -> dict:
+    """Run the full suite and return the collector plugin's JSON payload."""
+    with tempfile.TemporaryDirectory(prefix="cs-baseline-") as tmp:
+        plugin_dir = Path(tmp)
+        (plugin_dir / "_cs_baseline_collector.py").write_text(_COLLECTOR_PLUGIN)
+        dump_path = plugin_dir / "dump.json"
+
+        env = dict(os.environ)
+        env["CS_BASELINE_DUMP"] = str(dump_path)
+        pythonpath = [str(REPO_ROOT), str(plugin_dir)]
+        if env.get("PYTHONPATH"):
+            pythonpath.append(env["PYTHONPATH"])
+        env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+
+        argv = [sys.executable, *PYTEST_ARGS, "-p", "_cs_baseline_collector",
+                "--tb=no", *extra_args]
+        print(f"[baseline] running: {' '.join(argv)}", flush=True)
+        proc = subprocess.run(argv, cwd=str(REPO_ROOT), env=env)
+
+        if not dump_path.exists():
+            raise RuntimeError(
+                f"pytest exited {proc.returncode} without writing a run dump -- "
+                "the suite probably crashed (segfault / collection abort / OOM) "
+                "rather than merely failing. Re-run pytest by hand to see why."
+            )
+        payload = json.loads(dump_path.read_text())
+        if keep_json:
+            keep_json.write_text(json.dumps(payload, indent=2, sort_keys=True))
+            print(f"[baseline] raw run dump kept at {keep_json}")
+        return payload
+
+
+def git_commit() -> str:
+    try:
+        out = subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(REPO_ROOT),
+                             capture_output=True, text=True, check=True)
+        return out.stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# the diff
+# --------------------------------------------------------------------------- #
+
+
+def judge(payload: dict, baseline: set[str], header: dict[str, str],
+          invocation: str) -> int:
+    outcomes: dict[str, str] = payload.get("outcomes", {})
+    collected = set(payload.get("collected", []))
+    counts: dict[str, int] = payload.get("counts", {})
+    now_failed = {nodeid for nodeid, outcome in outcomes.items() if outcome == "failed"}
+
+    new_failures = sorted(now_failed - baseline)
+    seen = baseline & collected
+    now_passing = sorted(n for n in seen if outcomes.get(n) in ("passed", "xpassed"))
+    now_skipped = sorted(n for n in seen if outcomes.get(n) in ("skipped", "xfailed"))
+    # Renamed / deleted / deselected: in the ledger but the run never saw it.
+    vanished = sorted(baseline - collected)
+
+    shown = " ".join(f"{k}={counts[k]}" for k in
+                     ("failed", "passed", "skipped", "xfailed", "xpassed", "error")
+                     if counts.get(k))
+    print()
+    print("=" * 72)
+    print(f"this run:  {shown or 'no counts reported'}")
+    print(f"baseline:  {len(baseline)} known-red node IDs "
+          f"(measured at {header.get('measured-at-commit', '?')[:12]} "
+          f"on {header.get('measured-on', '?')})")
+
+    recorded = header.get("pytest-invocation")
+    if recorded and recorded != invocation:
+        print()
+        print("WARNING: this run's invocation differs from the one the baseline "
+              "was measured with.")
+        print(f"  baseline: {recorded}")
+        print(f"  this run: {invocation}")
+        print("  A marker-filtered or subset run is a different population; the "
+              "diff below may be noise.")
+
+    recorded_env = header.get("environment")
+    current_env = probe_environment()
+    if recorded_env and recorded_env != current_env:
+        print()
+        print("WARNING: the toolchain present now differs from when the baseline "
+              "was measured.")
+        print(f"  baseline: {recorded_env}")
+        print(f"  this run: {current_env}")
+        print("  Whole blocks of this suite are gated on these tools (~50 tests need "
+              "the `claude`")
+        print("  binary alone). A large swing below is probably PATH, not code.")
+
+    if now_passing:
+        print()
+        print(f"PROGRESS -- {len(now_passing)} baseline failure(s) now PASS. "
+              "Prune them from the ledger:")
+        for nodeid in now_passing:
+            print(f"  + {nodeid}")
+        print("  ->  python scripts/check_test_baseline.py --refresh")
+
+    if now_skipped:
+        print()
+        print(f"NOTE -- {len(now_skipped)} baseline failure(s) are now skipped/xfailed, "
+              "not fixed:")
+        for nodeid in now_skipped:
+            print(f"  ~ {nodeid} ({outcomes.get(nodeid)})")
+
+    if vanished:
+        print()
+        print(f"STALE -- {len(vanished)} baseline entry/entries were not collected at all "
+              "(renamed, deleted, or deselected):")
+        for nodeid in vanished:
+            print(f"  ? {nodeid}")
+        print("  ->  refresh the baseline if these tests are genuinely gone.")
+
+    if new_failures:
+        print()
+        print(f"FAIL -- {len(new_failures)} NEW test failure(s) not in the baseline:")
+        for nodeid in new_failures:
+            print(f"  ! {nodeid}")
+        print()
+        print("These are yours. Reproduce one with:")
+        print(f"  python -m pytest '{new_failures[0]}' -x -vv")
+        print("If it fails only inside the full suite it is an order-dependence bug, "
+              "still yours.")
+        print("=" * 72)
+        return 1
+
+    print()
+    print(f"OK -- no failure outside the baseline ({len(now_failed)} failing, "
+          f"all {len(now_failed & baseline)} already known-red).")
+    print("=" * 72)
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE,
+                        help="baseline ledger to read/write (default: %(default)s)")
+    parser.add_argument("--refresh", action="store_true",
+                        help="DELIBERATE re-measure: rewrite the baseline from this run "
+                             "instead of judging against it")
+    parser.add_argument("--from-json", type=Path, metavar="PATH",
+                        help="reuse a dump written by an earlier --json-out run instead "
+                             "of re-running the suite")
+    parser.add_argument("--json-out", type=Path, metavar="PATH",
+                        help="keep this run's raw dump at PATH")
+    parser.add_argument("pytest_args", nargs="*",
+                        help="extra args appended to the pytest invocation (changes the "
+                             "population; the guard warns when it does)")
+    args = parser.parse_args(argv)
+
+    invocation = describe_invocation(args.pytest_args)
+
+    if args.from_json:
+        if not args.from_json.exists():
+            print(f"ERROR: no such dump: {args.from_json}", file=sys.stderr)
+            return 2
+        try:
+            payload = json.loads(args.from_json.read_text())
+        except (OSError, ValueError) as exc:
+            print(f"ERROR: unreadable dump {args.from_json}: {exc}", file=sys.stderr)
+            return 2
+    else:
+        try:
+            payload = run_suite(args.pytest_args, args.json_out)
+        except (RuntimeError, OSError, ValueError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    outcomes: dict[str, str] = payload.get("outcomes", {})
+    counts: dict[str, int] = payload.get("counts", {})
+    failed = {nodeid for nodeid, outcome in outcomes.items() if outcome == "failed"}
+
+    if not outcomes:
+        print("ERROR: the run dump records no test outcomes at all -- collection "
+              "failed before any test ran.", file=sys.stderr)
+        return 2
+
+    if args.refresh:
+        body = render_baseline(failed, counts, git_commit(), invocation)
+        args.baseline.parent.mkdir(parents=True, exist_ok=True)
+        args.baseline.write_text(body)
+        print(f"\n[baseline] wrote {len(failed)} known-red node IDs to {args.baseline}")
+        print("[baseline] REVIEW THE DIFF before committing. Lines ADDED are "
+              "regressions you are about to bless;")
+        print("[baseline] lines REMOVED are debt you paid off.")
+        return 0
+
+    if not args.baseline.exists():
+        print(f"ERROR: no baseline at {args.baseline}. Create one deliberately, from a "
+              "PRISTINE tree:\n"
+              "  python scripts/check_test_baseline.py --refresh", file=sys.stderr)
+        return 2
+    try:
+        baseline, header = parse_baseline(args.baseline)
+    except OSError as exc:
+        print(f"ERROR: unreadable baseline {args.baseline}: {exc}", file=sys.stderr)
+        return 2
+    if not baseline:
+        print(f"ERROR: baseline {args.baseline} lists no node IDs.", file=sys.stderr)
+        return 2
+
+    return judge(payload, baseline, header, invocation)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/patch_openram.py
+++ b/scripts/patch_openram.py
@@ -1026,6 +1026,56 @@ def patch_openram(*, check_only: bool = False) -> PatchResult:
             except OSError as e:
                 res.errors.append(f"SPICE micron-unit patch failed ({e})")
 
+    # (10) Deep arrays need a 4-input NAND row decoder, but only freepdk45
+    # -- OpenRAM's reference technology -- defines nand4_leakage.  sky130,
+    # gf180mcu and scn3me_subm copied the leakage block and dropped that one
+    # key, so pnand4.analytical_power() raises KeyError on every ported PDK.
+    # A 64-deep array (6 address bits) never instantiates pnand4; a 4096-deep
+    # one (12 bits) always does, which is why small macros build and large
+    # ones die.  Every sibling value in these files is a placeholder 1 nW
+    # analytical constant -- OpenRAM runs with characterization disabled --
+    # so supplying the missing key costs no fidelity that was ever there.
+    _leak_pending: list[tuple[Path, str, str]] = []
+    _leak_have = 0
+    for _tech in ("sky130", "gf180mcu", "scn3me_subm"):
+        _tf = pkg / "technology" / _tech / "tech" / "tech.py"
+        if not _tf.exists():
+            continue
+        _old = _tf.read_text(errors="ignore")
+        if 'spice["nand4_leakage"]' in _old:
+            _leak_have += 1
+            continue
+        _idx = _old.find('spice["nand3_leakage"]')
+        if _idx < 0:
+            continue
+        _eol = _old.find("\n", _idx)
+        if _eol < 0:
+            continue
+        _new = (
+            _old[:_eol + 1]
+            + 'spice["nand4_leakage"] = 1       # Leakage power of 4-input nand in nW\n'
+            + _old[_eol + 1:]
+        )
+        _leak_pending.append((_tf, _old, _new))
+
+    if not _leak_pending:
+        res.already.append(
+            "nand4-leakage" if _leak_have else "nand4-leakage-unavailable")
+    elif check_only:
+        res.errors.append(
+            f"{len(_leak_pending)} technology tech.py missing nand4_leakage"
+        )
+    else:
+        try:
+            for _path, _old, _new in _leak_pending:
+                _bak = _path.with_suffix(".py.coresmith-bak")
+                if not _bak.exists():
+                    _bak.write_text(_old, encoding="utf-8")
+                _path.write_text(_new, encoding="utf-8")
+            res.applied.append("nand4-leakage")
+        except OSError as e:
+            res.errors.append(f"nand4_leakage patch failed ({e})")
+
     # Runnable iff __main__ importable now.
     try:
         importlib.invalidate_caches()


### PR DESCRIPTION
## What this fixes

One root cause with five symptoms, found while corroborating the chip_top gate-sim work on run `exp-raster-macro-20260727`: `discover_block_rtl` never read `rtl_target`, so the one block whose Verilog file is not named after it — the contract-locked Caravel pad adapter — was silently deleted from the assembled chip. The chip shipped with **no `io_in`/`io_out`/`io_oeb` at all**, the bus classifier fell back to a DUT-co-tuned BFM, and the run reported `INTEGRATION DV PASSED` / `SIGNOFF SCORECARD: PASS` on an ungradeable design.

Alongside the discovery fix, this lands the gates that make the class visible:

- **Block-completeness gate**: integration refuses to assemble a chip missing a block (retry/override/abort interrupt). On the validation run this gate caught a second, subtler instance of the same bug — see PR stack.
- **chip_top gate-sim actually wired**: `top_rtl_path` was not a `BackendState` field, nothing populated it, and nothing consumed `chip_gate_sim_ok` — the gate reported `not_run` on every real run while its unit test passed by injecting the value itself. Now fed from one shared `chip_rtl_sources()` builder (the same source set the passing integration DV elaborates, MODDUP-deduped), and a FAIL routes to diagnose instead of P&R.
- **Macro stand-ins read the real macro's interface**: the generator emitted a `wmask0` port for a macro that has none; the pin floated low and every framebuffer write was silently suppressed (74,581 divergences over 200k cycles, measured). Power/ground inouts are tied off instead of vetoing; default ON at chip_top scope; opt-in debug mode keeps comparing past the first divergence.
- **Honest DRC verdicts**: a missing Magic report was `violation_count: -1, pass: false` (absence read as failure); a missing KLayout report read as *clean* (absence read as success). "Could not measure" is now its own state with a reason, end to end.
- **Test-baseline ledger**: 75 known-red tests pinned with a checker that fails only on failures *outside* the baseline, so the 76th failure is visible. It caught real regressions three times during this work.

## Validation

Zero regressions by the ledger on the branch tip. Downstream validation (see stacked PR) drove a seeded raster run through these gates to a real chip-level gate-sim verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBWgL9qExhCeRdRMAXv7yX
