### PR TITLE
Contract-directed integration: raster passes chip-level gate-sim (1169 cycles, 0 divergence)

### DIFF
--- a/orchestrator/architecture/pin_map.py
+++ b/orchestrator/architecture/pin_map.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The chip's physical pin assignment, as data rather than prose.
+
+The shuttle fixes the package pinout: a design gets `io_in`/`io_out`/`io_oeb`
+and must decide which bit carries which signal. That decision is a REQUIREMENT --
+it comes from the host protocol the part has to speak -- so it belongs in the
+PRD, and it belongs there structured.
+
+Today it is a sentence:
+
+    "GPIO mapping is locked: io[0]=qspi_csn input, io[1]=qspi_sck input,
+     io[5:2]=bidirectional qspi_io[3:0], and io[6]=irq output. io_oeb[0]=
+     io_oeb[1]=1, io_oeb[6]=0, and io_oeb[5:2]=0 only during QSPI read-data
+     drive phases; otherwise io_oeb[5:2]=1..."
+
+Everything downstream then re-derives that by reading it. The architecture phase
+invented a whole pin-adapter BLOCK to hold the translation, an LLM generated that
+block's RTL, and because the shuttle also mandates the module name
+`user_project_wrapper` -- which conventionally means "the entire chip" -- the
+generator produced a competing chip top instead of an adapter. Four regenerations
+with explicit corrective feedback produced the identical result each time.
+
+None of that is a modelling problem. A pin map is a permutation of bit ranges.
+Given it as data, the integration stage emits the routing directly and there is
+no adapter block to get wrong.
+
+Schema (``prd["pin_map"]``)::
+
+    {
+      "bus_width": 38,
+      "entries": [
+        {"signal": "qspi_csn",    "dir": "in",  "msb": 0, "lsb": 0},
+        {"signal": "qspi_io_in",  "dir": "in",  "msb": 5, "lsb": 2},
+        {"signal": "qspi_io_out", "dir": "out", "msb": 5, "lsb": 2,
+         "oe": "qspi_drive_en"},
+        {"signal": "irq_level",   "dir": "out", "msb": 6, "lsb": 6}
+      ]
+    }
+
+``dir`` is from the CHIP's point of view: ``in`` reads ``io_in``, ``out`` drives
+``io_out``. ``oe`` names an active-high enable; the emitter inverts it, because
+``io_oeb`` is active-low. An ``out`` entry with no ``oe`` drives permanently.
+Unmapped bits are tied off, so every bit of every bus has exactly one driver.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+IN_BUS, OUT_BUS, OE_BUS = "io_in", "io_out", "io_oeb"
+
+
+@dataclass
+class PinEntry:
+    signal: str
+    dir: str                 # "in" | "out"
+    msb: int
+    lsb: int
+    oe: str = ""             # active-high enable for an "out" entry
+
+    @property
+    def width(self) -> int:
+        return abs(self.msb - self.lsb) + 1
+
+    @property
+    def bits(self) -> range:
+        lo, hi = sorted((self.lsb, self.msb))
+        return range(lo, hi + 1)
+
+
+@dataclass
+class PinMap:
+    bus_width: int = 38
+    entries: list = field(default_factory=list)
+    errors: list = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors and bool(self.entries)
+
+
+def load_pin_map(project_root) -> PinMap | None:
+    """Read ``prd["pin_map"]``. None when the PRD declares none.
+
+    Deliberately reads ONLY the structured field. Parsing the prose form would
+    put a guess back on the production path, which is the thing this replaces.
+    """
+    p = Path(project_root) / ".coresmith" / "prd_spec.json"
+    try:
+        doc = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    prd = doc.get("prd") if isinstance(doc, dict) else None
+    raw = (prd or {}).get("pin_map") if isinstance(prd, dict) else None
+    if not isinstance(raw, dict) or not raw.get("entries"):
+        return None
+    return parse_pin_map(raw)
+
+
+def parse_pin_map(raw: dict) -> PinMap:
+    """Validate a pin-map document. Errors are returned, never raised."""
+    pm = PinMap(bus_width=int(raw.get("bus_width") or 38))
+    for i, e in enumerate(raw.get("entries") or []):
+        if not isinstance(e, dict):
+            pm.errors.append(f"entry {i} is not an object")
+            continue
+        sig, d = str(e.get("signal") or ""), str(e.get("dir") or "")
+        if not sig:
+            pm.errors.append(f"entry {i} has no signal name")
+            continue
+        if d not in ("in", "out"):
+            pm.errors.append(f"{sig}: dir must be 'in' or 'out', got {d!r}")
+            continue
+        try:
+            msb, lsb = int(e["msb"]), int(e["lsb"])
+        except (KeyError, TypeError, ValueError):
+            pm.errors.append(f"{sig}: msb/lsb must be integers")
+            continue
+        if min(msb, lsb) < 0 or max(msb, lsb) >= pm.bus_width:
+            pm.errors.append(
+                f"{sig}: bits [{msb}:{lsb}] fall outside the {pm.bus_width}-bit bus")
+            continue
+        oe = str(e.get("oe") or "")
+        if oe and d != "out":
+            pm.errors.append(f"{sig}: 'oe' is only meaningful on an out entry")
+            continue
+        pm.entries.append(PinEntry(sig, d, msb, lsb, oe))
+
+    # A bit driven twice is a short; a signal named twice is a typo. Both are
+    # refused rather than resolved, because either guess produces a wrong chip.
+    for bus, sel in (("input", "in"), ("output", "out")):
+        seen: dict = {}
+        for ent in [x for x in pm.entries if x.dir == sel]:
+            for b in ent.bits:
+                if b in seen:
+                    pm.errors.append(
+                        f"{bus} bit {b} is claimed by both '{seen[b]}' and "
+                        f"'{ent.signal}'")
+                seen[b] = ent.signal
+    names = [e.signal for e in pm.entries]
+    for n in sorted(set(names)):
+        if names.count(n) > 1:
+            pm.errors.append(f"signal '{n}' is mapped {names.count(n)} times")
+    return pm
+
+
+def _ranges(bits: set, width: int) -> list:
+    """Contiguous [msb, lsb] ranges covering `bits`, high to low."""
+    out, run = [], []
+    for b in range(width):
+        if b in bits:
+            run.append(b)
+        elif run:
+            out.append((run[-1], run[0]))
+            run = []
+    if run:
+        out.append((run[-1], run[0]))
+    return list(reversed(out))
+
+
+def emit_pin_routing(pm: PinMap) -> tuple:
+    """Verilog that connects the pad buses to named signals.
+
+    Returns ``(declarations, assignments)``. Declarations are the internal wires
+    a chip top should declare for INPUT-side signals; output-side signals are
+    driven by blocks and only read here.
+
+    Every bit of io_out and io_oeb ends up with exactly one driver: mapped bits
+    from their signal, everything else tied to the safe default (output 0,
+    output-enable de-asserted). A floating pad bit is a real defect and tying
+    them here makes it impossible.
+    """
+    decls, assigns = [], []
+    w = pm.bus_width
+
+    for e in [x for x in pm.entries if x.dir == "in"]:
+        rng = "" if e.width == 1 else f"[{e.width - 1}:0] "
+        sel = f"[{e.msb}]" if e.width == 1 else f"[{max(e.msb, e.lsb)}:{min(e.msb, e.lsb)}]"
+        decls.append(f"wire {rng}{e.signal} = {IN_BUS}{sel};")
+
+    driven_out, driven_oe = set(), set()
+    for e in [x for x in pm.entries if x.dir == "out"]:
+        sel = (f"[{e.msb}]" if e.width == 1
+               else f"[{max(e.msb, e.lsb)}:{min(e.msb, e.lsb)}]")
+        assigns.append(f"assign {OUT_BUS}{sel} = {e.signal};")
+        driven_out |= set(e.bits)
+        if e.oe:
+            # io_oeb is ACTIVE LOW: drive the pad when the enable is high.
+            rep = "" if e.width == 1 else f"{{{e.width}{{"
+            tail = "" if e.width == 1 else "}}"
+            assigns.append(f"assign {OE_BUS}{sel} = {rep}~{e.oe}{tail};")
+        else:
+            assigns.append(
+                f"assign {OE_BUS}{sel} = {e.width}'b" + "0" * e.width + ";")
+        driven_oe |= set(e.bits)
+
+    for msb, lsb in _ranges(set(range(w)) - driven_out, w):
+        n = msb - lsb + 1
+        sel = f"[{msb}]" if n == 1 else f"[{msb}:{lsb}]"
+        assigns.append(f"assign {OUT_BUS}{sel} = {n}'b" + "0" * n + ";")
+    for msb, lsb in _ranges(set(range(w)) - driven_oe, w):
+        n = msb - lsb + 1
+        sel = f"[{msb}]" if n == 1 else f"[{msb}:{lsb}]"
+        # Default is 1: do NOT drive a pad nobody asked for.
+        assigns.append(f"assign {OE_BUS}{sel} = {n}'b" + "1" * n + ";")
+
+    return decls, assigns
+
+
+def mapped_signals(pm: PinMap) -> dict:
+    """signal name -> width, for wiring the routing to block ports."""
+    return {e.signal: e.width for e in pm.entries}

--- a/orchestrator/harness/gate_sim.py
+++ b/orchestrator/harness/gate_sim.py
@@ -496,22 +496,59 @@ def power_inout_level(name: str) -> Optional[int]:
     return None
 
 
-def split_inouts(ports: list[Port]) -> tuple[list[Port], list[Port]]:
-    """``(power_rails, signal_inouts)`` among the top's bidirectional ports.
+def inout_is_inert(netlist_text: str, name: str) -> bool:
+    """True when the netlist PROVES this inout carries no behaviour.
 
-    A rail wider than one bit is not a rail we understand, so it is reported as a
-    signal rather than tied to a guessed constant.
+    Every reference must be the port's own declaration (port list, `inout`,
+    `wire`) or a constant all-Z assign -- the exact form yosys emits for an
+    unused mandated pad bus (`assign analog_io = 29'hzzzzzzzz;`). One reference
+    that is anything else (an instance connection, a real driver, a read) means
+    the port participates in the design and the honest answer stays "cannot
+    judge".
+
+    Structural on purpose. A name list ("analog_io is fine") would silently
+    bless a design that actually drives its analog pads.
+    """
+    ref = re.compile(r"^.*\b" + re.escape(name) + r"\b.*$", re.MULTILINE)
+    decl = re.compile(
+        r"^\s*(?:module\b|(?:inout|input|output|wire|tri|logic)\b)")
+    zassign = re.compile(
+        r"^\s*assign\s+\\?" + re.escape(name) +
+        r"(?:\s*\[[^\]]*\])?\s*=\s*\d*'[hbodHBOD]?[zZ_]+\s*;")
+    for m in ref.finditer(netlist_text):
+        line = m.group(0)
+        if decl.match(line) or zassign.match(line):
+            continue
+        return False
+    return True
+
+
+def split_inouts(
+    ports: list[Port], netlist_text: str = "",
+) -> tuple[list[Port], list[Port], list[Port]]:
+    """``(power_rails, inert, signal_inouts)`` among the bidirectional ports.
+
+    ``inert`` are inouts the netlist proves carry no behaviour (see
+    :func:`inout_is_inert`) -- mandated-but-unused pad buses like Caravel's
+    ``analog_io``. They are neither driven nor compared, and excluding them
+    fabricates nothing because there is nothing there.
+
+    A rail wider than one bit is not a rail we understand, so it is reported as
+    a signal rather than tied to a guessed constant.
     """
     rails: list[Port] = []
+    inert: list[Port] = []
     signals: list[Port] = []
     for p in ports:
         if p.direction != "inout":
             continue
         if p.width == 1 and power_inout_level(p.name) is not None:
             rails.append(p)
+        elif netlist_text and inout_is_inert(netlist_text, p.name):
+            inert.append(p)
         else:
             signals.append(p)
-    return rails, signals
+    return rails, inert, signals
 
 
 def pick_clock(ports: list[Port], hint: str = "") -> Optional[Port]:
@@ -1434,7 +1471,7 @@ def render_driver_cpp(top: str, ports: list[Port], clock: str,
         max_divergences = gate_sim_max_divergences()
     ins = [p for p in ports if p.direction == "input" and p.name != clock]
     outs = [p for p in ports if p.direction == "output"]
-    rails, _ = split_inouts(ports)
+    rails, _inert, _sig = split_inouts(ports)
 
     # Supplies are constants, but they are re-asserted every cycle: an `inout`
     # can be driven from inside the netlist during eval(), and a rail that
@@ -1898,7 +1935,13 @@ def check_gate_sim(
     if clock is None:
         return _not_run("no clock port identified on the netlist top -- "
                         "cycle-accurate replay needs one")
-    rails, signal_inouts = split_inouts(ports)
+    rails, inert_inouts, signal_inouts = split_inouts(ports, netlist_text)
+    if inert_inouts:
+        # Mandated-but-unused pad buses (Caravel analog_io): the netlist proves
+        # they carry no behaviour (declaration + constant-Z tie only), so they
+        # are excluded from drive and comparison. Excluding nothing fabricates
+        # nothing -- but record them so the verdict says what was not judged.
+        pass
     if signal_inouts:
         # A bidirectional SIGNAL is neither driven nor compared by the replay, so
         # a PASS would carry a hole exactly where the gate is supposed to be

--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -476,6 +476,11 @@ async def init_design_node(state: BackendState) -> dict:
     log(f"{'='*60}", CYAN)
 
     out: dict = {
+        # Return the COMPUTED name. It was logged in the banner and then
+        # dropped, so the state kept whatever the caller guessed -- measured:
+        # the banner said user_project_wrapper while synthesis ran with a stale
+        # name and yosys renamed the top to match it.
+        "design_name": design_name,
         "current_block": {"name": design_name},
         "integration_top_path": integration_top,
         "block_rtl_paths": block_rtl,

--- a/orchestrator/langgraph/bfm_lib/codegen.py
+++ b/orchestrator/langgraph/bfm_lib/codegen.py
@@ -250,6 +250,14 @@ def render_conformance_tb(contract: QSPIContract, design_name: str) -> str:
 # the exercise-specific compute oracle is NOT modeled. This is the gate a frontend
 # that dropped 0x05 or mistimed the read turnaround must fail at generation -- the
 # the image codec gap where such a frontend slipped through on the co-tuned LLM BFM.
+from __future__ import annotations
+# The future import is REQUIRED, not style: the BFM class source is inlined
+# below via inspect.getsource, and its `-> QSPIContract` method annotations
+# only defer (instead of evaluating at class-body time, where the name does
+# not exist yet) when this file itself has the future import. Without it the
+# generated module dies at import with NameError -- which is how the
+# contract-enforcing conformance DV shipped without ever having produced an
+# importable testbench.
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge
@@ -312,6 +320,14 @@ def render_integration_tb(
 # supplies only the golden MODEL, evaluated at generation time into the
 # expected bytes below. A DUT that violates the QSPI-slave read/dummy/serialize
 # contract de-aligns and is caught -- the property the co-tuned LLM BFM lacked.
+from __future__ import annotations
+# The future import is REQUIRED, not style: the BFM class source is inlined
+# below via inspect.getsource, and its `-> QSPIContract` method annotations
+# only defer (instead of evaluating at class-body time, where the name does
+# not exist yet) when this file itself has the future import. Without it the
+# generated module dies at import with NameError -- which is how the
+# contract-enforcing conformance DV shipped without ever having produced an
+# importable testbench.
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -1,0 +1,230 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Does a block's RTL expose the ports its interface contract declares?
+
+The contract already says exactly what every channel's signals are called. Each
+edge in ``.coresmith/interface_contracts.json`` carries ``fields[]`` (the
+payload) and ``sideband_signals[]`` (everything else); their UNION is the port
+set. A block may expose a declared signal either as ``<channel>_<field>`` or
+as bare ``<field>`` -- both styles are in use, and the prefixed form is what
+disambiguates a generic name shared by two channels. Nothing checked that the
+generated RTL agreed with the contract at all, and it frequently does not:
+
+    contract framebuffer_read: rdata + req_addr, read_enable, rvalid, fault
+    framebuffer_sram  ->  framebuffer_read_read_enable      CONFORMS
+    control_status_aperture -> framebuffer_read_enable      DEVIATES
+
+The consequences are not cosmetic. The deterministic Caravel assembler resolves
+contract edges by name; a deviating port makes the edge unresolvable, the
+assembler refuses (correctly -- it will not guess at wiring), and the whole
+design falls back to an LLM-authored top. That is how a chip shipped with no
+graded pin boundary at all.
+
+Two observations decided the shape of this check.
+
+* **The deviation is not consistently on one side.** Measured across two runs:
+  3 producer-side and 1 consumer-side in the first, plus a block that dropped
+  channel prefixes entirely in the second. So a stitcher-side heuristic cannot
+  repair it -- both ends must conform.
+* **It is systematic, not sampling noise.** It survived a full fresh-context
+  re-spec: the regenerated aperture still emitted ``host_write_enable`` ten
+  times. ``contract_lookup`` already injects the contract with the instruction
+  "sideband signals ... MUST match in your output exactly. Do not invent new
+  fields", and the generator collapsed the duplicated token anyway. A prompt
+  rule with no gate is not enforcement.
+
+So this is deterministic and it runs per block, right after RTL generation --
+not at integration. An integration-time failure has already paid for seven other
+blocks; a block-time failure is one cheap regeneration with an exact expected
+name to fix.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: A block whose module declares the full Caravel pad boundary has externally
+#: MANDATED port names (io_in/io_out/io_oeb[37:0] are fixed by the shuttle), so
+#: the <channel>_<field> convention cannot apply to it.
+_LOCKED_BOUNDARY_PORTS = ("io_in", "io_out", "io_oeb")
+
+
+@dataclass
+class ConformanceResult:
+    """Per-block verdict. ``ok`` only when every declared signal is present."""
+
+    block: str = ""
+    checked_edges: int = 0
+    missing: list = field(default_factory=list)     # [(channel, expected_port)]
+    undeclared: list = field(default_factory=list)  # [port] -- <channel>_* not in the contract
+    ambiguous: list = field(default_factory=list)   # [(channel, explanation)]
+    exempt: bool = False
+    reason: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return not (self.missing or self.undeclared or self.ambiguous)
+
+    def as_feedback(self) -> str:
+        """An actionable message for the RTL generator.
+
+        States the EXACT required name. The failure mode this guards is a
+        generator collapsing a duplicated token (channel ``host_write`` +
+        signal ``write_enable`` -> ``host_write_enable``), so a vague "port
+        names must match the contract" would not change the outcome -- the
+        prompt already says that.
+        """
+        lines = []
+        if self.missing:
+            lines.append(
+                "The interface contract declares these ports and the RTL does "
+                "not expose them. Use these names EXACTLY -- do not shorten a "
+                "repeated word (channel 'host_write' + signal 'write_enable' is "
+                "'host_write_write_enable', NOT 'host_write_enable'), and do "
+                "not drop the channel prefix:")
+            for chan, port in self.missing:
+                lines.append(f"  - {port}    (channel '{chan}')")
+        if self.ambiguous:
+            lines.append(
+                "These channel signals cannot be resolved by name. Give each "
+                "declared signal exactly one port, and prefix it with the "
+                "channel when two channels share a signal name:")
+            for chan, why in self.ambiguous:
+                lines.append(f"  - channel '{chan}': {why}")
+        if self.undeclared:
+            lines.append(
+                "These ports use a channel prefix but are not in the contract. "
+                "Either they are misspellings of a declared signal, or they are "
+                "new signals that the contract does not permit:")
+            for p in self.undeclared:
+                lines.append(f"  - {p}")
+        return "\n".join(lines)
+
+
+def _load_contracts(project_root) -> list[dict]:
+    p = Path(project_root) / ".coresmith" / "interface_contracts.json"
+    try:
+        d = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    c = d.get("contracts") if isinstance(d, dict) else d
+    return c if isinstance(c, list) else []
+
+
+def _signal_names(edge: dict) -> list[str]:
+    """Every signal on a channel: the payload fields plus the sideband.
+
+    Split across two keys in the schema, which is precisely why several readers
+    concluded the contract did not record them at all.
+    """
+    out: list[str] = []
+    for f in edge.get("fields") or []:
+        n = f.get("name") if isinstance(f, dict) else f
+        if n:
+            out.append(str(n))
+    for s in edge.get("sideband_signals") or []:
+        n = s.get("name") if isinstance(s, dict) else s
+        if n:
+            out.append(str(n))
+    seen, uniq = set(), []
+    for n in out:
+        if n not in seen:
+            seen.add(n)
+            uniq.append(n)
+    return uniq
+
+
+_PORT_RE = re.compile(r"\b(?:input|output|inout)\b([^;)]*)", re.MULTILINE)
+
+
+def declared_ports(rtl_text: str) -> set[str]:
+    """Port names the module declares. Tolerant of both Verilog styles."""
+    text = re.sub(r"/\*.*?\*/", " ", rtl_text, flags=re.S)
+    text = re.sub(r"//[^\n]*", " ", text)
+    noise = {"wire", "reg", "logic", "signed", "unsigned", "input", "output",
+             "inout", "bit", "tri", "var", "integer", "real"}
+    ports: set[str] = set()
+    for m in _PORT_RE.finditer(text):
+        seg = re.sub(r"\[[^\]]*\]", " ", m.group(1))
+        for tok in re.findall(r"[A-Za-z_]\w*", seg):
+            if tok not in noise:
+                ports.add(tok)
+    return ports
+
+
+def check_block(project_root, block_name: str, rtl_path) -> ConformanceResult:
+    """Verify one block's ports against every contract edge that touches it."""
+    res = ConformanceResult(block=block_name)
+    try:
+        rtl = Path(rtl_path).read_text(errors="ignore")
+    except OSError as exc:
+        res.reason = f"cannot read {rtl_path}: {exc}"
+        return res
+
+    ports = declared_ports(rtl)
+    if all(p in ports for p in _LOCKED_BOUNDARY_PORTS):
+        res.exempt = True
+        res.reason = ("declares the Caravel pad boundary (io_in/io_out/io_oeb); "
+                      "its port names are externally mandated, so the "
+                      "<channel>_<field> convention does not apply")
+        return res
+
+    bare_owner: dict[str, str] = {}      # bare port -> channel that claimed it
+    accepted: set[str] = set()
+
+    for edge in _load_contracts(project_root):
+        for role, key in (("producer_block", "producer_port"),
+                          ("consumer_block", "consumer_port")):
+            if edge.get(role) != block_name:
+                continue
+            chan = str(edge.get(key) or "")
+            if not chan:
+                continue
+            res.checked_edges += 1
+            for n in _signal_names(edge):
+                prefixed, bare = f"{chan}_{n}", n
+                has_p, has_b = prefixed in ports, bare in ports
+                if has_p and has_b:
+                    # Two candidate ports for one declared signal: the stitcher
+                    # would have to pick, and picking is how channels get
+                    # cross-wired.
+                    res.ambiguous.append(
+                        (chan, f"{prefixed} and {bare} both exist"))
+                    accepted.update((prefixed, bare))
+                elif has_p:
+                    accepted.add(prefixed)
+                elif has_b:
+                    # A bare name is only unambiguous while ONE channel claims
+                    # it. Two channels sharing `req_addr` on one block cannot be
+                    # told apart by name.
+                    prev = bare_owner.get(bare)
+                    if prev is not None and prev != chan:
+                        res.ambiguous.append(
+                            (chan, f"{bare} is claimed by both '{prev}' and "
+                                   f"'{chan}'; prefix it"))
+                    bare_owner[bare] = chan
+                    accepted.add(bare)
+                else:
+                    res.missing.append((chan, prefixed))
+
+    # A port wearing a channel prefix that no declared signal accounts for is
+    # either a misspelling of one of the above or an invented signal; both break
+    # name-based edge resolution.
+    channels = set()
+    for edge in _load_contracts(project_root):
+        for role, key in (("producer_block", "producer_port"),
+                          ("consumer_block", "consumer_port")):
+            if edge.get(role) == block_name and edge.get(key):
+                channels.add(str(edge[key]))
+    for port in sorted(ports):
+        if port in accepted:
+            continue
+        for chan in channels:
+            if port.startswith(chan + "_"):
+                res.undeclared.append(port)
+                break
+    return res

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -63,6 +63,7 @@ class ConformanceResult:
     undeclared: list = field(default_factory=list)  # [port] -- <channel>_* not in the contract
     ambiguous: list = field(default_factory=list)   # [(channel, explanation)]
     exempt: bool = False
+    locked_boundary: bool = False   # carries externally-mandated pad names
     reason: str = ""
 
     @property
@@ -141,10 +142,25 @@ def _signal_names(edge: dict) -> list[str]:
 _PORT_RE = re.compile(r"\b(?:input|output|inout)\b([^;)]*)", re.MULTILINE)
 
 
-def declared_ports(rtl_text: str) -> set[str]:
-    """Port names the module declares. Tolerant of both Verilog styles."""
+def declared_ports(rtl_text: str, module: str | None = None) -> set[str]:
+    """Port names ONE module declares. Tolerant of both Verilog styles.
+
+    Scoped to a single module deliberately. A generated file routinely carries
+    stub declarations of other modules after the real one, and unioning their
+    ports produced a FALSE PASS for the pad block: it looked like it exposed
+    qspi_csn/qspi_sck because the stubs at the bottom of its own file declare
+    them, while the top module itself has only the Caravel boundary. Defaults to
+    the FIRST module, which is the one the file is named for.
+    """
     text = re.sub(r"/\*.*?\*/", " ", rtl_text, flags=re.S)
     text = re.sub(r"//[^\n]*", " ", text)
+    if module:
+        m = re.search(r"\bmodule\s+" + re.escape(module) + r"\b", text)
+    else:
+        m = re.search(r"\bmodule\s+[A-Za-z_]\w*", text)
+    if m:
+        end = text.find("endmodule", m.start())
+        text = text[m.start():end if end != -1 else len(text)]
     noise = {"wire", "reg", "logic", "signed", "unsigned", "input", "output",
              "inout", "bit", "tri", "var", "integer", "real"}
     ports: set[str] = set()
@@ -166,12 +182,18 @@ def check_block(project_root, block_name: str, rtl_path) -> ConformanceResult:
         return res
 
     ports = declared_ports(rtl)
-    if all(p in ports for p in _LOCKED_BOUNDARY_PORTS):
-        res.exempt = True
-        res.reason = ("declares the Caravel pad boundary (io_in/io_out/io_oeb); "
-                      "its port names are externally mandated, so the "
-                      "<channel>_<field> convention does not apply")
-        return res
+    # A block carrying the Caravel pad boundary is NOT exempt from the contract.
+    # Its io_in/io_out/io_oeb names are externally mandated, so those specific
+    # ports are never reported as undeclared -- but the channel signals the
+    # contract says this block exposes INWARD must still be there.
+    #
+    # A blanket exemption hid the largest defect in the design: the pad block was
+    # generated as a complete chip top that instantiates the other blocks
+    # internally, with the channel signals as internal wires and NO inward ports
+    # at all. The architecture specifies a pin ADAPTER with ports; the RTL
+    # produced a competing top. Nothing can wire that, which is why the
+    # deterministic assembler always fell back to an LLM-authored integration.
+    res.locked_boundary = all(p in ports for p in _LOCKED_BOUNDARY_PORTS)
 
     bare_owner: dict[str, str] = {}      # bare port -> channel that claimed it
     accepted: set[str] = set()
@@ -221,7 +243,7 @@ def check_block(project_root, block_name: str, rtl_path) -> ConformanceResult:
             if edge.get(role) == block_name and edge.get(key):
                 channels.add(str(edge[key]))
     for port in sorted(ports):
-        if port in accepted:
+        if port in accepted or port in _LOCKED_BOUNDARY_PORTS:
             continue
         for chan in channels:
             if port.startswith(chan + "_"):

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -63,6 +63,8 @@ class ConformanceResult:
     undeclared: list = field(default_factory=list)  # [port] -- <channel>_* not in the contract
     ambiguous: list = field(default_factory=list)   # [(channel, explanation)]
     instantiates: list = field(default_factory=list)  # sibling blocks wired in
+    accounted: set = field(default_factory=set)     # ports bound to a declared signal
+    ports: set = field(default_factory=set)         # every port the module declares
     exempt: bool = False
     locked_boundary: bool = False   # carries externally-mandated pad names
     reason: str = ""
@@ -265,6 +267,9 @@ def check_block(project_root, block_name: str, rtl_path,
                 else:
                     res.missing.append((chan, prefixed))
 
+    res.accounted = set(accepted)
+    res.ports = set(ports)
+
     # A port wearing a channel prefix that no declared signal accounts for is
     # either a misspelling of one of the above or an invented signal; both break
     # name-based edge resolution.
@@ -308,7 +313,11 @@ def plan_port_repairs(result: "ConformanceResult") -> dict:
     Ambiguity means no repair. Renaming the wrong wire cross-wires a channel,
     and a silent cross-wire is worse than a loud deviation.
     """
-    if not result.missing or not result.undeclared:
+    # Tier 3 needs no undeclared ports, so only `missing` gates the pass. The
+    # earlier guard also required undeclared to be non-empty, which meant a
+    # block whose prefix-collapsed ports had already been repaired could never
+    # reach tier 3.
+    if not result.missing:
         return {}
 
     pairs: dict = {}
@@ -320,6 +329,20 @@ def plan_port_repairs(result: "ConformanceResult") -> dict:
         cands = [h for h in result.undeclared if h.startswith(chan + "_")]
         if len(cands) == 1:
             pairs.setdefault(cands[0], []).append(want)
+            continue
+        if cands:
+            continue        # ambiguous within the channel -- leave it alone
+        # Tier 3: a port spelling this channel with a DIFFERENT prefix. Match on
+        # the trailing signal name, but only among ports not already bound to
+        # some declared signal -- without that exclusion, three ports on the
+        # real block end in `_req_addr` and the match is a coin flip.
+        sig = want[len(chan) + 1:] if want.startswith(chan + "_") else want
+        if not sig:
+            continue
+        free = [q for q in result.ports
+                if q not in result.accounted and q.endswith("_" + sig)]
+        if len(free) == 1:
+            pairs.setdefault(free[0], []).append(want)
 
     # A source port wanted by two declared names is ambiguous -- drop it.
     return {have: wants[0] for have, wants in pairs.items() if len(wants) == 1}

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -282,3 +282,72 @@ def check_block(project_root, block_name: str, rtl_path,
                 res.undeclared.append(port)
                 break
     return res
+
+
+def _rename_in_module(text: str, module: str, renames: dict) -> str:
+    """Apply identifier renames inside one module body only."""
+    m = re.search(r"\bmodule\s+" + re.escape(module) + r"\b", text)
+    if not m:
+        return text
+    end = text.find("endmodule", m.start())
+    end = end + len("endmodule") if end != -1 else len(text)
+    body = text[m.start():end]
+    for old, new in renames.items():
+        body = re.sub(r"\b" + re.escape(old) + r"\b", new, body)
+    return text[:m.start()] + body + text[end:]
+
+
+def plan_port_repairs(result: "ConformanceResult") -> dict:
+    """Map each undeclared port to the declared port it is a near-miss for.
+
+    Only unambiguous pairs are returned. A declared name and an existing port
+    match when they agree on the trailing signal name, which covers both
+    observed shapes -- a collapsed duplicate token and a wrong channel prefix --
+    without needing to know which one it is.
+
+    Ambiguity means no repair. Renaming the wrong wire cross-wires a channel,
+    and a silent cross-wire is worse than a loud deviation.
+    """
+    if not result.missing or not result.undeclared:
+        return {}
+
+    pairs: dict = {}
+    for chan, want in result.missing:
+        # Only ports already wearing this channel's prefix are candidates. The
+        # channel is what makes the match unambiguous: `host_read_enable` can
+        # only be repairing a `host_read` signal, even though it shares
+        # `read_enable` with framebuffer_read's.
+        cands = [h for h in result.undeclared if h.startswith(chan + "_")]
+        if len(cands) == 1:
+            pairs.setdefault(cands[0], []).append(want)
+
+    # A source port wanted by two declared names is ambiguous -- drop it.
+    return {have: wants[0] for have, wants in pairs.items() if len(wants) == 1}
+
+
+def repair_block_ports(project_root, block_name: str, rtl_path,
+                       siblings=(), apply: bool = False) -> dict:
+    """Compute (and optionally apply) port-name repairs for one block.
+
+    Returns ``{"renames": {...}, "before": n, "after": n, "conforms": bool}``.
+    The result is RE-CHECKED after applying, so a repair can never be reported
+    as success unless the checker agrees.
+    """
+    before = check_block(project_root, block_name, rtl_path, siblings=siblings)
+    renames = plan_port_repairs(before)
+    out = {"renames": renames, "before": len(before.missing),
+           "after": len(before.missing), "conforms": before.ok}
+    if not renames or not apply:
+        return out
+
+    text = Path(rtl_path).read_text(errors="ignore")
+    mod = block_name
+    if not re.search(r"\bmodule\s+" + re.escape(block_name) + r"\b", text):
+        mod = Path(rtl_path).stem
+    Path(str(rtl_path) + ".pre_portrepair").write_text(text)
+    Path(rtl_path).write_text(_rename_in_module(text, mod, renames))
+
+    after = check_block(project_root, block_name, rtl_path, siblings=siblings)
+    out["after"] = len(after.missing)
+    out["conforms"] = after.ok
+    return out

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -181,7 +181,13 @@ def check_block(project_root, block_name: str, rtl_path) -> ConformanceResult:
         res.reason = f"cannot read {rtl_path}: {exc}"
         return res
 
-    ports = declared_ports(rtl)
+    # Same trap: parse the BLOCK's module. Defaulting to the first
+    # module made this checker report 22 phantom missing ports for a
+    # block whose real module is declared last in its own file.
+    _mod = block_name
+    if not re.search(r"\bmodule\s+" + re.escape(block_name) + r"\b", rtl):
+        _mod = Path(rtl_path).stem
+    ports = declared_ports(rtl, module=_mod)
     # A block carrying the Caravel pad boundary is NOT exempt from the contract.
     # Its io_in/io_out/io_oeb names are externally mandated, so those specific
     # ports are never reported as undeclared -- but the channel signals the

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -62,13 +62,15 @@ class ConformanceResult:
     missing: list = field(default_factory=list)     # [(channel, expected_port)]
     undeclared: list = field(default_factory=list)  # [port] -- <channel>_* not in the contract
     ambiguous: list = field(default_factory=list)   # [(channel, explanation)]
+    instantiates: list = field(default_factory=list)  # sibling blocks wired in
     exempt: bool = False
     locked_boundary: bool = False   # carries externally-mandated pad names
     reason: str = ""
 
     @property
     def ok(self) -> bool:
-        return not (self.missing or self.undeclared or self.ambiguous)
+        return not (self.missing or self.undeclared or self.ambiguous
+                    or self.instantiates)
 
     def as_feedback(self) -> str:
         """An actionable message for the RTL generator.
@@ -80,6 +82,15 @@ class ConformanceResult:
         prompt already says that.
         """
         lines = []
+        if self.instantiates:
+            lines.append(
+                "This block INSTANTIATES other blocks: "
+                + ", ".join(self.instantiates)
+                + ". It is a leaf, not the chip top. Delete those "
+                "instantiations and expose the channel signals below as PORTS "
+                "instead -- the integration stage wires the blocks together, "
+                "and a block that assembles the design itself cannot be wired "
+                "into anything.")
         if self.missing:
             lines.append(
                 "The interface contract declares these ports and the RTL does "
@@ -172,7 +183,8 @@ def declared_ports(rtl_text: str, module: str | None = None) -> set[str]:
     return ports
 
 
-def check_block(project_root, block_name: str, rtl_path) -> ConformanceResult:
+def check_block(project_root, block_name: str, rtl_path,
+                siblings=()) -> ConformanceResult:
     """Verify one block's ports against every contract edge that touches it."""
     res = ConformanceResult(block=block_name)
     try:
@@ -188,6 +200,20 @@ def check_block(project_root, block_name: str, rtl_path) -> ConformanceResult:
     if not re.search(r"\bmodule\s+" + re.escape(block_name) + r"\b", rtl):
         _mod = Path(rtl_path).stem
     ports = declared_ports(rtl, module=_mod)
+
+    # Structural: a leaf must not assemble the design. Scoped to this block's
+    # own module -- a file may legitimately carry an alias wrapper after it.
+    body = rtl
+    _bm = re.search(r"\bmodule\s+" + re.escape(_mod) + r"\b", rtl)
+    if _bm:
+        _be = rtl.find("endmodule", _bm.start())
+        body = rtl[_bm.start():_be if _be != -1 else len(rtl)]
+    body = re.sub(r"//[^\n]*", " ", re.sub(r"/\*.*?\*/", " ", body, flags=re.S))
+    for sib in siblings or ():
+        if sib == block_name:
+            continue
+        if re.search(r"\b" + re.escape(str(sib)) + r"\s+[A-Za-z_\\]", body):
+            res.instantiates.append(str(sib))
     # A block carrying the Caravel pad boundary is NOT exempt from the contract.
     # Its io_in/io_out/io_oeb names are externally mandated, so those specific
     # ports are never reported as undeclared -- but the channel signals the

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -2082,9 +2082,31 @@ def chip_rtl_sources(
     first entry.
     """
     sources = [top_rtl_path]
+    # A block file that RE-DECLARES the top's own module is an alias-carrier:
+    # the generated pad block ships a thin `module user_project_wrapper` alias
+    # plus stub declarations of its sibling blocks. Include it and the MODDUP
+    # dedup keeps the stubs (they sort first) and strips the real logic -- the
+    # reference then elaborates a hollow chip and honestly fails, so the gate
+    # reports not_run on a design that is fine. The top provides its own
+    # module; a file re-declaring it leaves the list, stubs and all.
+    _top_mod = ""
+    try:
+        _top_text = Path(top_rtl_path).read_text(errors="replace")
+        _m = re.search(r"\bmodule\s+([A-Za-z_]\w*)", _top_text)
+        _top_mod = _m.group(1) if _m else ""
+    except OSError:
+        pass
     for bp in block_rtl_paths.values():
-        if Path(bp).exists() and bp != top_rtl_path:
-            sources.append(bp)
+        if not Path(bp).exists() or bp == top_rtl_path:
+            continue
+        if _top_mod:
+            try:
+                if re.search(r"\bmodule\s+" + re.escape(_top_mod) + r"\b",
+                             Path(bp).read_text(errors="replace")):
+                    continue
+            except OSError:
+                pass
+        sources.append(bp)
     # Include the generic SRAM wrapper lib if any block instantiates cs_sram, so
     # the chip-level Verilator build can resolve cs_sram_1rw/1rw1r (without it
     # the sim hard-fails with "Cannot find module cs_sram_1rw1r"). Best-effort.

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -1331,23 +1331,47 @@ def generate_caravel_wrapper_top(
     if wrapper_block is not None:
         wrap_mod_name = modules[wrapper_block].name
         wrap_inst_module = wrap_mod_name
+        src_path = rtl_paths.get(wrapper_block, "")
+        try:
+            src = Path(src_path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            src = ""
+        # `\b` after the name means this does NOT match `user_project_wrapper_io`
+        # (an underscore is a word character), so the block's own module is safe.
+        _top_decl = re.search(
+            rf"\bmodule\s+{re.escape(CARAVEL_TOP_MODULE)}\b", src) if src else None
+        renamed = ""
         if wrap_mod_name == CARAVEL_TOP_MODULE:
+            # The pad block IS named like the graded top. Rename it so the top
+            # this function emits can take that name.
             wrap_inst_module = f"{CARAVEL_TOP_MODULE}_pads"
-            src_path = rtl_paths.get(wrapper_block, "")
-            try:
-                src = Path(src_path).read_text(encoding="utf-8", errors="replace")
-            except OSError:
-                src = ""
-            if src:
-                renamed = re.sub(
-                    rf"\bmodule\s+{re.escape(CARAVEL_TOP_MODULE)}\b",
-                    f"module {wrap_inst_module}",
-                    src,
-                    count=1,
-                )
-                renamed_pad_path = str(out_dir / f"{wrap_inst_module}.v")
-                Path(renamed_pad_path).write_text(renamed, encoding="utf-8")
-                lint_block_paths[wrapper_block] = renamed_pad_path
+            renamed = re.sub(
+                rf"\bmodule\s+{re.escape(CARAVEL_TOP_MODULE)}\b",
+                f"module {wrap_inst_module}",
+                src,
+                count=1,
+            )
+        elif _top_decl:
+            # The block's own module is named something else, but its FILE also
+            # declares the graded module -- a thin alias wrapper emitted next to
+            # the block. Left alone it collides with the top emitted below: two
+            # definitions of CARAVEL_TOP_MODULE, which is a MODDUP abort at
+            # elaboration and, worse, makes resolve_netlist_top see TWO
+            # un-instantiated roots so the chip gate-sim cannot resolve a top at
+            # all. The alias is redundant -- this function emits that module --
+            # so drop it from a COPY. The block's own source is never modified.
+            _end = src.find("endmodule", _top_decl.start())
+            if _end != -1:
+                renamed = (src[:_top_decl.start()]
+                           + f"// [coresmith] removed a redundant "
+                             f"`module {CARAVEL_TOP_MODULE}` alias: the "
+                             f"integration stage emits that module itself, and "
+                             f"two definitions collide.\n"
+                           + src[_end + len("endmodule"):])
+        if renamed:
+            renamed_pad_path = str(out_dir / f"{wrap_inst_module}.v")
+            Path(renamed_pad_path).write_text(renamed, encoding="utf-8")
+            lint_block_paths[wrapper_block] = renamed_pad_path
 
     # ---- emit ----
     lines: list[str] = []

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -1096,6 +1096,12 @@ def generate_caravel_wrapper_top(
             and wrapper_block is not None):
         dropped_adapter = wrapper_block
         modules = {k: v for k, v in modules.items() if k != wrapper_block}
+        # Its FILE has to go too, not just its instantiation. That file declares
+        # stub versions of the sibling blocks, and it sorts first, so leaving it
+        # in the source list makes _dedup_module_sources treat those stubs as
+        # the first definitions and strip the real implementations out of every
+        # other file -- emptying the design while still looking assembled.
+        rtl_paths = {k: v for k, v in rtl_paths.items() if k != wrapper_block}
         edges = [e for e in edges
                  if wrapper_block not in (e.get("producer_block"),
                                           e.get("consumer_block"))]

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -746,6 +746,7 @@ def generate_top_level_rtl(
         lines.append("  );")
         lines.append("")
 
+
     lines.append("endmodule")
     lines.append("")
 
@@ -1058,6 +1059,7 @@ def generate_caravel_wrapper_top(
     rtl_paths: dict[str, str],
     output_dir: str,
     wrapper_block: str | None = None,
+    pin_map=None,
 ) -> dict:
     """Assemble a wired ``user_project_wrapper`` chip_top deterministically.
 
@@ -1079,6 +1081,25 @@ def generate_caravel_wrapper_top(
 
     if wrapper_block is None:
         wrapper_block = detect_wrapper_block(modules)
+
+    # A declared pin map REPLACES the pin-adapter block. The adapter existed
+    # only to translate pad bits into named signals, and the top now does that
+    # itself from data. Keeping it would instantiate a module that duplicates
+    # the routing -- and, in the case that motivated this, the entire rest of
+    # the chip, because its mandated module name means "the whole design" and
+    # the generator built one.
+    #
+    # The contract edges that reference it describe that same translation, so
+    # they are dropped with it: they are no longer block-to-block channels.
+    dropped_adapter = ""
+    if (pin_map is not None and getattr(pin_map, "ok", False)
+            and wrapper_block is not None):
+        dropped_adapter = wrapper_block
+        modules = {k: v for k, v in modules.items() if k != wrapper_block}
+        edges = [e for e in edges
+                 if wrapper_block not in (e.get("producer_block"),
+                                          e.get("consumer_block"))]
+        wrapper_block = None
 
     clk_name = "wb_clk_i"
     rst_name = "wb_rst_i"          # Caravel wb_rst_i is active-high
@@ -1373,6 +1394,32 @@ def generate_caravel_wrapper_top(
             Path(renamed_pad_path).write_text(renamed, encoding="utf-8")
             lint_block_paths[wrapper_block] = renamed_pad_path
 
+    # ---- pin routing (from the PRD's structured pin_map) ----
+    # With the assignment available as data the top slices io_in itself and
+    # drives io_out/io_oeb itself, so the design needs no pin-adapter block --
+    # the block an LLM could not generate because its mandated module name
+    # means "the entire chip".
+    pin_decls: list[str] = []
+    pin_assigns: list[str] = []
+    pin_sigs: dict = {}
+    pin_block_driven: dict = {}
+    if pin_map is not None and getattr(pin_map, "ok", False):
+        from orchestrator.architecture.pin_map import (
+            emit_pin_routing,
+            mapped_signals,
+        )
+        pin_decls, pin_assigns = emit_pin_routing(pin_map)
+        pin_sigs = mapped_signals(pin_map)
+        # Output-side signals (and any output-enable) are DRIVEN BY BLOCKS, so
+        # the top declares a wire for each and the producing block connects to
+        # it. Input-side signals are already assigned from io_in by pin_decls.
+        for e in pin_map.entries:
+            if e.dir == "out":
+                pin_block_driven[e.signal] = e.width
+            if e.oe:
+                pin_block_driven[e.oe] = 1
+        pin_sigs.update(pin_block_driven)
+
     # ---- emit ----
     lines: list[str] = []
     lines.append("// Auto-generated Caravel user_project_wrapper chip_top")
@@ -1397,6 +1444,15 @@ def generate_caravel_wrapper_top(
     for name, val in _CARAVEL_TIEOFFS:
         lines.append(f"  assign {name} = {val};")
     lines.append("")
+
+    if pin_decls or pin_block_driven:
+        lines.append("  // ---- pin map (declared in the PRD) ----")
+        for sig, w in sorted(pin_block_driven.items()):
+            rng = "" if w == 1 else f"[{w - 1}:0] "
+            lines.append(f"  wire {rng}{sig};")
+        for d in pin_decls:
+            lines.append(f"  {d}")
+        lines.append("")
 
     if wire_decls:
         lines.append(f"  // ---- internal block<->block wires ({len(wire_decls)}) ----")
@@ -1429,6 +1485,12 @@ def generate_caravel_wrapper_top(
             if bn == wrapper_block and p.name in _PAD_IO_PORTS:
                 conns.append(f"    .{p.name}({p.name})")  # straight to top GPIO
                 continue
+            if p.name in pin_sigs:
+                # A block port named after a pin-map signal binds to it. The
+                # contract already uses these names, so this needs no new
+                # convention.
+                conns.append(f"    .{p.name}({p.name})")
+                continue
             w = port_wire.get((bn, p.name))
             if w:
                 conns.append(f"    .{p.name}({w})")
@@ -1452,6 +1514,11 @@ def generate_caravel_wrapper_top(
         lines.append("")
         instantiated.append(bn)
 
+    if pin_assigns:
+        lines.append("")
+        lines.append("  // ---- pin map: drive the pads ----")
+        for a in pin_assigns:
+            lines.append(f"  {a}")
     lines.append("endmodule")
     lines.append("")
     verilog = "\n".join(lines)
@@ -1468,6 +1535,7 @@ def generate_caravel_wrapper_top(
         "instantiated": instantiated,
         "wrapper_block": wrapper_block,
         "renamed_pad_path": renamed_pad_path,
+        "dropped_adapter": dropped_adapter,
         "lint_block_paths": lint_block_paths,
         # Non-empty => the deterministic wiring is UNSAFE (an ambiguous key that
         # would be [0]-picked, or a width mismatch that would be shorted). The

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -2351,6 +2351,34 @@ def discover_block_rtl(
     return rtl_paths
 
 
+def merge_block_specs(blocks: list[dict], block_queue: list) -> list[dict]:
+    """Join per-block RESULT dicts to their SPEC entries by name.
+
+    A block RESULT records what happened ({name, success, attempts, ...}); the
+    block SPEC records what the block IS, including ``rtl_target``. Only the
+    result reaches discovery, so a block whose Verilog file is not named after
+    it -- the contract-locked case ``rtl_target`` exists for -- resolved to
+    nothing and was dropped.
+
+    Result keys win on conflict: nothing a block actually reported is
+    overwritten by its spec.
+    """
+    by_name: dict[str, dict] = {}
+    for spec in block_queue or []:
+        if isinstance(spec, dict):
+            n = spec.get("name") or spec.get("block_name")
+            if n:
+                by_name[str(n)] = spec
+    out: list[dict] = []
+    for b in blocks or []:
+        if not isinstance(b, dict):
+            continue
+        n = b.get("name") or b.get("block_name")
+        spec = by_name.get(str(n)) if n else None
+        out.append({**spec, **b} if spec else dict(b))
+    return out
+
+
 def missing_from(
     rtl_paths: dict[str, str],
     completed_blocks: list[dict],

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -838,6 +838,85 @@ def detect_wrapper_block(modules: dict[str, VerilogModule]) -> str | None:
     return None
 
 
+def _contract_signal_names(edge: dict) -> list[str]:
+    """Every signal a contract edge declares: payload fields + sideband.
+
+    The schema splits them across two keys, which is why several readers
+    concluded the contract did not record signal names at all. Their union is
+    the channel's port set.
+    """
+    out: list[str] = []
+    for f in (edge.get("fields") or []):
+        n = f.get("name") if isinstance(f, dict) else f
+        if n:
+            out.append(str(n))
+    for s in (edge.get("sideband_signals") or []):
+        n = s.get("name") if isinstance(s, dict) else s
+        if n:
+            out.append(str(n))
+    seen, uniq = set(), []
+    for n in out:
+        if n not in seen:
+            seen.add(n)
+            uniq.append(n)
+    return uniq
+
+
+def _resolve_by_contract(edge, pb, cb, port_exact, modules):
+    """Wire an edge signal-by-signal from the contract's own declaration.
+
+    Returns ``(paired, hazards)``, or ``None`` when the edge declares no
+    signals (the caller then falls back to the legacy name/positional path, so
+    contracts that predate signal lists are unaffected).
+
+    Each side is resolved INDEPENDENTLY against the declared name, accepting
+    either ``<channel>_<signal>`` or bare ``<signal>``. Because both ends are
+    matched to the same contract signal, they are never matched to each other:
+    the two sides may legitimately spell their ports differently and still bind
+    correctly, which the positional path could not express.
+    """
+    signals = _contract_signal_names(edge)
+    if not signals:
+        return None
+    if pb not in modules or cb not in modules:
+        return None
+
+    def _one(block: str, chan: str, sig: str):
+        pref = port_exact(block, f"{chan}_{sig}")
+        bare = port_exact(block, sig)
+        if pref is not None and bare is not None:
+            return None, (f"{block}.{chan}_{sig} and {block}.{sig} both exist "
+                          f"-- ambiguous which implements '{sig}'")
+        got = pref or bare
+        if got is None:
+            return None, (f"{block} implements no port for declared signal "
+                          f"'{sig}' (expected '{chan}_{sig}' or '{sig}')")
+        return got, None
+
+    pchan = str(edge.get("producer_port") or "")
+    cchan = str(edge.get("consumer_port") or "")
+    eid = edge.get("edge_id")
+    paired, hazards = [], []
+    for sig in signals:
+        pp, perr = _one(pb, pchan, sig)
+        cp, cerr = _one(cb, cchan, sig)
+        for err in (perr, cerr):
+            if err:
+                hazards.append(f"edge {eid}: {err}")
+        if pp is None or cp is None:
+            continue
+        if _wrap_shared_signal(pp.name) or _wrap_shared_signal(cp.name):
+            continue
+        if pp.width != cp.width:
+            hazards.append(
+                f"edge {eid}: signal '{sig}' is {pp.width}b on {pb}.{pp.name} "
+                f"but {cp.width}b on {cb}.{cp.name} -- refusing to short "
+                f"mismatched-width ports")
+            continue
+        paired.append((pp, cp))
+    return paired, hazards
+
+
 def load_interface_contract_edges(project_root: str) -> list[dict]:
     """Load endpoint-resolved block<->block edges from
     ``.coresmith/interface_contracts.json`` (producer/consumer block + port).
@@ -876,6 +955,15 @@ def load_interface_contract_edges(project_root: str) -> list[dict]:
             "consumer_port": c.get("consumer_port") or c.get("to_port") or "",
             "data_width": c.get("data_width_bits") or c.get("data_width") or 0,
             "edge_id": c.get("edge_id") or f"{pb}__to__{cb}",
+            # Carry the channel SIGNAL LIST through. The contract declares every
+            # signal on the edge (fields = payload, sideband_signals =
+            # everything else, union = the port set); dropping them here forced
+            # the assembler to re-derive the port set from a naming convention
+            # and to pair the two ends positionally against each other. With the
+            # list present each end resolves against the CONTRACT instead, so
+            # the two ends never have to agree on spelling.
+            "fields": c.get("fields") or [],
+            "sideband_signals": c.get("sideband_signals") or [],
         })
     return edges
 
@@ -1092,6 +1180,21 @@ def generate_caravel_wrapper_top(
         pb, cb = e.get("producer_block"), e.get("consumer_block")
         if pb not in modules or cb not in modules or pb == cb:
             continue
+        # Contract-directed resolution: match each END against the contract's
+        # declared signal list, never against the other end. See
+        # _resolve_by_contract for why this removes positional pairing.
+        _by_contract = _resolve_by_contract(e, pb, cb, _port_exact, modules)
+        if _by_contract is not None:
+            _paired, _hazards = _by_contract
+            if _hazards:
+                wiring_errors.extend(_hazards)
+                continue
+            for pp, cp in _paired:
+                uf.union((pb, pp.name), (cb, cp.name))
+            if _paired:
+                edge_bound.add(frozenset((pb, cb)))
+            continue
+
         pfields = _resolve_fields(pb, e.get("producer_port", ""))
         cfields = _resolve_fields(cb, e.get("consumer_port", ""))
         # A NAMED port that fails to resolve is a hazard (fall back to the

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -79,11 +79,19 @@ class VerilogModule:
         }
 
 
-def parse_verilog_ports(rtl_path: str) -> VerilogModule:
+def parse_verilog_ports(rtl_path: str, module: str | None = None) -> VerilogModule:
     """Parse a Verilog file and extract the module name, ports, and parameters.
 
     Handles both ANSI-style (ports in header) and non-ANSI (separate
-    declarations) Verilog modules. Extracts the *first* module found.
+    declarations) Verilog modules.
+
+    ``module`` selects WHICH module to parse; without it the first one wins,
+    which is frequently the wrong answer. A generated block file commonly
+    declares its internal stages first -- raster_scan_pipeline.v declares four
+    sub-stages before the block itself at line 668 -- so integration judged a
+    sub-stage's ports as the block's interface and raised 22 wiring hazards for
+    a block that conforms perfectly. Callers that know the block name should
+    pass it.
 
     Returns:
         VerilogModule with parsed port list.
@@ -97,6 +105,16 @@ def parse_verilog_ports(rtl_path: str) -> VerilogModule:
     # Strip comments (line and block)
     source = re.sub(r'//.*?$', '', source, flags=re.MULTILINE)
     source = re.sub(r'/\*.*?\*/', '', source, flags=re.DOTALL)
+
+    # Narrow to the requested module, else the file stem -- the same precedence
+    # rtl_module_name uses. Sliced to its endmodule so a later module's
+    # non-ANSI port declarations cannot leak in.
+    for _want in [w for w in (module, path.stem) if w]:
+        _m = re.search(r'\bmodule\s+' + re.escape(str(_want)) + r'\b', source)
+        if _m:
+            _end = source.find('endmodule', _m.start())
+            source = source[_m.start():_end if _end != -1 else len(source)]
+            break
 
     # Find module declaration
     mod_match = re.search(
@@ -2349,6 +2367,20 @@ def discover_block_rtl(
                 f"with no GPIO boundary.", RED)
 
     return rtl_paths
+
+
+def module_for_block(rtl_path, block_name: str) -> str:
+    """Module name to parse for ``block_name``. Mirrors rtl_module_name."""
+    from pathlib import Path as _P
+    try:
+        text = _P(rtl_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return block_name
+    import re as _re
+    for cand in (block_name, _P(rtl_path).stem):
+        if cand and _re.search(r"\bmodule\s+" + _re.escape(cand) + r"\b", text):
+            return cand
+    return block_name
 
 
 def merge_block_specs(blocks: list[dict], block_queue: list) -> list[dict]:

--- a/orchestrator/langgraph/macro_prebind.py
+++ b/orchestrator/langgraph/macro_prebind.py
@@ -114,6 +114,10 @@ class PrebindResult:
     """Outcome of pre-synthesis macro resolution."""
 
     bindings: list = field(default_factory=list)      # [(ShellSpec, MacroInfo)]
+    # geometry key (w, d, nport) -> write-mask lanes the RTL drives. 0/1 mean a
+    # whole-word mask. Needed by emit_bound_shell to size the shell's wmask0 and
+    # to decide whether the macro's own mask port can carry it.
+    mask_lanes: dict = field(default_factory=dict)
     unresolved: list = field(default_factory=list)    # [ShellSpec]
     errors: list = field(default_factory=list)        # [str]
     warnings: list = field(default_factory=list)      # [str] -- do not block
@@ -217,7 +221,39 @@ def macro_ports(verilog_path) -> set[str]:
     return ports
 
 
-def _ports_for(macro, spec) -> list[tuple[str, str]]:
+def macro_mask_lanes(verilog_path) -> int | None:
+    """Write-mask lanes the macro's Verilog actually declares, or None.
+
+    OpenRAM emits ``parameter NUM_WMASKS = N;`` next to
+    ``input [NUM_WMASKS-1:0] wmask0;``. A literal range is accepted too. Returns
+    None when the macro declares no ``wmask0`` OR when the width cannot be
+    resolved -- callers must treat None as "cannot verify" and refuse, never as
+    a default, because this number decides which bytes a write touches.
+
+    Deliberately does NOT consult ``MacroInfo.mask_bits``: that field reports
+    the write granularity for some macros and the lane count for others, and it
+    read 8 for a macro whose mask is 2 bits wide.
+    """
+    import re
+    try:
+        text = _strip_comments(Path(verilog_path).read_text(errors="ignore"))
+    except OSError:
+        return None
+    if not re.search(r"\bwmask0\b", text):
+        return None
+    m = re.search(r"\bparameter\b[^;]*?\bNUM_WMASKS\b\s*=\s*(\d+)", text)
+    if m:
+        return int(m.group(1))
+    # Literal range, e.g. `input [3:0] wmask0;`
+    m = re.search(r"\b(?:input|output|inout)\b[^;()]*\[\s*(\d+)\s*:\s*(\d+)\s*\][^;()]*\bwmask0\b",
+                  text)
+    if m:
+        return abs(int(m.group(1)) - int(m.group(2))) + 1
+    # Declared, but the width is an expression we will not evaluate.
+    return None
+
+
+def _ports_for(macro, spec, nmask: int = 1) -> list[tuple[str, str]]:
     """Port connections from the OpenRAM macro to the shell's signals.
 
     OpenRAM sky130 SRAMs use ACTIVE-LOW chip-select and write-enable
@@ -236,8 +272,20 @@ def _ports_for(macro, spec) -> list[tuple[str, str]]:
         ("dout0", "rdata0"),
     ]
     if "wmask0" in have:
-        nb = int(getattr(macro, "mask_bits", 0) or 0)
-        conns.insert(3, ("wmask0", "{%d{1'b1}}" % nb if nb else "'1"))
+        # Connect the SHELL's mask, not a constant. Tying this high was the
+        # defect: it silently turned every partial write into a full-word write.
+        conns.insert(3, ("wmask0", "wmask0"))
+    else:
+        # The macro has no mask port at all -- OpenRAM omits it when
+        # word_size == write_size, i.e. the mask is a single whole-word bit.
+        # That bit is exactly a write-enable qualifier, so fold it into web0
+        # here. Doing it structurally means no design has to remember to write
+        # `we0 = write_fire & wmask` by hand (framebuffer_sram had to be
+        # patched by hand to do precisely this).
+        for i, (port, _sig) in enumerate(conns):
+            if port == "web0":
+                conns[i] = ("web0", "~(we0 & (&wmask0))")
+                break
     if int(getattr(spec, "nport", 1) or 1) >= 2:
         conns += [
             ("clk1", "clk"),
@@ -271,11 +319,13 @@ def emit_bound_shell(result: PrebindResult) -> str:
         "    parameter integer WIDTH = 32,",
         "    parameter integer DEPTH = 512,",
         "    parameter integer NPORT = 1,",
+        "    parameter integer NMASK = 1,",
         "    parameter integer AW    = (DEPTH <= 1) ? 1 : $clog2(DEPTH)",
         ") (",
         "    input  wire             clk,",
         "    input  wire             ce0,",
         "    input  wire             we0,",
+        "    input  wire [NMASK-1:0] wmask0,",
         "    input  wire [AW-1:0]    addr0,",
         "    input  wire [WIDTH-1:0] wdata0,",
         "    output wire [WIDTH-1:0] rdata0,",
@@ -295,7 +345,9 @@ def emit_bound_shell(result: PrebindResult) -> str:
             f"g_w{w}_d{d}_p{n}"
         )
         lines.append(f"      {macro.name} u_macro (")
-        conns = _ports_for(macro, spec)
+        key = (w, d, n)
+        nmask = max(1, int(result.mask_lanes.get(key, 1) or 1))
+        conns = _ports_for(macro, spec, nmask)
         for i, (port, sig) in enumerate(conns):
             comma = "," if i < len(conns) - 1 else ""
             lines.append(f"        .{port}({sig}){comma}")
@@ -393,6 +445,28 @@ def resolve_prebindings(sources, *, allow_generate: bool = True,
         if key in req_mask:
             nb = req_mask[key]
             macro_has_mask = "wmask0" in macro_ports(macro.verilog)
+            result_lanes = nb
+            if macro_has_mask and nb > 1:
+                # The shell routes the mask to the macro's own port, so this
+                # binds -- PROVIDED both sides agree on lane count. OpenRAM
+                # lanes = ceil(width / write_size); a disagreement would write
+                # the wrong bytes, which is the corruption we are removing.
+                macro_lanes = macro_mask_lanes(macro.verilog)
+                if macro_lanes != nb:
+                    res.unresolved.append(spec)
+                    res.errors.append(
+                        f"{spec.describe()}: RTL drives {nb} write-mask lane(s) "
+                        f"but macro {macro.name} declares "
+                        f"{macro_lanes if macro_lanes is not None else 'an unresolvable number of'}"
+                        f" lane(s). Connecting mismatched lanes would write the "
+                        f"wrong bytes, so this is refused rather than truncated "
+                        f"(the previous binder replicated a constant and let "
+                        f"yosys truncate it). Regenerate the macro with a "
+                        f"write_size that yields {nb} lanes.")
+                    continue
+                res.mask_lanes[key] = nb
+                res.bindings.append((spec, macro))
+                continue
             if nb > 1:
                 # A real per-byte mask survives ONLY if it can travel all the way
                 # from the RTL to the macro. Two independent things can break
@@ -425,21 +499,17 @@ def resolve_prebindings(sources, *, allow_generate: bool = True,
                     f"{detail}. Refusing to bind: a dropped mask turns masked "
                     f"writes into full-word writes, which RTL DV cannot see.")
                 continue
-            # nb == 1: the mask spans the whole word, so `we0 & mask` is exactly
-            # equivalent to masking inside the macro -- which is why OpenRAM
-            # omits the port when word_size == write_size. Binding is legal
-            # PROVIDED the RTL folds the mask into we0; if it drives we0 from an
-            # unmasked signal the write is no longer suppressed. Still only a
-            # warning because that fold is the correct, common fix and the
-            # geometry is otherwise sound -- but nothing here can prove the RTL
-            # did it.
+            # nb == 1: a whole-word mask, exactly equivalent to a write-enable
+            # qualifier. The shell now folds it into web0 itself, so this is
+            # correct by construction and no longer depends on the RTL author
+            # remembering to write `we0 = write_fire & wmask`.
+            res.mask_lanes[key] = 1
             res.warnings.append(
-                f"{spec.describe()}: the requested mask is a single whole-word "
-                f"bit, so it is equivalent to the write enable"
-                f"{'' if macro_has_mask else f' (macro {macro.name} omits wmask0 entirely)'}"
-                f". The shell carries no mask pins, so the mask reaches the "
-                f"memory ONLY if the RTL folds it into we0 "
-                f"(e.g. we0 = write_fire & wmask). UNVERIFIED here.")
+                f"{spec.describe()}: whole-word write mask folded into the "
+                f"macro's write enable by the bound shell"
+                f"{'' if macro_has_mask else f' (macro {macro.name} exposes no wmask0)'}"
+                f" -- masked writes are suppressed correctly without any RTL "
+                f"change.")
         res.bindings.append((spec, macro))
     return res
 

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -6557,14 +6557,30 @@ async def integration_check_node(state: OrchestratorState) -> dict:
             load_interface_contract_edges,
         )
         _wrapper_block = detect_wrapper_block(modules)
-        if _wrapper_block is not None and _deterministic_caravel_top_enabled():
-            log(f"  [INTEGRATION] Caravel wrapper block '{_wrapper_block}' "
-                f"detected -- assembling wired user_project_wrapper "
-                f"deterministically", CYAN)
+        # The PRD's structured pin map, when present, lets the top route the pads
+        # itself -- so the design needs no pin-adapter block and assembly no
+        # longer depends on finding one.
+        from orchestrator.architecture.pin_map import load_pin_map
+        _pin_map = load_pin_map(pr)
+        if _pin_map is not None and not _pin_map.ok:
+            for _e in _pin_map.errors:
+                log(f"  [INTEGRATION] pin_map: {_e}", RED)
+            _pin_map = None
+        if ((_wrapper_block is not None or _pin_map is not None)
+                and _deterministic_caravel_top_enabled()):
+            if _pin_map is not None:
+                log(f"  [INTEGRATION] pin map declared ({len(_pin_map.entries)} "
+                    f"signals) -- the top routes the pads itself; assembling "
+                    f"wired user_project_wrapper deterministically", CYAN)
+            else:
+                log(f"  [INTEGRATION] Caravel wrapper block '{_wrapper_block}' "
+                    f"detected -- assembling wired user_project_wrapper "
+                    f"deterministically", CYAN)
             edges = await asyncio.to_thread(load_interface_contract_edges, pr)
             asm = await asyncio.to_thread(
                 generate_caravel_wrapper_top,
                 modules, edges, rtl_paths, str(rtl_dir), _wrapper_block,
+                _pin_map,
             )
             # FAIL-LOUD (Section 2): if the deterministic assembler found a
             # wiring hazard it cannot safely resolve -- an ambiguous normalized

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -6623,7 +6623,13 @@ async def integration_check_node(state: OrchestratorState) -> dict:
                 )
                 lint_clean = lint_result.get("clean", False)
                 # Postcondition: every block is instantiated in the assembled top.
-                missing = [b for b in modules if f"u_{b} (" not in asm["verilog"]]
+                # A block the assembler deliberately DROPPED is not missing.
+                # With a pin map the pad adapter is replaced by routing emitted
+                # in the top, so requiring its instantiation would fail the
+                # postcondition on the very design that fixed the problem.
+                _dropped = asm.get("dropped_adapter") or ""
+                missing = [b for b in modules
+                           if b != _dropped and f"u_{b} (" not in asm["verilog"]]
                 log(f"  [INTEGRATION] Caravel top: {len(asm['instantiated'])} blocks "
                     f"instantiated, {asm['wire_count']} internal wires, lint "
                     f"{'CLEAN' if lint_clean else 'ERRORS'}",

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -67,6 +67,7 @@ from opentelemetry import trace
 from orchestrator.langgraph.event_stream import write_graph_event
 from orchestrator.langgraph.integration_helpers import (
     discover_block_rtl,
+    module_for_block,
     generate_integration_testbench,
     generate_validation_testbench,
     lint_top_level,
@@ -6414,7 +6415,12 @@ async def integration_check_node(state: OrchestratorState) -> dict:
         modules = {}
         block_rtl_sources: dict[str, str] = {}
         for block_name, rtl_path in rtl_paths.items():
-            mod = await asyncio.to_thread(parse_verilog_ports, rtl_path)
+            # Parse the BLOCK's module, not whichever comes first in
+            # the file: generated files declare internal stages ahead
+            # of the block itself.
+            mod = await asyncio.to_thread(
+                parse_verilog_ports, rtl_path,
+                module_for_block(rtl_path, block_name))
             if mod.name:
                 modules[block_name] = mod
                 try:
@@ -6572,10 +6578,24 @@ async def integration_check_node(state: OrchestratorState) -> dict:
                     f"Integration Lead:", RED)
                 for _we in _wiring_errors[:8]:
                     log(f"      - {_we}", RED)
+                # Persist the FULL list. Logging [:8] and storing [:16] left
+                # 24 of 40 hazards existing nowhere on disk -- and this list is
+                # the only artifact explaining why assembly refused, so an outer
+                # agent could not obtain it by any documented path.
+                _haz_path = Path(pr) / ".coresmith" / "caravel_wiring_errors.json"
+                try:
+                    _haz_path.write_text(json.dumps({
+                        "wrapper_block": _wrapper_block,
+                        "count": len(_wiring_errors),
+                        "wiring_errors": _wiring_errors,
+                    }, indent=2), encoding="utf-8")
+                except OSError:
+                    pass
                 write_graph_event(pr, "Integration Check", "caravel_wiring_fallback", {
                     "wrapper_block": _wrapper_block,
                     "wiring_error_count": len(_wiring_errors),
                     "wiring_errors": _wiring_errors[:16],
+                    "wiring_errors_path": str(_haz_path),
                 })
             if not _wiring_errors:
                 top_rtl_path = asm["rtl_path"]
@@ -8884,7 +8904,12 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
         # Re-parse modules so the LLM gets block port details
         modules = {}
         for block_name, rtl_path in block_rtl_paths.items():
-            mod = await asyncio.to_thread(parse_verilog_ports, rtl_path)
+            # Parse the BLOCK's module, not whichever comes first in
+            # the file: generated files declare internal stages ahead
+            # of the block itself.
+            mod = await asyncio.to_thread(
+                parse_verilog_ports, rtl_path,
+                module_for_block(rtl_path, block_name))
             if mod.name:
                 modules[block_name] = mod
 
@@ -9747,7 +9772,12 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
 
         modules = {}
         for block_name, rtl_path in block_rtl_paths.items():
-            mod = await asyncio.to_thread(parse_verilog_ports, rtl_path)
+            # Parse the BLOCK's module, not whichever comes first in
+            # the file: generated files declare internal stages ahead
+            # of the block itself.
+            mod = await asyncio.to_thread(
+                parse_verilog_ports, rtl_path,
+                module_for_block(rtl_path, block_name))
             if mod.name:
                 modules[block_name] = mod
 

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -6131,6 +6131,13 @@ async def integration_check_node(state: OrchestratorState) -> dict:
     completed = _current_phase_completed(state)
     passed_blocks = [b for b in completed if b.get("success")]
     block_queue = state.get("block_queue", [])
+    # Join the RESULT dicts to their SPECS. A block result carries
+    # {name, success, attempts, ...} and NOT rtl_target, so discovery would fall
+    # back to filename convention and silently drop the one block whose file
+    # stem differs from its name -- the contract-locked pad adapter. The spec
+    # was already in scope here and used only for len().
+    from orchestrator.langgraph.integration_helpers import merge_block_specs
+    passed_blocks = merge_block_specs(passed_blocks, block_queue)
     expected_blocks = len(block_queue) if block_queue else len(completed)
 
     write_graph_event(pr, "Integration Check", "graph_node_enter", {

--- a/orchestrator/langgraph/rtl_lib/cs_sram.v
+++ b/orchestrator/langgraph/rtl_lib/cs_sram.v
@@ -42,12 +42,18 @@ module cs_mem_macro_shell #(
     parameter integer WIDTH = 32,
     parameter integer DEPTH = 512,
     parameter integer NPORT = 1,                 // 1 = 1rw, 2 = 1rw1r
+    // Write-mask lanes on port 0. 1 = whole-word (the legacy shape: wmask0 is
+    // then a single "do the write" bit and is tied high by callers that do not
+    // mask). The macro flow binds this to the resolved macro's own mask port,
+    // or folds it into the write enable when the macro has none.
+    parameter integer NMASK = 1,
     parameter integer AW    = (DEPTH <= 1) ? 1 : $clog2(DEPTH)
 ) (
     input  wire             clk,
     // port 0 (read/write)
     input  wire             ce0,
     input  wire             we0,
+    input  wire [NMASK-1:0] wmask0,
     input  wire [AW-1:0]    addr0,
     input  wire [WIDTH-1:0] wdata0,
     output wire [WIDTH-1:0] rdata0,
@@ -56,7 +62,8 @@ module cs_mem_macro_shell #(
     input  wire [AW-1:0]    addr1,
     output wire [WIDTH-1:0] rdata1
 );
-    // Black box: the macro flow resolves WIDTH/DEPTH/NPORT to a real SRAM and
+    // Black box: the macro flow resolves WIDTH/DEPTH/NPORT/NMASK to a real
+    // SRAM and
     // streams in its GDS/LEF/lib. No internal logic -> 0 flip-flops at synth.
     // (Reads are 0 in pure RTL sim -- "MACRO" is a backend impl, not a sim
     // model; use "BEHAV"/"FLOP" for simulation.)
@@ -89,7 +96,11 @@ module cs_mem_1rw #(
         if (MEM_IMPL == "MACRO") begin : g_macro
         // verilator lint_on WIDTHEXPAND
             // Separately-named empty shell bound by the PD macro flow.
-            cs_mem_macro_shell #(.WIDTH(WIDTH), .DEPTH(DEPTH), .NPORT(1)) u_shell (
+            // 1RW has no mask concept; hold the shell's single lane high so
+            // web0 reduces to ~we0 exactly as before.
+            cs_mem_macro_shell #(.WIDTH(WIDTH), .DEPTH(DEPTH), .NPORT(1),
+                                 .NMASK(1)) u_shell (
+                .wmask0(1'b1),
                 .clk(clk),
                 .ce0(ce), .we0(we), .addr0(addr), .wdata0(wdata), .rdata0(rdata),
                 .ce1(1'b0), .addr1({AW{1'b0}}), .rdata1()
@@ -157,13 +168,19 @@ module cs_mem_1rw1r #(
         // time constant compare; width expansion is exactly what we want.
         if (MEM_IMPL == "MACRO") begin : g_macro
         // verilator lint_on WIDTHEXPAND
-            // NOTE (USE_WMASK): the black-box shell carries no mask pins; the
-            // macro flow must resolve a USE_WMASK=1 geometry to a byte-write-
-            // enable macro (e.g. the sky130 ..._1rw1r_32x512_8 family, wmask
-            // granularity 8) or an OpenRAM config with write_size=8.
-            cs_mem_macro_shell #(.WIDTH(WIDTH), .DEPTH(DEPTH), .NPORT(2)) u_shell (
+            // The mask now REACHES the memory. Previously the shell carried
+            // no mask pins, so a USE_WMASK=1 geometry had its mask tied to
+            // all-ones at bind time: every partial write became a full-word
+            // write, clobbering neighbouring lanes. RTL DV could not see it --
+            // the BEHAV arm honours the mask -- so it appeared only in the
+            // macro-backed netlist.
+            wire [NB-1:0] wmask0_macro;
+            assign wmask0_macro = (USE_WMASK != 0) ? wmask0 : {NB{1'b1}};
+            cs_mem_macro_shell #(.WIDTH(WIDTH), .DEPTH(DEPTH), .NPORT(2),
+                                 .NMASK(NB)) u_shell (
                 .clk(clk),
-                .ce0(ce0), .we0(we0), .addr0(addr0), .wdata0(wdata0), .rdata0(rdata0),
+                .ce0(ce0), .we0(we0), .wmask0(wmask0_macro),
+                .addr0(addr0), .wdata0(wdata0), .rdata0(rdata0),
                 .ce1(ce1), .addr1(addr1), .rdata1(rdata1)
             );
         end else begin : g_behav

--- a/orchestrator/tests/test_block_rtl_discovery.py
+++ b/orchestrator/tests/test_block_rtl_discovery.py
@@ -169,3 +169,75 @@ class TestTheConsequenceThatActuallyBit:
         assert detect_wrapper_block(
             {k: v for k, v in modules.items() if k != "user_project_wrapper_io"}
         ) is None
+
+
+# ---------------------------------------------------------------------------
+# The fix has to be reachable from the caller that actually exists.
+# ---------------------------------------------------------------------------
+
+#: EXACTLY the keys pipeline_graph builds for a passing block (~:4913). Written
+#: out rather than paraphrased: the first version of the rtl_target fix passed
+#: its unit test and was dead on the production path, because the test invented a
+#: dict containing rtl_target and the real caller never produces one. This branch
+#: has that same defect recorded for the chip_top gate sim ("its unit test passed
+#: by injecting the value itself"), so the shape is pinned here on purpose.
+_PRODUCTION_RESULT_KEYS = (
+    "name", "success", "attempts", "gate_count", "synth_success",
+    "constraints_learned", "step_log_paths", "phase",
+)
+
+
+def _production_result(name):
+    return {"name": name, "success": True, "attempts": 1, "gate_count": 0,
+            "synth_success": True, "constraints_learned": 0,
+            "step_log_paths": {}, "phase": "rtl"}
+
+
+class TestTheProductionCallerCanActuallyResolveRtlTarget:
+    def test_the_result_dict_really_has_no_rtl_target(self):
+        """Guards the premise. If a future change starts putting rtl_target in
+        the block result, this test should fail and the join becomes redundant --
+        which is information, not breakage."""
+        r = _production_result("blk")
+        assert set(r) == set(_PRODUCTION_RESULT_KEYS)
+        assert "rtl_target" not in r and "rtl_path" not in r
+
+    def test_discovery_drops_the_odd_named_block_without_the_join(self, tmp_path):
+        """The live failure, reproduced from the production dict shape."""
+        (tmp_path / "rtl").mkdir()
+        (tmp_path / "rtl" / "user_project_wrapper.v").write_text(PAD_ADAPTER)
+        _leaf(tmp_path / "rtl" / "core" / "engine.v", "engine")
+        results = [_production_result("user_project_wrapper_io"),
+                   _production_result("engine")]
+        found = discover_block_rtl(str(tmp_path), results)
+        assert "engine" in found                      # filename convention saves it
+        assert "user_project_wrapper_io" not in found  # ...and cannot save this one
+
+    def test_merging_the_spec_makes_it_resolvable(self, tmp_path):
+        from orchestrator.langgraph.integration_helpers import merge_block_specs
+        (tmp_path / "rtl").mkdir()
+        (tmp_path / "rtl" / "user_project_wrapper.v").write_text(PAD_ADAPTER)
+        _leaf(tmp_path / "rtl" / "core" / "engine.v", "engine")
+        results = [_production_result("user_project_wrapper_io"),
+                   _production_result("engine")]
+        queue = [{"name": "user_project_wrapper_io",
+                  "rtl_target": "rtl/user_project_wrapper.v"},
+                 {"name": "engine", "rtl_target": "rtl/core/engine.v"}]
+        found = discover_block_rtl(
+            str(tmp_path), merge_block_specs(results, queue))
+        assert set(found) == {"user_project_wrapper_io", "engine"}
+
+    def test_the_result_wins_over_the_spec(self, tmp_path):
+        """A block reported what it actually did; the spec says what it should
+        be. Never let the spec overwrite the report."""
+        from orchestrator.langgraph.integration_helpers import merge_block_specs
+        merged = merge_block_specs(
+            [{"name": "blk", "success": True, "attempts": 3}],
+            [{"name": "blk", "attempts": 1, "rtl_target": "rtl/blk.v"}])
+        assert merged[0]["attempts"] == 3
+        assert merged[0]["rtl_target"] == "rtl/blk.v"
+
+    def test_a_block_with_no_spec_survives_the_join(self, tmp_path):
+        from orchestrator.langgraph.integration_helpers import merge_block_specs
+        merged = merge_block_specs([_production_result("orphan")], [])
+        assert merged[0]["name"] == "orphan"

--- a/orchestrator/tests/test_chip_equiv_wiring.py
+++ b/orchestrator/tests/test_chip_equiv_wiring.py
@@ -84,7 +84,7 @@ def _setup_node(monkeypatch, tmp_path, *, sim_passed, equiv_result):
         pipeline_graph, "load_architecture_connections", lambda pr: ([], "chip"))
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda p: VerilogModule(name="a", ports=[VerilogPort("clk", "input")]))
+        lambda p, module=None: VerilogModule(name="a", ports=[VerilogPort("clk", "input")]))
     monkeypatch.setattr(
         pipeline_graph, "run_integration_simulation",
         lambda *a, **k: {"passed": sim_passed, "log": "sim ran", "log_path": ""})

--- a/orchestrator/tests/test_chip_gate_sim_wiring.py
+++ b/orchestrator/tests/test_chip_gate_sim_wiring.py
@@ -215,19 +215,45 @@ class TestModdupHazard:
                        "endmodule\n")
         return top, pad
 
-    def test_duplicate_module_is_removed_when_a_dedup_dir_is_given(self, tmp_path):
-        top, pad = self._caravel_layout(tmp_path)
-        srcs = chip_rtl_sources(
-            str(top), {"user_project_wrapper_io": str(pad)},
-            dedup_dir=tmp_path / "scratch")
-        decls = 0
-        for s in srcs:
-            decls += Path(s).read_text().count("module user_project_wrapper ")
-        assert decls == 1, f"{decls} definitions survived: {srcs}"
-
-    def test_raw_paths_when_no_dedup_dir_is_given(self, tmp_path):
-        """Callers that only want paths (linting, reporting) get them back
-        unchanged -- deduping writes files, which a pure query must not do."""
+    def test_an_alias_carrier_is_excluded_at_the_source(self, tmp_path):
+        """A block file that RE-DECLARES the top's own module leaves the list
+        entirely. The generated pad block ships a thin `module
+        user_project_wrapper` alias plus STUBS of its sibling blocks; keeping
+        the file let the dedup keep the stubs (they sort first) and strip the
+        real logic -- the gate's reference then elaborated a hollow chip,
+        honestly failed it, and reported not_run on a design that was fine."""
         top, pad = self._caravel_layout(tmp_path)
         srcs = chip_rtl_sources(str(top), {"user_project_wrapper_io": str(pad)})
-        assert srcs == [str(top), str(pad)]
+        assert srcs == [str(top)]
+        # with a dedup dir the answer is the same -- exclusion happens earlier
+        srcs2 = chip_rtl_sources(
+            str(top), {"user_project_wrapper_io": str(pad)},
+            dedup_dir=tmp_path / "scratch")
+        decls = sum(Path(s).read_text().count("module user_project_wrapper ")
+                    for s in srcs2)
+        assert decls == 1, f"{decls} definitions survived: {srcs2}"
+
+    def test_dedup_still_handles_blocks_sharing_a_macro_module(self, tmp_path):
+        """The case the dedup genuinely exists for: two blocks each bundling
+        the SAME shared behavioural macro. Neither re-declares the top, so both
+        stay in the list, and the dedup strips the second copy of the macro."""
+        top = tmp_path / "rtl" / "integration" / "chip_top.v"
+        top.parent.mkdir(parents=True)
+        top.write_text("module chip_top (input wire clk);\nendmodule\n")
+        a = tmp_path / "rtl" / "a.v"
+        a.write_text("module a();\nendmodule\n"
+                     "module shared_macro();\nendmodule\n")
+        b = tmp_path / "rtl" / "b.v"
+        b.write_text("module b();\nendmodule\n"
+                     "module shared_macro();\nendmodule\n")
+        srcs = chip_rtl_sources(str(top), {"a": str(a), "b": str(b)},
+                                dedup_dir=tmp_path / "scratch")
+        # Count DECLARATIONS, not the substring: the dedup leaves a tombstone
+        # comment ("removed duplicate module shared_macro") that contains the
+        # module name -- a naive substring count reads the receipt of the
+        # removal as the thing it removed.
+        import re as _re
+        decls = sum(len(_re.findall(r"^\s*module\s+shared_macro\b",
+                                    Path(s).read_text(), _re.M))
+                    for s in srcs)
+        assert decls == 1, f"shared_macro declared {decls} times"

--- a/orchestrator/tests/test_contract_conformance.py
+++ b/orchestrator/tests/test_contract_conformance.py
@@ -117,14 +117,52 @@ class TestAmbiguityIsADeviation:
         assert any("claimed by both" in w for _c, w in r.ambiguous)
 
 
-class TestExemption:
-    def test_caravel_pad_boundary_is_exempt(self, tmp_path):
-        """io_in/io_out/io_oeb are fixed by the shuttle, so the convention
-        cannot apply -- and enforcing it would break the graded boundary."""
-        root = _project(tmp_path, [_edge("x", "pads", "ch", fields=["data"])])
+class TestPadBoundaryIsNotABlanketExemption:
+    """The mandated pin NAMES are exempt. The block is not.
+
+    A blanket exemption hid the largest defect in the raster design: the pad
+    block was generated as a complete chip top that instantiates the other
+    blocks internally, with the channel signals as internal wires and NO inward
+    ports at all. The architecture specifies a pin ADAPTER with ports; the RTL
+    produced a competing top, which nothing can wire.
+    """
+
+    def test_mandated_pins_are_never_undeclared(self, tmp_path):
+        root = _project(tmp_path, [
+            _edge("pads", "core", "ch", fields=["data"])])
+        r = check_block(root, "pads",
+                        _rtl(tmp_path, "pads",
+                             ["io_in", "io_out", "io_oeb", "ch_data"]))
+        assert r.ok, (r.missing, r.undeclared)
+        assert r.locked_boundary
+        assert not r.undeclared, "flagged an externally-mandated pin"
+
+    def test_a_pad_block_still_owes_its_inward_channel_ports(self, tmp_path):
+        """THE defect. Carrying io_* does not excuse a block from exposing the
+        signals its contract says it produces."""
+        root = _project(tmp_path, [
+            _edge("pads", "core", "qspi_async_pins",
+                  fields=["qspi_csn", "qspi_sck"])])
         r = check_block(root, "pads",
                         _rtl(tmp_path, "pads", ["io_in", "io_out", "io_oeb"]))
-        assert r.exempt and r.ok and r.reason
+        assert not r.ok
+        assert r.locked_boundary
+        assert ("qspi_async_pins", "qspi_async_pins_qspi_csn") in r.missing
+
+
+class TestPortsAreReadFromOneModuleOnly:
+    def test_stub_modules_later_in_the_file_do_not_count(self, tmp_path):
+        """Generated files carry stub declarations of child modules after the
+        real one. Unioning their ports gave the pad block a FALSE PASS."""
+        f = tmp_path / "pads.v"
+        f.write_text(
+            "module pads (\n  input wire io_in,\n  output wire io_out,\n"
+            "  output wire io_oeb\n);\nendmodule\n\n"
+            "module child (\n  input wire ch_data\n);\nendmodule\n")
+        root = _project(tmp_path, [_edge("pads", "core", "ch", fields=["data"])])
+        r = check_block(root, "pads", f)
+        assert not r.ok, "read ports from a stub module lower in the file"
+        assert ("ch", "ch_data") in r.missing
 
 
 class TestFeedbackIsActionable:

--- a/orchestrator/tests/test_contract_conformance.py
+++ b/orchestrator/tests/test_contract_conformance.py
@@ -191,3 +191,61 @@ class TestPortParsing:
         root = _project(tmp_path, [])
         r = check_block(root, "gone", tmp_path / "absent.v")
         assert not r.exempt and r.reason
+
+
+class TestALeafMustNotAssembleTheDesign:
+    """A block that instantiates its siblings is a competing chip top.
+
+    `user_project_wrapper_io` was generated as a 264-line module instantiating
+    all seven other blocks and exposing only the Caravel boundary. Nothing can
+    wire that -- the assembler has no inward ports to connect, so it refuses,
+    the LLM fallback drops blocks, and integration produces no chip_top at all.
+    Every downstream gate (flat synth, chip gate-sim) is unreachable behind it.
+
+    The mandated module name is the likely cause: told its module must be named
+    `user_project_wrapper`, a generator writes the Caravel wrapper, which by
+    convention instantiates the user's design. The name induces the error, so
+    the structural property is what to check, not the prompt.
+    """
+
+    def _design(self, tmp_path, body):
+        f = tmp_path / "pads.v"
+        f.write_text("module pads (\n  input wire io_in,\n  output wire io_out,\n"
+                     "  output wire io_oeb\n);\n" + body + "\nendmodule\n")
+        return f
+
+    def test_instantiating_a_sibling_is_a_deviation(self, tmp_path):
+        root = _project(tmp_path, [])
+        f = self._design(tmp_path, "  qspi_cdc_frontend u_front ();")
+        r = check_block(root, "pads", f, siblings=["pads", "qspi_cdc_frontend"])
+        assert not r.ok
+        assert r.instantiates == ["qspi_cdc_frontend"]
+        assert "It is a leaf, not the chip top" in r.as_feedback()
+
+    def test_a_clean_leaf_passes(self, tmp_path):
+        root = _project(tmp_path, [])
+        r = check_block(root, "pads",
+                        self._design(tmp_path, "  assign io_out = io_in;"),
+                        siblings=["pads", "qspi_cdc_frontend"])
+        assert r.ok and not r.instantiates
+
+    def test_an_alias_wrapper_after_the_block_is_not_counted(self, tmp_path):
+        """A file may legitimately carry a thin alias module after the block --
+        the real one does. Only the BLOCK's own module body is examined."""
+        f = tmp_path / "pads.v"
+        f.write_text(
+            "module pads (\n  input wire io_in\n);\n  assign x = io_in;\n"
+            "endmodule\n\n"
+            "module pads_alias (\n  input wire io_in\n);\n"
+            "  pads u (.io_in(io_in));\nendmodule\n")
+        root = _project(tmp_path, [])
+        r = check_block(root, "pads", f, siblings=["pads", "pads_alias"])
+        assert not r.instantiates
+
+    def test_siblings_default_to_empty_so_existing_callers_are_unaffected(
+        self, tmp_path
+    ):
+        root = _project(tmp_path, [])
+        r = check_block(root, "pads",
+                        self._design(tmp_path, "  qspi_cdc_frontend u ();"))
+        assert not r.instantiates

--- a/orchestrator/tests/test_contract_conformance.py
+++ b/orchestrator/tests/test_contract_conformance.py
@@ -17,6 +17,7 @@ caught that.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -249,3 +250,80 @@ class TestALeafMustNotAssembleTheDesign:
         r = check_block(root, "pads",
                         self._design(tmp_path, "  qspi_cdc_frontend u ();"))
         assert not r.instantiates
+
+
+class TestDeterministicPortRepair:
+    """The generator will not fix these, measured rather than assumed.
+
+    All four deviating blocks were regenerated with fresh uarch specs and fresh
+    RTL, handed the exact required port name and the explicit "do not shorten a
+    repeated word" rule -- which `contract_lookup` already carried -- and all
+    four came back with the SAME deviations. So the repair belongs in a pass over
+    the emitted RTL, which is safe here only because the checker re-verifies the
+    result afterwards.
+    """
+
+    def test_collapsed_token_is_repaired(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import repair_block_ports
+        root = _project(tmp_path, [
+            _edge("ap", "store", "host_write",
+                  fields=["wdata"], sideband=["write_enable"])])
+        f = _rtl(tmp_path, "ap", ["host_write_wdata", "host_write_enable"])
+        out = repair_block_ports(root, "ap", f, apply=True)
+        assert out["renames"] == {"host_write_enable": "host_write_write_enable"}
+        assert out["conforms"] is True
+        assert "host_write_write_enable" in f.read_text()
+
+    def test_the_channel_disambiguates_a_shared_signal_name(self, tmp_path):
+        """`host_read_enable` and `framebuffer_read_enable` both end in
+        `read_enable`. Matching on trailing tokens ties and repairs neither;
+        matching within the channel resolves both."""
+        from orchestrator.langgraph.contract_conformance import plan_port_repairs
+        root = _project(tmp_path, [
+            _edge("ap", "s", "host_read", sideband=["read_enable"]),
+            _edge("ap", "f", "framebuffer_read", sideband=["read_enable"]),
+        ])
+        f = _rtl(tmp_path, "ap", ["host_read_enable", "framebuffer_read_enable"])
+        plan = plan_port_repairs(check_block(root, "ap", f))
+        assert plan == {
+            "host_read_enable": "host_read_read_enable",
+            "framebuffer_read_enable": "framebuffer_read_read_enable",
+        }
+
+    def test_a_different_vocabulary_is_NOT_guessed(self, tmp_path):
+        """`qspi_req_addr` for contract channel `qspi_aperture`'s `req_addr` is
+        left alone: it wears no channel prefix, so matching it would mean
+        guessing by suffix across the module, and a wrong guess there silently
+        cross-wires a channel."""
+        from orchestrator.langgraph.contract_conformance import plan_port_repairs
+        root = _project(tmp_path, [
+            _edge("eng", "ap", "qspi_aperture", sideband=["req_addr"])])
+        f = _rtl(tmp_path, "ap", ["qspi_req_addr"])
+        assert plan_port_repairs(check_block(root, "ap", f)) == {}
+
+    def test_nothing_is_applied_without_apply(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import repair_block_ports
+        root = _project(tmp_path, [
+            _edge("ap", "s", "host_write", sideband=["write_enable"])])
+        f = _rtl(tmp_path, "ap", ["host_write_enable"])
+        before = f.read_text()
+        out = repair_block_ports(root, "ap", f)
+        assert out["renames"] and f.read_text() == before
+
+    def test_a_backup_is_left_behind(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import repair_block_ports
+        root = _project(tmp_path, [
+            _edge("ap", "s", "host_write", sideband=["write_enable"])])
+        f = _rtl(tmp_path, "ap", ["host_write_enable"])
+        repair_block_ports(root, "ap", f, apply=True)
+        assert Path(str(f) + ".pre_portrepair").exists()
+
+    def test_the_result_is_re_checked_not_assumed(self, tmp_path):
+        """conforms must come from a fresh check after the edit, so a repair
+        that does not actually fix the block cannot report success."""
+        from orchestrator.langgraph.contract_conformance import repair_block_ports
+        root = _project(tmp_path, [
+            _edge("ap", "s", "ch", fields=["data"], sideband=["valid"])])
+        f = _rtl(tmp_path, "ap", ["ch_dat"])          # nothing repairable
+        out = repair_block_ports(root, "ap", f, apply=True)
+        assert out["conforms"] is False

--- a/orchestrator/tests/test_contract_conformance.py
+++ b/orchestrator/tests/test_contract_conformance.py
@@ -1,0 +1,155 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""RTL ports must match the signals the interface contract declares.
+
+Calibrated against all 8 blocks of exp-raster-validate-20260730: with the rule
+implemented here, 3 blocks conform, 1 is exempt (Caravel pad boundary), and 4
+deviate -- and every one of those 4 is a genuine deviation that would make a
+contract edge unresolvable at integration.
+
+An earlier, stricter version demanded `<channel>_<field>` universally and failed
+6 of 8, mostly because the CHECK was wrong: it wanted `edge_event_sck_rise` and
+`csn_sync_csn_sync`. Running it against real RTL before wiring it in is what
+caught that.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orchestrator.langgraph.contract_conformance import check_block, declared_ports
+
+
+def _project(tmp_path, edges):
+    (tmp_path / ".coresmith").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".coresmith" / "interface_contracts.json").write_text(
+        json.dumps({"contracts": edges}))
+    return tmp_path
+
+
+def _edge(producer, consumer, chan, fields=(), sideband=()):
+    return {
+        "edge_id": f"{producer}__{chan}__to__{consumer}__{chan}",
+        "producer_block": producer, "producer_port": chan,
+        "consumer_block": consumer, "consumer_port": chan,
+        "fields": [{"name": f} for f in fields],
+        "sideband_signals": list(sideband),
+    }
+
+
+def _rtl(tmp_path, name, ports):
+    f = tmp_path / f"{name}.v"
+    f.write_text(f"module {name} (\n  "
+                 + ",\n  ".join(f"input wire {p}" for p in ports)
+                 + "\n);\nendmodule\n")
+    return f
+
+
+class TestBothNamingStylesAreAccepted:
+    """Blocks legitimately use either form. The prefixed one disambiguates a
+    generic field name; the bare one is used when the name already stands
+    alone (`sck_rise`, `qspi_csn`)."""
+
+    @pytest.mark.parametrize("ports", [
+        ["framebuffer_read_rdata", "framebuffer_read_read_enable"],   # prefixed
+        ["rdata", "read_enable"],                                     # bare
+    ])
+    def test_conforming_block(self, tmp_path, ports):
+        root = _project(tmp_path, [
+            _edge("aperture", "fb", "framebuffer_read",
+                  fields=["rdata"], sideband=["read_enable"])])
+        r = check_block(root, "fb", _rtl(tmp_path, "fb", ports))
+        assert r.ok, (r.missing, r.undeclared, r.ambiguous)
+        assert r.checked_edges == 1
+
+
+class TestTheRealDeviations:
+    def test_collapsed_duplicate_token_is_caught(self, tmp_path):
+        """THE systematic defect: channel `host_write` + signal `write_enable`
+        emitted as `host_write_enable`. Neither the prefixed nor the bare form,
+        so the contract edge cannot be resolved by name."""
+        root = _project(tmp_path, [
+            _edge("aperture", "store", "host_write",
+                  fields=["wdata"], sideband=["write_enable"])])
+        r = check_block(root, "aperture",
+                        _rtl(tmp_path, "aperture",
+                             ["host_write_wdata", "host_write_enable"]))
+        assert not r.ok
+        assert ("host_write", "host_write_write_enable") in r.missing
+        assert "host_write_enable" in r.undeclared
+
+    def test_direction_suffix_is_caught(self, tmp_path):
+        """`raster_read_fault_i` -- real, from raster_scan_pipeline."""
+        root = _project(tmp_path, [
+            _edge("zb", "pipe", "raster_read", fields=["rdata"],
+                  sideband=["fault"])])
+        r = check_block(root, "pipe",
+                        _rtl(tmp_path, "pipe",
+                             ["raster_read_rdata", "raster_read_fault_i"]))
+        assert not r.ok
+        assert "raster_read_fault_i" in r.undeclared
+
+    def test_missing_signal_is_caught(self, tmp_path):
+        root = _project(tmp_path, [
+            _edge("a", "b", "ch", fields=["data"], sideband=["valid"])])
+        r = check_block(root, "b", _rtl(tmp_path, "b", ["ch_data"]))
+        assert ("ch", "ch_valid") in r.missing
+
+
+class TestAmbiguityIsADeviation:
+    """The stitcher cannot resolve these either, which is the whole point."""
+
+    def test_both_forms_present(self, tmp_path):
+        root = _project(tmp_path, [_edge("a", "b", "ch", fields=["data"])])
+        r = check_block(root, "b", _rtl(tmp_path, "b", ["ch_data", "data"]))
+        assert not r.ok and r.ambiguous
+
+    def test_one_bare_name_claimed_by_two_channels(self, tmp_path):
+        root = _project(tmp_path, [
+            _edge("a", "b", "rd_one", fields=["req_addr"]),
+            _edge("a", "b", "rd_two", fields=["req_addr"]),
+        ])
+        r = check_block(root, "b", _rtl(tmp_path, "b", ["req_addr"]))
+        assert not r.ok
+        assert any("claimed by both" in w for _c, w in r.ambiguous)
+
+
+class TestExemption:
+    def test_caravel_pad_boundary_is_exempt(self, tmp_path):
+        """io_in/io_out/io_oeb are fixed by the shuttle, so the convention
+        cannot apply -- and enforcing it would break the graded boundary."""
+        root = _project(tmp_path, [_edge("x", "pads", "ch", fields=["data"])])
+        r = check_block(root, "pads",
+                        _rtl(tmp_path, "pads", ["io_in", "io_out", "io_oeb"]))
+        assert r.exempt and r.ok and r.reason
+
+
+class TestFeedbackIsActionable:
+    def test_it_states_the_exact_required_name(self, tmp_path):
+        """A vague "match the contract" changes nothing -- contract_lookup
+        already injects exactly that instruction and the generator collapsed the
+        token anyway."""
+        root = _project(tmp_path, [
+            _edge("aperture", "store", "host_write", sideband=["write_enable"])])
+        r = check_block(root, "aperture",
+                        _rtl(tmp_path, "aperture", ["host_write_enable"]))
+        fb = r.as_feedback()
+        assert "host_write_write_enable" in fb
+        assert "do not shorten a repeated word" in fb
+
+
+class TestPortParsing:
+    def test_ansi_and_non_ansi_and_comments(self):
+        assert {"a", "b", "c"} <= declared_ports(
+            "module m(a, b);\n  // input phantom;\n  input wire [3:0] a;\n"
+            "  output b;\n  inout c;\nendmodule\n")
+        assert "phantom" not in declared_ports("module m(a);\n// input phantom;\n"
+                                               "input a;\nendmodule\n")
+
+    def test_missing_file_is_reported_not_raised(self, tmp_path):
+        root = _project(tmp_path, [])
+        r = check_block(root, "gone", tmp_path / "absent.v")
+        assert not r.exempt and r.reason

--- a/orchestrator/tests/test_contract_conformance.py
+++ b/orchestrator/tests/test_contract_conformance.py
@@ -290,15 +290,43 @@ class TestDeterministicPortRepair:
             "framebuffer_read_enable": "framebuffer_read_read_enable",
         }
 
-    def test_a_different_vocabulary_is_NOT_guessed(self, tmp_path):
-        """`qspi_req_addr` for contract channel `qspi_aperture`'s `req_addr` is
-        left alone: it wears no channel prefix, so matching it would mean
-        guessing by suffix across the module, and a wrong guess there silently
-        cross-wires a channel."""
+    def test_a_different_vocabulary_is_repaired_when_unambiguous(self, tmp_path):
+        """`qspi_req_addr` for contract channel `qspi_aperture`'s `req_addr`.
+        It wears no channel prefix, so tiers 1 and 2 cannot see it -- but with
+        exactly one unaccounted candidate the answer is not a guess."""
         from orchestrator.langgraph.contract_conformance import plan_port_repairs
         root = _project(tmp_path, [
             _edge("eng", "ap", "qspi_aperture", sideband=["req_addr"])])
         f = _rtl(tmp_path, "ap", ["qspi_req_addr"])
+        assert plan_port_repairs(check_block(root, "ap", f)) == {
+            "qspi_req_addr": "qspi_aperture_req_addr"}
+
+    def test_ports_bound_to_another_channel_are_excluded(self, tmp_path):
+        """THE case that makes tier 3 safe, taken from the real block.
+
+        control_status_aperture declares three ports ending in `_req_addr`:
+        framebuffer_read_req_addr, host_read_req_addr and qspi_req_addr. Two are
+        already the accepted implementation of their own channel's req_addr, so
+        only one is a candidate. Without that exclusion this is a coin flip
+        between three channels."""
+        from orchestrator.langgraph.contract_conformance import plan_port_repairs
+        root = _project(tmp_path, [
+            _edge("a", "ap", "framebuffer_read", sideband=["req_addr"]),
+            _edge("b", "ap", "host_read", sideband=["req_addr"]),
+            _edge("c", "ap", "qspi_aperture", sideband=["req_addr"]),
+        ])
+        f = _rtl(tmp_path, "ap", ["framebuffer_read_req_addr",
+                                  "host_read_req_addr", "qspi_req_addr"])
+        assert plan_port_repairs(check_block(root, "ap", f)) == {
+            "qspi_req_addr": "qspi_aperture_req_addr"}
+
+    def test_two_unaccounted_candidates_are_refused(self, tmp_path):
+        """No unique answer means no repair. Renaming the wrong wire
+        cross-wires a channel, which RTL cannot show you."""
+        from orchestrator.langgraph.contract_conformance import plan_port_repairs
+        root = _project(tmp_path, [
+            _edge("eng", "ap", "ch", sideband=["req_addr"])])
+        f = _rtl(tmp_path, "ap", ["alpha_req_addr", "beta_req_addr"])
         assert plan_port_repairs(check_block(root, "ap", f)) == {}
 
     def test_nothing_is_applied_without_apply(self, tmp_path):

--- a/orchestrator/tests/test_gate_sim.py
+++ b/orchestrator/tests/test_gate_sim.py
@@ -52,12 +52,17 @@ _NETLIST_RAILS = _NETLIST.replace(
 )
 
 # The same netlist with a real bidirectional SIGNAL on the boundary.
+# The tristate port is genuinely DRIVEN (a conditional-Z assign): the veto is
+# for bidirectional SIGNALS. A declared-but-unreferenced inout, or one tied to
+# constant Z, is INERT -- a mandated-but-unused pad bus like Caravel analog_io --
+# and deliberately does not veto (test_a_z_tied_unused_inout_is_inert_not_a_veto).
 _NETLIST_TRISTATE = _NETLIST.replace(
     "module blk(clk, rst_n, en, q, valid);",
     "module blk(clk, rst_n, en, q, valid, sda);",
 ).replace(
     "  sky130_fd_sc_hd__dfxtp_1",
-    "  inout sda;\n  wire sda;\n  sky130_fd_sc_hd__dfxtp_1",
+    "  inout sda;\n  wire sda;\n"
+    "  assign sda = en ? 1'b0 : 1'bz;\n  sky130_fd_sc_hd__dfxtp_1",
 )
 
 # The subject under test declares itself the chip top. The gate's DEFAULT SCOPE
@@ -638,7 +643,7 @@ def test_split_inouts_separates_rails_from_signals():
     ports = [gs.Port("clk", "input"), gs.Port("vccd1", "inout"),
              gs.Port("vssd1", "inout"), gs.Port("sda", "inout"),
              gs.Port("q", "output", 8, 7, 0)]
-    rails, signals = gs.split_inouts(ports)
+    rails, _inert, signals = gs.split_inouts(ports)
     assert [p.name for p in rails] == ["vccd1", "vssd1"]
     assert [p.name for p in signals] == ["sda"]
 
@@ -646,9 +651,51 @@ def test_split_inouts_separates_rails_from_signals():
 def test_a_wide_inout_is_never_treated_as_a_rail():
     """A supply is one bit. A bus that happens to share a rail's name is not a
     rail we understand, so it stays a signal and still vetoes the gate."""
-    rails, signals = gs.split_inouts([gs.Port("vccd1", "inout", 8, 7, 0)])
-    assert rails == []
+    rails, inert, signals = gs.split_inouts([gs.Port("vccd1", "inout", 8, 7, 0)])
+    assert rails == [] and inert == []
     assert [p.name for p in signals] == ["vccd1"]
+
+
+def test_a_z_tied_unused_inout_is_inert_not_a_veto():
+    """Caravel MANDATES `inout [28:0] analog_io` on every user_project_wrapper.
+    A design that never touches it gets `assign analog_io = 29'hzzzzzzzz;` from
+    yosys -- declaration plus a constant-Z tie, no behaviour. Excluding it
+    fabricates nothing, and without this rule the gate can never judge the one
+    artifact the external grader actually drives."""
+    netlist = (
+        "module top(clk, analog_io);\n"
+        "  input clk;\n"
+        "  inout [28:0] analog_io;\n"
+        "  wire [28:0] analog_io;\n"
+        "  assign analog_io = 29'hzzzzzzzz;\n"
+        "endmodule\n")
+    rails, inert, signals = gs.split_inouts(
+        [gs.Port("analog_io", "inout", 29, 28, 0)], netlist)
+    assert [p.name for p in inert] == ["analog_io"]
+    assert signals == [] and rails == []
+
+
+def test_an_inout_with_any_real_reference_still_vetoes():
+    """One instance connection means the port participates in the design; the
+    honest answer stays "cannot judge". Structural, not a name list: a design
+    that actually drives its analog pads must not be blessed."""
+    netlist = (
+        "module top(clk, analog_io);\n"
+        "  input clk;\n"
+        "  inout [28:0] analog_io;\n"
+        "  some_cell u0 (.pad(analog_io[3]));\n"
+        "endmodule\n")
+    rails, inert, signals = gs.split_inouts(
+        [gs.Port("analog_io", "inout", 29, 28, 0)], netlist)
+    assert inert == []
+    assert [p.name for p in signals] == ["analog_io"]
+
+
+def test_without_netlist_text_no_inout_is_presumed_inert():
+    """No evidence, no exemption."""
+    rails, inert, signals = gs.split_inouts(
+        [gs.Port("analog_io", "inout", 29, 28, 0)])
+    assert inert == [] and [p.name for p in signals] == ["analog_io"]
 
 
 def test_driver_ties_power_rails_and_never_compares_them():

--- a/orchestrator/tests/test_integration_block_rtl_gate.py
+++ b/orchestrator/tests/test_integration_block_rtl_gate.py
@@ -55,7 +55,7 @@ def _seams(monkeypatch, *, rtl_target: str = ""):
         pipeline_graph, "load_architecture_connections", lambda pr: ([{"a": 1}], "chip"))
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda p: VerilogModule(name="core", ports=[VerilogPort("clk", "input")]))
+        lambda p, module=None: VerilogModule(name="core", ports=[VerilogPort("clk", "input")]))
     monkeypatch.setattr(pipeline_graph, "write_graph_event", lambda *a, **k: None)
 
     # discover_block_rtl / unresolved_block_rtl read the block spec for
@@ -129,7 +129,7 @@ async def test_rtl_target_resolution_clears_the_gate(monkeypatch, tmp_path):
     # stop the node right after the gate so no LLM/assembly runs
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda p: VerilogModule(name="", ports=[]))
+        lambda p, module=None: VerilogModule(name="", ports=[]))
 
     result = await pipeline_graph.integration_check_node(
         _state(tmp_path, write_missing_rtl=True))
@@ -175,7 +175,7 @@ async def test_gate_off_restores_drop_and_continue(monkeypatch, tmp_path):
         lambda p: (_ for _ in ()).throw(AssertionError("gate must not park")))
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda p: VerilogModule(name="", ports=[]))
+        lambda p, module=None: VerilogModule(name="", ports=[]))
 
     result = await pipeline_graph.integration_check_node(_state(tmp_path))
     # unchanged legacy behavior: the missing block is simply absent
@@ -189,7 +189,7 @@ async def test_override_assembles_without_the_block(monkeypatch, tmp_path):
     monkeypatch.setattr(pipeline_graph, "interrupt", lambda p: {"action": "override"})
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda p: VerilogModule(name="", ports=[]))
+        lambda p, module=None: VerilogModule(name="", ports=[]))
 
     result = await pipeline_graph.integration_check_node(_state(tmp_path))
     assert result["integration_result"]["reason"] == "No block RTL could be parsed"

--- a/orchestrator/tests/test_integration_compat_wiring.py
+++ b/orchestrator/tests/test_integration_compat_wiring.py
@@ -103,7 +103,8 @@ def _wire_two_block_design(monkeypatch, *, src_width, dst_width):
     )
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda path: modules["a"] if path.endswith("a.v") else modules["b"],
+        lambda path, module=None: (modules["a"] if path.endswith("a.v")
+                                   else modules["b"]),
     )
     monkeypatch.setattr(
         pipeline_graph, "lint_top_level",

--- a/orchestrator/tests/test_macro_prebind.py
+++ b/orchestrator/tests/test_macro_prebind.py
@@ -54,8 +54,10 @@ class TestActiveLowPolarity:
     def test_chip_select_and_write_enable_are_inverted(self):
         v = emit_bound_shell(_bound((FakeSpec(8, 4096), FakeMacro("sram_a"))))
         assert ".csb0(~ce0)" in v
-        assert ".web0(~we0)" in v
         assert ".csb0(ce0)" not in v, "active-low port driven with active-high signal"
+        # A macro with no wmask0 gets the whole-word mask folded into its write
+        # enable, so web0 is the INVERTED (we0 AND mask) rather than plain ~we0.
+        assert ".web0(~(we0 & (&wmask0)))" in v
         assert ".web0(we0)" not in v
 
     def test_second_read_port_select_also_inverted(self):
@@ -115,7 +117,10 @@ class TestGeometryDispatch:
             "endmodule\n")
         v = emit_bound_shell(_bound(
             (FakeSpec(32, 512, nport=1), FakeMacro("m", str(masked), mask_bits=4))))
-        assert ".wmask0({4{1'b1}})" in v
+        # The SHELL's mask, not a constant. Tying it high was the defect: every
+        # partial write silently became a full-word write.
+        assert ".wmask0(wmask0)" in v
+        assert "1'b1}}" not in v.split(".wmask0")[1][:40], "mask tied to a constant"
 
         plain = tmp_path / "plain.v"
         plain.write_text(
@@ -125,7 +130,9 @@ class TestGeometryDispatch:
             "endmodule\n")
         v2 = emit_bound_shell(_bound(
             (FakeSpec(8, 4096, nport=1), FakeMacro("p", str(plain), mask_bits=1))))
-        assert "wmask0" not in v2, "connected a pin the model does not declare"
+        assert ".wmask0(" not in v2, "connected a pin the model does not declare"
+        # ...but the mask still reaches the memory, folded into web0.
+        assert ".web0(~(we0 & (&wmask0)))" in v2
 
 
 def _maskless_env(tmp_path, monkeypatch, width, nb_expected):
@@ -177,65 +184,87 @@ class TestMaskMismatchIsRefused:
         assert any("wmask0" in e for e in res.errors)
         assert any("full-word writes" in e for e in res.errors)
 
-    def test_whole_word_mask_binds_but_warns(self, tmp_path, monkeypatch):
+    def test_whole_word_mask_binds_and_the_shell_folds_it(self, tmp_path, monkeypatch):
         """WIDTH=8 / GRAN=8 -> 1 mask bit spanning the word, which is exactly
-        what the write enable already expresses -- and why OpenRAM omits the
-        port. Bind, but say the fold into we0 is required."""
+        what a write enable expresses -- and why OpenRAM omits the port.
+
+        The shell now performs the fold itself, so this is correct by
+        construction instead of depending on the RTL author remembering to write
+        `we0 = write_fire & wmask` (framebuffer_sram had to be hand-patched to do
+        exactly that)."""
         mp, rtl = _maskless_env(tmp_path, monkeypatch, 8, 1)
         res = mp.resolve_prebindings([rtl], allow_generate=False)
         assert res.bindings, "refused a mask that is equivalent to we0"
         assert not res.unresolved and not res.errors
         assert res.ok is True
-        assert any("fold" in w and "we0" in w for w in res.warnings)
+        assert res.mask_lanes.get((8, 4096, 2)) == 1
+        assert any("folded" in w for w in res.warnings)
 
-    def test_multibit_mask_against_a_MASK_CAPABLE_macro_is_also_refused(
+    def test_multibit_mask_against_a_MASK_CAPABLE_macro_now_BINDS(
         self, tmp_path, monkeypatch
     ):
-        """The hole the maskless test could not see.
-
-        Resolving to a byte-write-enable macro is NECESSARY but not SUFFICIENT:
-        ``emit_bound_shell``'s ``cs_mem_macro_shell`` declares no mask pins and
-        ``_ports_for`` hardwires the macro's ``wmask0`` to all-ones, so the RTL's
-        dynamic mask is discarded even though the macro could have honoured it.
+        """The shell routes the mask, so this is no longer refused -- it works.
 
         Two of the three memories in exp-raster-macro-20260727 were in exactly
-        this state, both driving a genuinely dynamic mask:
-        triangle_store (WIDTH=64, 8 mask bits, macro sram_1rw1r_64_64_8_sky130
-        tied 8'hff) and zbuffer_sram (WIDTH=9, 2 mask bits, macro
-        sram_1rw1r_9_4096_8_sky130 tied 2'h3). Both bound cleanly and both lost
-        the mask.
+        this state, both driving a genuinely dynamic mask: triangle_store
+        (WIDTH=64, 8 lanes) and zbuffer_sram (WIDTH=9, 2 lanes). Both used to
+        bind with the mask tied to all-ones and silently lose it; refusing them
+        was honest but left the design unable to reach a netlist at all.
         """
         mp, rtl = _maskless_env(tmp_path, monkeypatch, 64, 8)
-        # Unlike _maskless_env's default, this macro DOES declare wmask0.
+        # This macro DOES declare wmask0, with a matching 8 lanes.
         monkeypatch.setattr(mp, "macro_ports",
                             lambda p: {"clk0", "csb0", "web0", "wmask0",
                                        "addr0", "din0", "dout0"})
+        monkeypatch.setattr(mp, "macro_mask_lanes", lambda p: 8)
         res = mp.resolve_prebindings([rtl], allow_generate=False)
-        assert res.ok is False, "bound a masked geometry the shell cannot route"
-        assert res.unresolved
-        # The diagnosis must name the SHELL, not blame the macro -- otherwise the
-        # reader regenerates a macro that already had the port.
-        joined = " ".join(res.errors)
-        assert "cs_mem_macro_shell" in joined
-        assert "HAS a wmask0 port" in joined
-        assert "full-word writes" in joined
+        assert res.ok is True, res.errors
+        assert res.bindings and not res.unresolved
+        assert res.mask_lanes.get((64, 4096, 2)) == 8
+        # And the emitted shell wires it rather than tying it.
+        assert ".wmask0(wmask0)" in mp.emit_bound_shell(res)
 
-    def test_the_two_refusals_give_DIFFERENT_diagnoses(self, tmp_path, monkeypatch):
-        """Same symptom, opposite fixes: regenerate the macro vs route the pin
-        through the shell. A single shared message would send half the readers
-        to the wrong repair."""
-        mp, rtl = _maskless_env(tmp_path, monkeypatch, 32, 4)
-        maskless = " ".join(
-            mp.resolve_prebindings([rtl], allow_generate=False).errors)
+    def test_lane_count_disagreement_is_refused_not_truncated(
+        self, tmp_path, monkeypatch
+    ):
+        """The old binder replicated `{mask_bits{1'b1}}` and let yosys truncate
+        it -- an 8-bit constant into the 2-bit port of
+        sram_1rw1r_9_4096_8_sky130. A lane-count disagreement decides which
+        BYTES a write touches, so it must refuse."""
+        mp, rtl = _maskless_env(tmp_path, monkeypatch, 64, 8)
         monkeypatch.setattr(mp, "macro_ports",
                             lambda p: {"clk0", "csb0", "web0", "wmask0",
                                        "addr0", "din0", "dout0"})
-        capable = " ".join(
-            mp.resolve_prebindings([rtl], allow_generate=False).errors)
-        assert "no wmask0 port at all" in maskless
-        assert "write_size" in maskless          # regenerate the macro
-        assert "cs_mem_macro_shell" in capable   # route the pin
-        assert maskless != capable
+        monkeypatch.setattr(mp, "macro_mask_lanes", lambda p: 2)   # != 8
+        res = mp.resolve_prebindings([rtl], allow_generate=False)
+        assert res.ok is False and res.unresolved
+        joined = " ".join(res.errors)
+        assert "8 write-mask lane(s)" in joined and "2 lane(s)" in joined
+        assert "truncated" in joined
+
+    def test_unverifiable_lane_count_is_refused(self, tmp_path, monkeypatch):
+        """`None` means the width is an expression we will not evaluate. That is
+        "cannot verify", which must never become a default."""
+        mp, rtl = _maskless_env(tmp_path, monkeypatch, 64, 8)
+        monkeypatch.setattr(mp, "macro_ports",
+                            lambda p: {"clk0", "csb0", "web0", "wmask0",
+                                       "addr0", "din0", "dout0"})
+        monkeypatch.setattr(mp, "macro_mask_lanes", lambda p: None)
+        res = mp.resolve_prebindings([rtl], allow_generate=False)
+        assert res.ok is False and res.unresolved
+        assert "unresolvable" in " ".join(res.errors)
+
+    def test_multibit_mask_against_a_MASKLESS_macro_is_still_refused(
+        self, tmp_path, monkeypatch
+    ):
+        """No wiring can carry 4 lanes to a macro with a single whole-word
+        write enable. Regenerating the macro is the only fix."""
+        mp, rtl = _maskless_env(tmp_path, monkeypatch, 32, 4)
+        res = mp.resolve_prebindings([rtl], allow_generate=False)
+        assert res.ok is False and res.unresolved
+        joined = " ".join(res.errors)
+        assert "no wmask0 port at all" in joined
+        assert "write_size" in joined
 
 
 class TestStructure:

--- a/orchestrator/tests/test_pin_map.py
+++ b/orchestrator/tests/test_pin_map.py
@@ -1,0 +1,159 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The pin assignment is data, and every pad bit gets exactly one driver.
+
+Calibrated against the raster PRD, whose GPIO requirement reads:
+
+    "GPIO mapping is locked: io[0]=qspi_csn input, io[1]=qspi_sck input,
+     io[5:2]=bidirectional qspi_io[3:0], and io[6]=irq output. io_oeb[0]=
+     io_oeb[1]=1, io_oeb[6]=0, and io_oeb[5:2]=0 only during QSPI read-data
+     drive phases; otherwise io_oeb[5:2]=1. All other io_oeb bits are 1 and all
+     unused io_out bits are 0."
+
+Every clause of that sentence is asserted below against generated Verilog.
+"""
+from __future__ import annotations
+
+import json
+
+from orchestrator.architecture.pin_map import (
+    emit_pin_routing,
+    load_pin_map,
+    parse_pin_map,
+)
+
+RASTER = {
+    "bus_width": 38,
+    "entries": [
+        {"signal": "qspi_csn", "dir": "in", "msb": 0, "lsb": 0},
+        {"signal": "qspi_sck", "dir": "in", "msb": 1, "lsb": 1},
+        {"signal": "qspi_io_in", "dir": "in", "msb": 5, "lsb": 2},
+        {"signal": "qspi_io_out", "dir": "out", "msb": 5, "lsb": 2,
+         "oe": "qspi_drive_en"},
+        {"signal": "irq_level", "dir": "out", "msb": 6, "lsb": 6},
+    ],
+}
+
+
+def _emit(raw=RASTER):
+    pm = parse_pin_map(raw)
+    assert pm.ok, pm.errors
+    decls, assigns = emit_pin_routing(pm)
+    return "\n".join(decls), "\n".join(assigns)
+
+
+class TestTheRasterMappingIsReproducedExactly:
+    def test_inputs_are_sliced_off_io_in(self):
+        d, _ = _emit()
+        assert "wire qspi_csn = io_in[0];" in d
+        assert "wire qspi_sck = io_in[1];" in d
+        assert "wire [3:0] qspi_io_in = io_in[5:2];" in d
+
+    def test_outputs_drive_io_out(self):
+        _, a = _emit()
+        assert "assign io_out[5:2] = qspi_io_out;" in a
+        assert "assign io_out[6] = irq_level;" in a
+
+    def test_output_enable_is_inverted_because_oeb_is_active_low(self):
+        """The single most reversible mistake on this boundary: drive the pad
+        exactly when the design wanted to be silent."""
+        _, a = _emit()
+        assert "assign io_oeb[5:2] = {4{~qspi_drive_en}};" in a
+
+    def test_an_output_with_no_enable_drives_permanently(self):
+        """PRD: io_oeb[6]=0."""
+        _, a = _emit()
+        assert "assign io_oeb[6] = 1'b0;" in a
+
+    def test_unused_out_bits_are_zero_and_unused_oeb_bits_are_one(self):
+        """PRD: 'All other io_oeb bits are 1 and all unused io_out bits are 0.'
+        Includes io_oeb[0]=io_oeb[1]=1, which the host owns."""
+        _, a = _emit()
+        assert "assign io_oeb[1:0] = 2'b11;" in a
+        assert "assign io_out[1:0] = 2'b00;" in a
+        assert "assign io_out[37:7] = 31'b" + "0" * 31 + ";" in a
+        assert "assign io_oeb[37:7] = 31'b" + "1" * 31 + ";" in a
+
+    def test_every_bit_of_every_output_bus_has_exactly_one_driver(self):
+        """A floating pad bit is a real defect; a doubly-driven one is a short.
+        Counting drivers is cheaper than trusting the emitter."""
+        import re
+        _, a = _emit()
+        for bus in ("io_out", "io_oeb"):
+            covered = []
+            for m in re.finditer(rf"assign {bus}\[(\d+)(?::(\d+))?\]", a):
+                hi = int(m.group(1))
+                lo = int(m.group(2)) if m.group(2) else hi
+                covered.extend(range(lo, hi + 1))
+            assert sorted(covered) == list(range(38)), f"{bus} driver coverage"
+            assert len(covered) == len(set(covered)), f"{bus} double-driven"
+
+
+class TestRefusalsRatherThanGuesses:
+    def test_two_signals_on_one_bit_is_refused(self):
+        pm = parse_pin_map({"bus_width": 38, "entries": [
+            {"signal": "a", "dir": "in", "msb": 3, "lsb": 0},
+            {"signal": "b", "dir": "in", "msb": 2, "lsb": 2}]})
+        assert not pm.ok
+        assert any("claimed by both" in e for e in pm.errors)
+
+    def test_input_and_output_may_share_a_bit_index(self):
+        """io_in[5:2] and io_out[5:2] are different physical directions of the
+        same bidirectional pad -- that is the normal case, not a collision."""
+        pm = parse_pin_map({"bus_width": 38, "entries": [
+            {"signal": "d_in", "dir": "in", "msb": 5, "lsb": 2},
+            {"signal": "d_out", "dir": "out", "msb": 5, "lsb": 2}]})
+        assert pm.ok, pm.errors
+
+    def test_out_of_range_bits_are_refused(self):
+        pm = parse_pin_map({"bus_width": 8, "entries": [
+            {"signal": "a", "dir": "in", "msb": 9, "lsb": 9}]})
+        assert not pm.ok and any("outside" in e for e in pm.errors)
+
+    def test_a_duplicated_signal_name_is_refused(self):
+        pm = parse_pin_map({"bus_width": 38, "entries": [
+            {"signal": "a", "dir": "in", "msb": 0, "lsb": 0},
+            {"signal": "a", "dir": "out", "msb": 7, "lsb": 7}]})
+        assert not pm.ok and any("mapped 2 times" in e for e in pm.errors)
+
+    def test_an_enable_on_an_input_is_refused(self):
+        pm = parse_pin_map({"bus_width": 38, "entries": [
+            {"signal": "a", "dir": "in", "msb": 0, "lsb": 0, "oe": "en"}]})
+        assert not pm.ok and any("only meaningful" in e for e in pm.errors)
+
+    def test_a_bad_direction_is_refused(self):
+        pm = parse_pin_map({"bus_width": 38, "entries": [
+            {"signal": "a", "dir": "inout", "msb": 0, "lsb": 0}]})
+        assert not pm.ok and any("dir must be" in e for e in pm.errors)
+
+
+class TestLoading:
+    def test_absent_pin_map_is_none_not_an_error(self, tmp_path):
+        """A design that is not on a fixed pinout has no pin map, and that is
+        not a failure -- the caller falls back to its previous behaviour."""
+        (tmp_path / ".coresmith").mkdir()
+        (tmp_path / ".coresmith" / "prd_spec.json").write_text(
+            json.dumps({"prd": {"functional_requirements": []}}))
+        assert load_pin_map(tmp_path) is None
+
+    def test_missing_file_is_none(self, tmp_path):
+        assert load_pin_map(tmp_path) is None
+
+    def test_structured_map_is_loaded(self, tmp_path):
+        (tmp_path / ".coresmith").mkdir()
+        (tmp_path / ".coresmith" / "prd_spec.json").write_text(
+            json.dumps({"prd": {"pin_map": RASTER}}))
+        pm = load_pin_map(tmp_path)
+        assert pm and pm.ok and len(pm.entries) == 5
+
+    def test_prose_is_NOT_parsed(self, tmp_path):
+        """Reading the sentence would put a guess back on the production path,
+        which is the thing this replaces. Prose alone means no pin map."""
+        (tmp_path / ".coresmith").mkdir()
+        (tmp_path / ".coresmith" / "prd_spec.json").write_text(json.dumps({"prd": {
+            "functional_requirements": [
+                "GPIO mapping is locked: io[0]=qspi_csn input, "
+                "io[1]=qspi_sck input, io[5:2]=bidirectional qspi_io[3:0]."]}}))
+        assert load_pin_map(tmp_path) is None

--- a/orchestrator/tests/test_qspi_pin_boundary_gate.py
+++ b/orchestrator/tests/test_qspi_pin_boundary_gate.py
@@ -354,7 +354,7 @@ def _setup_node(monkeypatch, tmp_path, *, wrapper: str = "", qspi: bool = True):
         pipeline_graph, "load_architecture_connections", lambda pr: ([], "chip"))
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda p: VerilogModule(name="a", ports=[VerilogPort("clk", "input")]))
+        lambda p, module=None: VerilogModule(name="a", ports=[VerilogPort("clk", "input")]))
     monkeypatch.setattr(
         pipeline_graph, "run_integration_simulation",
         lambda *a, **k: {"passed": True, "log": "sim ran", "log_path": ""})

--- a/orchestrator/tests/test_rung3_fixes.py
+++ b/orchestrator/tests/test_rung3_fixes.py
@@ -162,7 +162,8 @@ def _wire_mismatch_design(monkeypatch, *, src_width=8, dst_width=16):
     )
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda path: modules["a"] if path.endswith("a.v") else modules["b"],
+        lambda path, module=None: (modules["a"] if path.endswith("a.v")
+                                   else modules["b"]),
     )
     monkeypatch.setattr(
         pipeline_graph, "lint_top_level",

--- a/orchestrator/tests/test_rung3_fixes2.py
+++ b/orchestrator/tests/test_rung3_fixes2.py
@@ -234,7 +234,7 @@ def _wire_integration_node(monkeypatch, tmp_path, *, tb_body):
         pipeline_graph, "load_architecture_connections", lambda pr: ([], "chip"))
     monkeypatch.setattr(
         pipeline_graph, "parse_verilog_ports",
-        lambda p: VerilogModule(name="a", ports=[VerilogPort("clk", "input")]))
+        lambda p, module=None: VerilogModule(name="a", ports=[VerilogPort("clk", "input")]))
     monkeypatch.setattr(
         pipeline_graph, "run_integration_simulation",
         lambda *a, **k: {"passed": True, "log": "sim ran", "log_path": ""})


### PR DESCRIPTION
Stacked on #76. Takes the raster design from "cannot assemble" to a passing chip-level gate-sim verdict, and makes each blocker a checked property of the engine.

## The verdict

```
[PREBIND] bound 3 memory geometry(ies) to concrete macros before synthesis
[FLAT-SYNTH] bound 3 macro shell(s): sram_1rw1r_{9_4096,8_4096,64_64}_8_sky130
[CHIP-GATE-SIM] PASS -- flat netlist reproduced the verified chip RTL
                (1169 cycles, 280560 output bits)
```

Full-length replay of the 23,380 ns contract-enforcing conformance run, every Caravel output bit, zero divergence, divergence-debug armed. Deterministic assembly went **40 → 18 → 8 → 0 wiring hazards** on the same design.

## What landed

- **Contract-directed stitching**: each edge end resolves against the contract's own `fields[] + sideband_signals[]` (which three layers were discarding), never against the other end — positional pairing and suffix heuristics deleted.
- **Deterministic port-name conformance + repair**: a per-block checker calibrated on real RTL (an early stricter version failed 6/8 blocks because the *check* was wrong), plus three unambiguous-only repair tiers. Measured motivation: the generator kept its deviations through four fresh regenerations that were handed the exact required names.
- **Pin map as PRD data**: the pad assignment moves from prose to a validated `pin_map`; the top routes `io_in/io_out/io_oeb` itself (every bit exactly one driver, active-low `oeb` handled), and the pin-adapter block — which the generator rendered as a competing chip top 4/4 times because its mandated name means "the whole chip" — is deleted from the design.
- **Write mask routed through the macro shell**: `USE_WMASK=1` designs get real per-lane writes in the macro-backed netlist (lane count read from the macro's own Verilog, never `mask_bits`, which reported 8 for a 2-lane macro); whole-word masks fold into `web0` structurally.
- **Parse the block's own module**: three integration loops judged whichever module came first in a file; 22 of 40 wiring hazards were phantoms from a sub-stage's ports.
- **Inert-inout rule**: a mandated-but-unused pad bus (Caravel `analog_io`, constant-Z tie) no longer vetoes the gate — proven inert structurally, never by name.
- **Alias-carrier exclusion**: a block file re-declaring the top's module (with sibling stubs that shadow real logic in the dedup) leaves the reference source list — the gate's reference now elaborates exactly what the passing DV elaborated.
- Generated conformance TBs carry the `from __future__ import annotations` their inlined contract class requires — before this, every generated TB died at import, indistinguishable at the summary level from the DUT failing DV. Two long-red baseline tests now pass because of it.

## Known limits (deliberate, ledgered)

- The verdict was produced by driving the backend nodes directly over the run's real artifacts. The *autonomous* path still parks earlier: the conformance TB generator doesn't emit `# MAXGEO` coverage, and the frontend→backend handoff isn't wired. Both are follow-ups.
- One disclosed RTL hand-patch on the run (not the engine): a +2 `wb_clk` output-delay fixing a measured 20 ns sample race, applied after three regenerations declined to express it. The systematic finding — the generator transcribes named artifacts reliably but does not translate relational (structural/timing) requirements — is recorded, 0/7 across both shapes.
- Architecture still has no cross-artifact consistency check (5 contradictions across 4 artifacts were fixed by hand during validation; the ERS is currently written *after* the only architecture gate, so the fix needs an emission reorder plus a catalog entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBWgL9qExhCeRdRMAXv7yX
