### PR TITLE
Contract conformance in the per-block flow + gate honesty fixes

### DIFF
--- a/orchestrator/architecture/model_integration.py
+++ b/orchestrator/architecture/model_integration.py
@@ -1151,16 +1151,68 @@ def _slice_reachability_probe(project_root: str, ref_path: str,
     return out
 
 
+#: A probe verdict that says what actually happened, not just that nothing
+#: complained. ``pass`` requires a DISCRIMINATING check to have concluded --
+#: one capable of returning the other answer. ``not_run`` is the honest verdict
+#: when only the structural checks ran: the model imports and exposes a factory,
+#: which says nothing about whether its math is ever exercised.
+VERDICT_PASS = "pass"
+VERDICT_FAIL = "fail"
+VERDICT_NOT_RUN = "not_run"
+
+
+def _golden_feasibility_verdict(result: dict) -> dict:
+    """Fill in the tri-state ``verdict`` (+ its reason) from the checks that ran.
+
+    Every block of the first hands-off run logged
+    ``golden-feasibility OK (skipped)`` in GREEN -- an OK whose parenthetical
+    said, in the same breath, that the only discriminating check had not run.
+    The probe's CONTENT is unchanged here; what it CLAIMS is not.
+    """
+    checks = result.get("checks") or {}
+    reach = checks.get("slice_reachability") or {}
+    if not result.get("ran"):
+        result["verdict"] = VERDICT_NOT_RUN
+        result["discriminating"] = False
+        return result
+    if not result.get("passed"):
+        result["verdict"] = VERDICT_FAIL
+        result["discriminating"] = True
+        return result
+    if reach.get("verdict") == "reachable":
+        result["verdict"] = VERDICT_PASS
+        result["discriminating"] = True
+        return result
+    result["verdict"] = VERDICT_NOT_RUN
+    result["discriminating"] = False
+    result["not_run_reason"] = (
+        "the model imports and exposes a @block factory, but the only "
+        "DISCRIMINATING check -- slice reachability, which runs the golden "
+        "reference and watches whether this block's slice functions are "
+        "actually called and produce output -- did not conclude: "
+        + (str(reach.get("reason") or "no reachability result")) + ". "
+        "Nothing here has exercised the model's math, so this is not evidence "
+        "the model is non-degenerate."
+    )
+    return result
+
+
 def check_golden_feasibility(project_root: str, block_name: str) -> dict:
     """Probe whether a generated block golden/model is non-degenerate.
 
-    Returns ``{block, ran, passed, skipped, reason, checks}``; never raises. Used
-    by ``_maybe_generate_block_golden`` (to close the swallow) and by the
-    ``coresmith golden-check`` CLI. Writes the verdict to
-    ``.coresmith/blocks/<b>/golden_feasibility.json``.
+    Returns ``{block, ran, passed, skipped, verdict, discriminating, reason,
+    checks}``; never raises. Used by ``_maybe_generate_block_golden`` (to close
+    the swallow) and by the ``coresmith golden-check`` CLI. Writes the verdict
+    to ``.coresmith/blocks/<b>/golden_feasibility.json``.
+
+    ``passed`` keeps its meaning (nothing the probe checked came back bad) and
+    still drives ``CORESMITH_GOLDEN_FEASIBILITY_GATE``; ``verdict`` is the
+    honest tri-state -- ``pass`` only when a check that COULD have said
+    otherwise concluded.
     """
     result = {"block": block_name, "ran": False, "passed": True,
-              "skipped": False, "reason": "", "checks": {}}
+              "skipped": False, "verdict": VERDICT_NOT_RUN,
+              "discriminating": False, "reason": "", "checks": {}}
     try:
         from orchestrator.architecture import composition as _composition
         if not _composition.block_goldens_enabled():
@@ -1200,6 +1252,7 @@ def check_golden_feasibility(project_root: str, block_name: str) -> dict:
 
 def _persist_golden_feasibility(project_root: str, block_name: str,
                                 result: dict) -> dict:
+    _golden_feasibility_verdict(result)
     try:
         import json as _json
         bdir = Path(project_root) / ".coresmith" / "blocks" / block_name

--- a/orchestrator/architecture/model_integration.py
+++ b/orchestrator/architecture/model_integration.py
@@ -1290,8 +1290,9 @@ def _classify_gap(project_root: str, expected: Any, observed: Any) -> str:
     composed correctly and ONE downstream block emitted wrong/short content. That
     is ``block_math`` (route to a single-block re-spec, not a whole-chip re-fan).
     Only a divergence at/near offset 0 (no shared framing) is a true ``contract``
-    width/framing mismatch. Keystone fix: the length-only heuristic sent the Opus
-    codec's entropy coding bug (byte-32 residual) down the contract path and re-fanned all
+    width/framing mismatch. Keystone fix: the length-only heuristic sent a
+    measured single-block content defect (a divergence starting at byte 32, well
+    past the shared framing prefix) down the contract path and re-fanned all
     8 blocks twice (>55% of that run's token budget).
     """
     if _prefix_classify_enabled() and _is_byteseq(expected) and _is_byteseq(observed):
@@ -1489,6 +1490,189 @@ def _attach_stall_autopsy(project_root: str, violations: list[dict]) -> list[dic
         except Exception:  # noqa: BLE001
             pass
     return violations
+
+
+# ---------------------------------------------------------------------------
+# Per-block localization fallback for a composition TIMEOUT
+# ---------------------------------------------------------------------------
+#
+# When the composed model runs unbounded, there is no divergence offset to trace
+# and no traceback to read, so the failure reported "First-divergence block:
+# (unlocalized)" -> broadcast re-spec of every block. A timeout is exactly the
+# case where saying WHERE matters most (a stall has ONE first cause), and it was
+# the case that said the least.
+#
+# The stall autopsy above is the dynamic answer, but it only exists when an edge
+# monitor wrote the file. This is the deterministic fallback that always runs: a
+# per-block probe over the composition itself. Nothing here simulates anything --
+# it reads what the composition wired and what each block model can even be
+# imported to be -- so it is fast, safe on a hung run, and unit-testable.
+
+def stall_localization_enabled() -> bool:
+    """True (default) -> a composition timeout is localized by the block probe.
+
+    ``CORESMITH_GATE_STALL_LOCALIZE=0`` restores the pre-fix behaviour (report
+    ``(unlocalized)`` and broadcast). Both branches are tested.
+    """
+    return os.environ.get(
+        "CORESMITH_GATE_STALL_LOCALIZE", "1"
+    ).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _instance_ports(chip_model_src: str) -> dict[str, list[str]]:
+    """``{block_name: [signal identifiers wired into it]}`` from the composition.
+
+    Parses ``m.submodules.<inst> = <BlockClass>(<name>, kw=<name>, ...)`` out of
+    ``_chip_model.py`` with the ast module -- no regex guessing at Python syntax.
+    Blocks are keyed by the CLASS name (which is the block-model module name, the
+    identifier every other localization path uses). ``{}`` on any parse failure.
+    """
+    import ast as _ast
+
+    out: dict[str, list[str]] = {}
+    try:
+        tree = _ast.parse(chip_model_src)
+    except SyntaxError:
+        return out
+    for node in _ast.walk(tree):
+        if not isinstance(node, _ast.Assign) or not isinstance(node.value, _ast.Call):
+            continue
+        call = node.value
+        cls = ""
+        if isinstance(call.func, _ast.Name):
+            cls = call.func.id
+        elif isinstance(call.func, _ast.Attribute):
+            cls = call.func.attr
+        if not cls:
+            continue
+        # only ``m.submodules.<x> = ...`` / ``m.submodules += ...`` targets
+        targets_submodule = False
+        for tgt in node.targets:
+            src = _ast.dump(tgt)
+            if "submodules" in src:
+                targets_submodule = True
+        if not targets_submodule:
+            continue
+        names: list[str] = []
+        for arg in list(call.args) + [kw.value for kw in call.keywords]:
+            if isinstance(arg, _ast.Name):
+                names.append(arg.id)
+        if names:
+            out.setdefault(cls, []).extend(names)
+    return out
+
+
+def _identifier_counts(chip_model_src: str) -> dict[str, int]:
+    """How many times each identifier is READ in the composition source.
+
+    LOAD contexts only: a signal's own ``x = Signal(8)`` declaration is not a
+    use of it, and counting it would hide the very thing we are looking for (a
+    signal whose ONLY use is the one block instantiation it is passed to).
+    """
+    import ast as _ast
+
+    counts: dict[str, int] = {}
+    try:
+        tree = _ast.parse(chip_model_src)
+    except SyntaxError:
+        return counts
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Name) and isinstance(node.ctx, _ast.Load):
+            counts[node.id] = counts.get(node.id, 0) + 1
+    return counts
+
+
+def probe_composition_stall(project_root: str, models_dir) -> dict:
+    """Per-block probe for a composition that never returned. NEVER raises.
+
+    Two deterministic checks, both of which name a BLOCK:
+
+      * ``import_failures`` -- the block model does not even import standalone.
+        A composition that hangs around an unimportable block is localized.
+      * ``dangling`` -- signals wired into exactly ONE block instance and read
+        nowhere else in the composition. A block output nothing consumes never
+        moves a downstream handshake, and a block input nothing drives is stuck
+        at its reset value: both are stall causes with a name attached.
+
+    Returns ``{"blocks": [...], "import_failures": {...}, "dangling": {...},
+    "candidates": [...], "summary": str}``. ``candidates`` is the ordered list of
+    blocks the evidence points at; empty means the probe found nothing and the
+    caller must keep saying ``(unlocalized)`` rather than guess.
+    """
+    report: dict = {
+        "blocks": [], "import_failures": {}, "dangling": {},
+        "candidates": [], "summary": "",
+    }
+    try:
+        d = Path(models_dir)
+        if not d.is_dir():
+            return report
+        blocks = sorted(
+            p.stem for p in d.glob("*.py")
+            if not p.name.startswith("__") and p.stem != "_chip_model"
+        )
+        report["blocks"] = blocks
+
+        for name in blocks:
+            try:
+                _import_module_from_path(d / f"{name}.py", f"_cs_probe_{name}")
+            except Exception as exc:  # noqa: BLE001 - that IS the finding
+                report["import_failures"][name] = f"{type(exc).__name__}: {exc}"
+
+        chip = d / "_chip_model.py"
+        if chip.exists():
+            try:
+                src = chip.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                src = ""
+            if src:
+                ports = _instance_ports(src)
+                counts = _identifier_counts(src)
+                for cls, names in sorted(ports.items()):
+                    if cls not in blocks:
+                        continue
+                    # A signal referenced ONCE in the whole composition is
+                    # referenced only by this instantiation: nothing on the other
+                    # side of it.
+                    lonely = sorted({n for n in names if counts.get(n, 0) <= 1})
+                    if lonely:
+                        report["dangling"][cls] = lonely
+
+        candidates = list(report["import_failures"]) + [
+            b for b in report["dangling"] if b not in report["import_failures"]
+        ]
+        report["candidates"] = candidates
+        report["summary"] = _format_stall_localization(report)
+    except Exception:  # noqa: BLE001 - a diagnostic must not replace the failure
+        return report
+    return report
+
+
+def _format_stall_localization(report: dict) -> str:
+    """Human/LLM-readable rendering of :func:`probe_composition_stall`."""
+    lines: list[str] = []
+    imports = report.get("import_failures") or {}
+    dangling = report.get("dangling") or {}
+    if not imports and not dangling:
+        return ""
+    lines.append(
+        "PER-BLOCK STALL PROBE (the composed sim never returned, so there is no "
+        "divergence offset and no traceback -- this is what the composition "
+        "itself says):"
+    )
+    for name, err in sorted(imports.items()):
+        lines.append(
+            f"  block {name}: its block model DOES NOT IMPORT standalone -- {err}"
+        )
+    for name, ports in sorted(dangling.items()):
+        lines.append(
+            f"  block {name}: {len(ports)} signal(s) wired into this instance and "
+            f"read NOWHERE else in _chip_model.py -- an output nothing consumes "
+            f"never advances a downstream handshake, and an input nothing drives "
+            f"holds at its reset value: {', '.join(ports[:12])}"
+            + (" ..." if len(ports) > 12 else "")
+        )
+    return "\n".join(lines)
 
 
 _SIGNATURE_ERROR_MARKERS = (
@@ -1814,23 +1998,41 @@ def _run_full_model_dv(
                 _state.write_text(_json.dumps({"timeouts": _prior + 1}))
             except Exception:  # noqa: BLE001
                 pass
+            # Same localization fallback as the default-tier timeout: a stall
+            # that cannot say WHERE broadcasts a re-spec to every block.
+            _fmdv_probe: dict = {}
+            _fmdv_block = _first_divergence_block(project_root)
+            if stall_localization_enabled():
+                _fmdv_probe = probe_composition_stall(project_root, models_dir)
+                _c = _fmdv_probe.get("candidates") or []
+                if len(_c) == 1 and not _fmdv_block:
+                    _fmdv_block = _c[0]
+            _fmdv_where = (
+                _fmdv_block,
+                (f" LOCALIZED to block {_fmdv_block!r}." if _fmdv_block
+                 else " NOT localized to a single block (the probe found no "
+                      "single-block evidence)."),
+            )
             violations.append(_attach_stall_autopsy(project_root, [{
                 "type": "model_integration_failure",
                 "criterion": "full_model_dv_timeout",
                 "stimulus_tier": "acceptance",
                 "acceptance_case": str(name),
-                "first_divergence_block": _first_divergence_block(project_root),
+                "first_divergence_block": _fmdv_where[0],
                 "expected": expected,
                 "observed": f"full-model-dv simulate() did not return within "
-                            f"{budget:.0f}s on acceptance case {name!r}",
+                            f"{budget:.0f}s on acceptance case {name!r}."
+                            + _fmdv_where[1],
                 "gap_class": "contract",
+                "stall_localization": _fmdv_probe,
                 "suggested_fix": (
                     "The composed model cannot process the mission-scale "
                     "acceptance stimulus within the Full Model DV budget. "
                     "Next attempt auto-extends (x1.5, cap "
                     f"{_cap:.0f}s); use CORESMITH_SIM_PYTHON=pypy3 to JIT the "
                     "Amaranth sim if not already."
-                ),
+                ) + (("\n\n" + str(_fmdv_probe.get("summary") or ""))
+                     if _fmdv_probe.get("summary") else ""),
             }])[0])
             break
         if sim_exc is not None:
@@ -2306,15 +2508,35 @@ def _run_gate_inner(
         simulate, chip_model_path, models_dir, stimulus, sim_timeout
     )
     if timed_out:
+        # LOCALIZE. "(unlocalized)" on a timeout broadcasts a re-spec to every
+        # block, and a stall has ONE first cause. The per-block probe reads what
+        # the composition wired and what each block model imports to; when it
+        # points at exactly ONE block that block is NAMED, and the evidence is
+        # attached either way.
+        _probe: dict = {}
+        _fdb_timeout = _first_divergence_block(project_root)
+        if stall_localization_enabled():
+            _probe = probe_composition_stall(project_root, models_dir)
+            _cands = _probe.get("candidates") or []
+            if len(_cands) == 1 and not _fdb_timeout:
+                _fdb_timeout = _cands[0]
+        _probe_txt = str(_probe.get("summary") or "")
+        _where = (
+            f" LOCALIZED to block {_fdb_timeout!r}." if _fdb_timeout
+            else " NOT localized to a single block (the probe found no "
+                 "single-block evidence)."
+        )
         return _attach_stall_autopsy(project_root, [
             {
                 "type": "model_integration_failure",
-                "first_divergence_block": _first_divergence_block(project_root),
+                "first_divergence_block": _fdb_timeout,
                 "expected": expected,
                 "observed": f"simulate() did not return within {sim_timeout:.0f}s "
-                            "(no output frame-end / runaway emission / deadlock)",
+                            "(no output frame-end / runaway emission / deadlock)."
+                            + _where,
                 "criterion": "simulate_timeout",
                 "gap_class": "contract",
+                "stall_localization": _probe,
                 "suggested_fix": (
                     "The integrated chip model's simulate() ran unbounded. Usually "
                     "the pipeline never asserts the output frame-end (m_axis_tlast) "
@@ -2322,7 +2544,7 @@ def _run_gate_inner(
                     "emission to the frame, and that simulate() has a hard cycle cap "
                     "(see prompt). Raise CORESMITH_GATE_SIM_TIMEOUT for a legitimately "
                     "long sim."
-                ),
+                ) + (("\n\n" + _probe_txt) if _probe_txt else ""),
             }
         ])
     if sim_exc is not None:
@@ -2475,7 +2697,8 @@ def _run_gate_inner(
             # Legacy escape hatch (opt-in): the OLD, too-weak Tier-B check that
             # accepted any NON-DEGENERATE output WITHOUT comparing it to the
             # reference. This let a composition streaming a handful of garbage
-            # bytes pass (e.g. the codec that emitted ~0.5% of the reference
+            # bytes pass (e.g. a measured composition that emitted ~0.5% of the
+            # reference
             # bytes yet "passed"). Kept only for designs with genuinely no usable
             # oracle comparison.
             if _is_degenerate(observed_norm):

--- a/orchestrator/architecture/model_integration.py
+++ b/orchestrator/architecture/model_integration.py
@@ -73,10 +73,10 @@ def _import_module_from_path(path: Path, mod_name: str):
 
     Audit F2: the module's OWN directory goes on ``sys.path`` for the duration
     of the import. Project reference implementations and stimulus files live in
-    ``inputs/`` and import sibling helpers by plain name (e.g. the reference_codec
-    golden's ``import reference_codec_vectors``) -- without the parent dir on the path
-    that import raises ``No module named ...`` and the gate used to swallow it
-    as a no-op.
+    ``inputs/`` and import sibling helpers by plain name (a reference
+    implementation's ``import <its>_vectors``) -- without the parent dir on the
+    path that import raises ``No module named ...`` and the gate used to
+    swallow it as a no-op.
     """
     import sys
 
@@ -588,8 +588,8 @@ def _field_localization_enabled() -> bool:
     PRODUCING SUB-CHAIN of only the diverging output field(s).
 
     This is the convergence fix for framework-HDL composition runs: a wrong-bytes
-    divergence in ONE field of a multi-field output (e.g. a video codec's
-    ``{"bitstream": ..., "recon": ..., "stats": ...}``) is localizable to the
+    divergence in ONE field of a multi-field output (a design that emits
+    several named streams at once) is localizable to the
     blocks that feed that field, so a gate-triggered re-spec touches only those
     blocks and KEEPS the (passing) blocks of the other fields' sub-chains.
     Without this the gate returns no ``affected_blocks`` and the daemon
@@ -646,7 +646,8 @@ def _is_sideband_block(name: str, bd: dict) -> bool:
         if b.get("name") == name:
             desc = (b.get("description") or "").lower()
             # A block that explicitly does NOT participate in functional decisions
-            # is a pure monitor (video_codec lifecycle_status_monitor says exactly this).
+            # is a pure monitor (a status/telemetry block says exactly this
+            # of itself in its own description).
             if "without participating" in desc or "does not participate" in desc:
                 return True
     return False
@@ -808,9 +809,9 @@ def _localize_affected_blocks(
 
     conns = _bd_connections(bd)
     # Producer sub-chains follow the FUNCTIONAL DATAPATH only. The status/monitor
-    # sideband (every block -> lifecycle_status_monitor via event_axis) is NOT a
-    # datapath: a passing ``stats`` field proves the monitor good, it does NOT
-    # prove the datapath blocks that merely report to it good. Walking datapath
+    # sideband (every block -> a status/telemetry block over an event bus) is
+    # NOT a datapath: a passing status field proves the monitor good, it does
+    # NOT prove the datapath blocks that merely report to it good. Walking datapath
     # edges keeps the shared-prefix subtraction honest.
     dp_conns = _datapath_connections(conns, bd)
 
@@ -848,12 +849,13 @@ def _localize_affected_blocks(
 
     # Forward extension (bounded): a diverging field's value is also touched by
     # the datapath blocks that FORWARD/serialize it downstream to the chip
-    # boundary -- they can corrupt it too (e.g. entropy_bitstream_engine ->
-    # output_stream_adapter). Walk forward from each diverging terminal, but STOP
+    # boundary -- they can corrupt it too (an encoder stage feeding an output
+    # serializer). Walk forward from each diverging terminal, but STOP
     # at any block that is a PASSING field's terminal or lies in a passing field's
     # producer region: the diverging value does not flow THROUGH a block that is
     # busy producing a (correct) different output, so crossing it would be a
-    # false-positive (the recon-terminal -> entropy case). This keeps the
+    # false-positive (a passing field's terminal feeding the diverging one's
+    # producer). This keeps the
     # extension to the diverging field's OWN tail.
     outgoing: dict[str, list[str]] = {}
     for e in dp_conns:
@@ -878,9 +880,8 @@ def _localize_affected_blocks(
     # so it is proven-good and is NOT the culprit for the diverging field.
     # Re-spec only the blocks EXCLUSIVE to the diverging field(s) (the field's own
     # tail). This is the sharpest honest localization: it keeps every block that
-    # any passing field exercised. (For codecv4: recon proves
-    # input/pixel_block/intra good, so bitstream's exclusive tail =
-    # entropy_bitstream_engine + output_stream_adapter.)
+    # any passing field exercised: a passing field's sub-chain is proven good,
+    # so the diverging field's EXCLUSIVE tail is what is left to re-spec.
     exclusive = div_blocks - pass_blocks
     affected = exclusive if exclusive else (div_blocks - (pass_blocks - div_blocks))
     # Keep deterministic block-diagram order (``order`` computed at function top).
@@ -943,7 +944,7 @@ def _is_degenerate(observed: Any) -> bool:
     """True when ``observed`` is degenerate (all-zero / constant / None / empty).
 
     Used by the functional Tier-B non-degenerate fallback: a flat / collapsed
-    output (the class of bug that shipped the codec flat-output) is rejected
+    output (the class of bug that ships a design with a flat output) is rejected
     even without a declared acceptance predicate. Numpy/bytes-safe.
     """
     if observed is None:
@@ -1029,12 +1030,12 @@ def first_divergence_offset(expected: Any, observed: Any) -> int:
 # decomposed block).
 #
 # SCOPE (honest): a *sophisticated* stub -- one that drives the right ports but
-# routes the primary DATA path to a terminal error (the reference codec's dct_token_engine
-# emitting m_axis_error_completion instead of m_axis_fragment_coeff) -- is NOT
+# routes the primary DATA path to a terminal error (a transform stage emitting
+# its error-completion channel instead of its payload channel) -- is NOT
 # caught here. Detecting that requires simulating the block MODEL and byte-
 # comparing to the golden's boundary I/O, which needs a per-block Amaranth sim
 # harness + a confident block->golden slice (Phase 2's generalized mapping). That
-# is the documented follow-up. For the reference codec-class stub the uarch FEASIBILITY
+# is the documented follow-up. For that class of stub the uarch FEASIBILITY
 # gate (Phase 1) is the live backstop: it stops the block at spec time, before a
 # model is ever generated. This probe closes the *other* half -- the swallow.
 # ---------------------------------------------------------------------------
@@ -1056,9 +1057,9 @@ def _slice_reachability_probe(project_root: str, ref_path: str,
 
     Robust by construction: concludes 'reachable'/'unreachable' ONLY when the
     slice functions resolve to module-level callables we can actually intercept
-    (free-function goldens, e.g. the video codec). For method-based goldens (the reference codec's
-    stateful decoder methods) module-level instrumentation does not apply, so we
-    honest-SKIP rather than risk a false 'unreachable'. Never raises.
+    (free-function goldens). For method-based goldens (a stateful reference
+    whose slice lives in methods) module-level instrumentation does not apply,
+    so we honest-SKIP rather than risk a false 'unreachable'. Never raises.
     """
     out = {"verdict": "skipped", "reason": "", "calls": {}}
     import json as _json
@@ -1264,7 +1265,7 @@ def _persist_golden_feasibility(project_root: str, block_name: str,
     return result
 
 
-# A real header/framing prefix (parameter-set/group_header) is comfortably longer than
+# A real header/framing prefix is comfortably longer than
 # this; a genuine width/framing mismatch diverges at or near offset 0.
 _PREFIX_CLASSIFY_MIN = 8
 
@@ -1284,7 +1285,7 @@ def _classify_gap(project_root: str, expected: Any, observed: Any) -> str:
 
     PREFIX PROBE (CORESMITH_GATE_PREFIX_CLASSIFY, default on): for byte/seq
     outputs, length alone is misleading. A 238-byte golden vs a 50-byte composed
-    output that is BYTE-EXACT through byte 31 (the parameter-set/group_header framing)
+    output that is BYTE-EXACT through byte 31 (a header/framing prefix)
     and only then diverges/truncates is NOT a framing contract gap -- the chain
     composed correctly and ONE downstream block emitted wrong/short content. That
     is ``block_math`` (route to a single-block re-spec, not a whole-chip re-fan).
@@ -1590,7 +1591,7 @@ def _run_simulate_subprocess(chip_model_path, models_dir, stimulus,
     """Run ``simulate(stimulus)`` in a subprocess under ``interpreter``.
 
     Set ``CORESMITH_SIM_PYTHON=pypy3`` to JIT the pure-Python model sim (the
-    full-QCIF codec sim was ~430 s on CPython) WITHOUT running the whole
+    largest measured model sim was ~430 s on CPython) WITHOUT running the whole
     CPython daemon (FastAPI/pydantic/numpy/otel -- slow under PyPy's cpyext)
     under PyPy. The subprocess timeout actually KILLS a runaway sim, unlike the
     un-interruptible daemon thread. Returns ``(result, timed_out, exc)``.
@@ -1738,8 +1739,8 @@ def _run_full_model_dv(
     """FULL MODEL DV [dv-hardening-14]: mission-scale model-vs-golden.
 
     The armC lesson: the fast composition gate certified a 30dB floor on a
-    single-pixel_block stimulus (no cascade depth); real textured full-frame
-    content landed at ~21-23dB and no downstream gate could see it
+    single-tile stimulus (no cascade depth); real mission-scale content landed
+    at ~21-23dB and no downstream gate could see it
     (integration DV's oracle IS the model). This tier re-runs the SAME
     model-vs-golden comparison on the FRD's mission-scale acceptance stimulus
     (full frame / full audio segment / full program -- domain-generic: the
@@ -2115,8 +2116,8 @@ def _run_gate_inner(
     except Exception as exc:  # noqa: BLE001
         # Audit F2: a reference that RESOLVES but cannot be IMPORTED is a
         # broken oracle, not a goldenless run -- swallowing it as a no-op is
-        # how the encoder CLI printed "composed model == golden byte-exact"
-        # after "No module named 'reference_codec_vectors'". Report a violation.
+        # how a CLI printed "composed model == golden byte-exact" after a
+        # bare "No module named ..." from the reference. Report a violation.
         logger.warning(
             "model integration gate: reference import failed: %s -- violation "
             "(NOT a pass)", exc
@@ -2176,7 +2177,7 @@ def _run_gate_inner(
     # STATIC COMPOSITION AUDIT (pre-sim). Catches the mechanical wiring-defect
     # classes (bad kwargs, undriven nets, zero-width Signals, .symdict wiring)
     # in milliseconds WITH actionable feedback, instead of burning a full
-    # simulate-and-diff round to discover them (the 2026-07 video_codec A/B burned 10+
+    # simulate-and-diff round to discover them (a measured A/B burned 10+
     # attempts across two worker models on exactly these). Runs after all the
     # no-op early-returns above so gate no-op semantics are unchanged.
     from orchestrator.architecture.composition_audit import audit_violations

--- a/orchestrator/architecture/pin_map_retire.py
+++ b/orchestrator/architecture/pin_map_retire.py
@@ -1,0 +1,448 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""A declared pin map RETIRES the pad-adapter block, before it is generated.
+
+``orchestrator/architecture/pin_map.py`` made the shuttle's pin assignment DATA,
+and ``generate_caravel_wrapper_top`` emits the routing from it -- then DROPS the
+pad-adapter block, because the top now does the adapter's whole job. That fixed
+assembly. It did not fix the flow: the block was still in the BLOCK QUEUE, so
+the run kept paying to microarchitect, generate, lint and gate a module the chip
+does not contain.
+
+That cost is not theoretical. The adapter's module name is mandated to be
+``user_project_wrapper``, which by convention means "the entire chip", and the
+generator produced a full chip top instead of a leaf adapter 6 times out of 6
+across three runs -- with explicit corrective feedback each time. The in-flow
+conformance gate then correctly refused the shape (13 deviations: 6 missing
+channel ports, 7 sibling instantiations) and parked the run twice
+(``contract_conformance_unrepairable``). Both hands-off attempts died there.
+
+Refusing the wrong shape after generating it is the right gate on the wrong
+question. The design does not contain this block at all once a pin map covers
+it, so the flow must not ask for it. This module answers, deterministically:
+
+    Is block B the pad adapter, and does the PRD pin map COVER what B was
+    contracted to translate?
+
+Both halves are evidence, never a name:
+
+* **Pad adapter** -- the block carrying the LOCKED Caravel boundary. Identified
+  the way the rest of the engine already identifies it: an ``interfaces`` group
+  in its architecture entry declaring all of io_in/io_out/io_oeb (the same
+  ``_LOCKED_BOUNDARY_PORTS`` triple ``contract_conformance.check_block`` uses for
+  ``locked_boundary``), or an ``rtl_target`` whose module is the Caravel top
+  (the same ``CARAVEL_TOP_MODULE`` ``detect_wrapper_block`` prefers), or -- once
+  RTL exists -- a module declaring that boundary. No block NAME is matched.
+
+* **Coverage** -- every signal the interface contract says the block translates
+  (each touching edge's ``fields`` + ``sideband_signals``, the union that
+  ``contract_conformance._signal_names`` computes) must appear in the pin map,
+  either as a mapped signal or as an output-enable. Six signals on the run that
+  motivated this; the pin map maps five plus one ``oe``. Exactly covered.
+
+PARTIAL coverage is NOT a retirement. A boundary where the top routes some pads
+and a block routes the rest is a contradiction the operator has to resolve --
+the two would fight over the same bus -- so :func:`plan_retirement` returns
+``park=True`` and the caller raises an interrupt instead of guessing. ZERO
+coverage means this pin map is not about this block; nothing is retired and the
+flow is unchanged (loudly logged, because the assembler drops the adapter on a
+valid pin map regardless and an operator should know the two disagree).
+
+``CORESMITH_PINMAP_RETIRES_ADAPTER=0`` restores the previous behaviour: the
+block is generated, and the assembler drops it afterwards as before.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: The externally mandated Caravel pad vector. Same triple as
+#: ``contract_conformance._LOCKED_BOUNDARY_PORTS`` and
+#: ``integration_helpers._PAD_IO_PORTS`` -- a block declaring all three carries
+#: the locked boundary.
+LOCKED_BOUNDARY_PORTS = ("io_in", "io_out", "io_oeb")
+
+#: The shuttle-mandated top module name (mirrors
+#: ``integration_helpers.CARAVEL_TOP_MODULE``; duplicated rather than imported so
+#: this module stays import-light for the harness).
+CARAVEL_TOP_MODULE = "user_project_wrapper"
+
+#: Recorded in state / on disk as the block's skip reason.
+RETIRE_REASON = "retired_by_pin_map"
+
+#: Carried artifact, read by the final report.
+ARTIFACT_NAME = "retired_blocks.json"
+
+#: Written into the retired block's own directory so the reason is where a
+#: reader of that block looks.
+BLOCK_NOTE_NAME = "RETIRED_BY_PIN_MAP.md"
+
+
+def retirement_enabled() -> bool:
+    """Retire the pad adapter when a pin map covers it (default ON).
+
+    ``CORESMITH_PINMAP_RETIRES_ADAPTER=0`` restores the previous behaviour.
+    """
+    return (os.environ.get("CORESMITH_PINMAP_RETIRES_ADAPTER", "1")
+            or "1").strip().lower() not in {"0", "false", "no", "off"}
+
+
+# ---------------------------------------------------------------------------
+# Evidence: which block is the pad adapter?
+# ---------------------------------------------------------------------------
+
+def _architecture_blocks(project_root) -> dict:
+    """``block_diagram.json`` entries by name (the richest block metadata).
+
+    ``block_specs.json`` / ``block_queue.json`` carry only name/tier/rtl_target;
+    the ``interfaces`` map that records the locked boundary lives here.
+    """
+    p = Path(project_root) / ".coresmith" / "block_diagram.json"
+    try:
+        doc = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    blocks = doc.get("blocks") if isinstance(doc, dict) else doc
+    out: dict = {}
+    for b in blocks or []:
+        if isinstance(b, dict) and b.get("name"):
+            out[str(b["name"])] = b
+    return out
+
+
+def _spec_declares_locked_boundary(spec: dict) -> bool:
+    """Does this block's architecture entry declare the Caravel pad vector?
+
+    Looks inside ``interfaces`` (``{group: {port: width}}``) and, defensively,
+    at any top-level ``ports``/``signals`` mapping -- the pad triple is what is
+    being looked for, not a particular schema.
+    """
+    if not isinstance(spec, dict):
+        return False
+    names: set[str] = set()
+
+    def _harvest(obj) -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                names.add(str(k))
+                _harvest(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                if isinstance(v, str):
+                    names.add(v)
+                else:
+                    _harvest(v)
+
+    for key in ("interfaces", "ports", "signals", "io"):
+        if key in spec:
+            _harvest(spec.get(key))
+    return all(p in names for p in LOCKED_BOUNDARY_PORTS)
+
+
+def _rtl_target_module(spec: dict) -> str:
+    """The module name a block's ``rtl_target`` file is named for."""
+    target = str((spec or {}).get("rtl_target") or "").strip()
+    return Path(target).stem if target else ""
+
+
+def _rtl_declares_locked_boundary(project_root, spec: dict) -> bool:
+    """Third-tier evidence: the block's RTL, when it already exists, declares
+    the pad vector. Only consulted when the architecture metadata is silent --
+    a retirement must not depend on RTL existing, since the point is to retire
+    the block BEFORE any is generated."""
+    target = str((spec or {}).get("rtl_target") or "").strip()
+    if not target:
+        return False
+    for cand in (Path(target), Path(project_root) / target):
+        try:
+            if not cand.is_file():
+                continue
+            text = cand.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        from orchestrator.langgraph.contract_conformance import declared_ports
+        ports = declared_ports(text, module=None)
+        if all(p in ports for p in LOCKED_BOUNDARY_PORTS):
+            return True
+    return False
+
+
+def pad_adapter_blocks(project_root, block_queue) -> list[str]:
+    """Blocks carrying the locked Caravel pad boundary, in queue order.
+
+    Structural, never by name. Returns [] for a non-Caravel design.
+    """
+    arch = _architecture_blocks(project_root)
+    found: list[str] = []
+    for entry in block_queue or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or entry.get("block_name") or "")
+        if not name:
+            continue
+        spec = {**(arch.get(name) or {}), **entry}
+        if (_spec_declares_locked_boundary(spec)
+                or _rtl_target_module(spec) == CARAVEL_TOP_MODULE
+                or _rtl_declares_locked_boundary(project_root, spec)):
+            found.append(name)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Evidence: what was the block contracted to translate, and is it covered?
+# ---------------------------------------------------------------------------
+
+def _contracts(project_root) -> list:
+    p = Path(project_root) / ".coresmith" / "interface_contracts.json"
+    try:
+        d = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    c = d.get("contracts") if isinstance(d, dict) else d
+    return c if isinstance(c, list) else []
+
+
+def _edge_signals(edge: dict) -> list[str]:
+    """Payload fields + sideband: a channel's full signal set.
+
+    Same union ``contract_conformance._signal_names`` and
+    ``integration_helpers._contract_signal_names`` compute; the schema splits
+    them across two keys, which is why readers have concluded the contract does
+    not record signal names at all.
+    """
+    out: list[str] = []
+    for key in ("fields", "sideband_signals"):
+        for f in edge.get(key) or []:
+            n = f.get("name") if isinstance(f, dict) else f
+            if n:
+                out.append(str(n))
+    seen, uniq = set(), []
+    for n in out:
+        if n not in seen:
+            seen.add(n)
+            uniq.append(n)
+    return uniq
+
+
+def contract_signals_for_block(project_root, block_name: str) -> list[str]:
+    """Every signal the interface contract says this block carries.
+
+    The union over every edge naming the block as producer or consumer -- i.e.
+    exactly the set the conformance gate demands the block expose as ports, and
+    therefore exactly what a pin map has to route for the block to be redundant.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for edge in _contracts(project_root):
+        if not isinstance(edge, dict):
+            continue
+        if block_name not in (edge.get("producer_block"),
+                              edge.get("consumer_block")):
+            continue
+        for n in _edge_signals(edge):
+            if n not in seen:
+                seen.add(n)
+                out.append(n)
+    return out
+
+
+def pin_map_signal_names(pin_map) -> list[str]:
+    """Every name a pin map binds: mapped signals plus their output-enables.
+
+    The ``oe`` of an out entry is a real routed signal -- the top inverts it
+    into ``io_oeb`` -- so a contract signal satisfied by an ``oe`` is covered.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for e in getattr(pin_map, "entries", []) or []:
+        for n in (getattr(e, "signal", ""), getattr(e, "oe", "")):
+            if n and n not in seen:
+                seen.add(n)
+                out.append(n)
+    return out
+
+
+@dataclass
+class RetirementPlan:
+    """What to do with the pad-adapter block, and the evidence for it."""
+
+    block: str = ""
+    retire: bool = False
+    park: bool = False
+    reason: str = ""
+    contract_signals: list = field(default_factory=list)
+    pin_map_signals: list = field(default_factory=list)
+    covered: list = field(default_factory=list)
+    uncovered: list = field(default_factory=list)
+    message: str = ""
+
+    @property
+    def acted(self) -> bool:
+        return self.retire or self.park
+
+
+def plan_retirement(project_root, block_queue, pin_map=None) -> RetirementPlan:
+    """Decide whether a declared pin map retires the pad-adapter block.
+
+    ``pin_map`` defaults to ``load_pin_map(project_root)``. Returns a plan with
+    ``retire`` (full coverage), ``park`` (partial coverage -- a contradiction),
+    or neither (no pin map / no adapter / no contract edges / zero overlap).
+    Never raises: every input is treated as untrusted data.
+    """
+    plan = RetirementPlan()
+    if pin_map is None:
+        from orchestrator.architecture.pin_map import load_pin_map
+        pin_map = load_pin_map(project_root)
+    if pin_map is None:
+        plan.reason = "no pin_map declared in the PRD"
+        return plan
+    if not getattr(pin_map, "ok", False):
+        plan.reason = ("pin_map is present but INVALID ("
+                       + "; ".join(getattr(pin_map, "errors", []) or [])
+                       + ") -- refusing to retire anything on a bad map")
+        return plan
+
+    adapters = pad_adapter_blocks(project_root, block_queue)
+    if not adapters:
+        plan.reason = ("no block carries the locked Caravel pad boundary -- "
+                       "nothing for the pin map to replace")
+        return plan
+    plan.block = adapters[0]
+
+    plan.contract_signals = contract_signals_for_block(project_root, plan.block)
+    plan.pin_map_signals = pin_map_signal_names(pin_map)
+    if not plan.contract_signals:
+        plan.reason = (
+            f"no interface-contract edge names '{plan.block}', so there is no "
+            f"declared translation for the pin map to cover -- not retiring on "
+            f"an unevidenced guess")
+        return plan
+
+    mapped = set(plan.pin_map_signals)
+    plan.covered = [s for s in plan.contract_signals if s in mapped]
+    plan.uncovered = [s for s in plan.contract_signals if s not in mapped]
+
+    if not plan.uncovered:
+        plan.retire = True
+        plan.reason = RETIRE_REASON
+        plan.message = (
+            f"the PRD pin map routes all {len(plan.covered)} signal(s) "
+            f"'{plan.block}' was contracted to translate "
+            f"({', '.join(plan.covered)}) -- the chip top emits that routing "
+            f"itself, so there is no adapter to generate")
+        return plan
+
+    if not plan.covered:
+        # The pin map is about something else entirely. Not a partial boundary,
+        # so not the contradiction the park exists for -- but say so, because
+        # the assembler drops the adapter on ANY valid pin map and an operator
+        # should not discover that disagreement at integration time.
+        plan.reason = (
+            f"the pin map maps {sorted(mapped)} and covers NONE of the "
+            f"{len(plan.contract_signals)} signal(s) '{plan.block}' is "
+            f"contracted to translate ({', '.join(plan.contract_signals)}) -- "
+            f"not retiring; note that the integration assembler still drops a "
+            f"pad adapter whenever a valid pin map is present")
+        return plan
+
+    plan.park = True
+    plan.reason = "pin_map_partially_covers_pad_adapter"
+    plan.message = (
+        f"the PRD pin map covers {len(plan.covered)} of "
+        f"{len(plan.contract_signals)} signal(s) '{plan.block}' is contracted "
+        f"to translate: covered {plan.covered}, NOT covered {plan.uncovered}. "
+        f"A boundary where the chip top routes some pads and a block routes "
+        f"the rest is a contradiction -- both would drive the same bus. "
+        f"Either extend prd.pin_map to cover {plan.uncovered}, or remove the "
+        f"pin map and let the adapter own the whole boundary.")
+    return plan
+
+
+def apply_retirement(block_queue, plan: RetirementPlan) -> list:
+    """The block queue with the retired block removed (a new list).
+
+    Idempotent: re-applying to an already-reduced queue is a no-op, which is
+    what makes it safe on every tier re-entry and every checkpoint resume.
+    """
+    if not plan or not plan.retire or not plan.block:
+        return list(block_queue or [])
+    return [b for b in (block_queue or [])
+            if not (isinstance(b, dict)
+                    and (b.get("name") or b.get("block_name")) == plan.block)]
+
+
+# ---------------------------------------------------------------------------
+# Artifacts: the reason has to survive the run
+# ---------------------------------------------------------------------------
+
+def _artifact_path(project_root) -> Path:
+    return Path(project_root) / ".coresmith" / ARTIFACT_NAME
+
+
+def read_retired_blocks(project_root) -> list:
+    """Retirement records for this run (``[]`` when nothing was retired)."""
+    try:
+        doc = json.loads(_artifact_path(project_root).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    rows = doc.get("retired") if isinstance(doc, dict) else doc
+    return rows if isinstance(rows, list) else []
+
+
+def record_retirement(project_root, plan: RetirementPlan) -> dict:
+    """Persist the retirement: a carried artifact + a note in the block's dir.
+
+    Returns the record (also the shape stored in orchestrator state). Writes are
+    best-effort -- a bookkeeping failure must never fail the run -- but the
+    record is returned either way so state still carries it.
+    """
+    record = {
+        "block": plan.block,
+        "reason": RETIRE_REASON,
+        "skipped": True,
+        "retired_at": time.time(),
+        "contract_signals": list(plan.contract_signals),
+        "pin_map_signals": list(plan.pin_map_signals),
+        "covered_signals": list(plan.covered),
+        "explanation": plan.message,
+    }
+    try:
+        rows = [r for r in read_retired_blocks(project_root)
+                if isinstance(r, dict) and r.get("block") != plan.block]
+        rows.append(record)
+        p = _artifact_path(project_root)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"retired": rows}, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+    try:
+        bd = Path(project_root) / ".coresmith" / "blocks" / plan.block
+        bd.mkdir(parents=True, exist_ok=True)
+        (bd / BLOCK_NOTE_NAME).write_text(
+            f"# {plan.block}: RETIRED ({RETIRE_REASON})\n"
+            "\n"
+            "This block was NOT microarchitected, generated, simulated or\n"
+            "synthesized, and it is deliberately ABSENT from the assembled\n"
+            "chip. It is not missing and it did not fail.\n"
+            "\n"
+            f"Why: {plan.message}.\n"
+            "\n"
+            "Contract signals this block was to translate:\n"
+            + "".join(f"  - {s}\n" for s in plan.contract_signals)
+            + "\nPin-map signals that route them instead:\n"
+            + "".join(f"  - {s}\n" for s in plan.pin_map_signals)
+            + "\nThe routing is emitted directly into the chip top by\n"
+              "orchestrator/architecture/pin_map.py:emit_pin_routing, from\n"
+              "prd_spec.json's structured `pin_map`. Set\n"
+              "CORESMITH_PINMAP_RETIRES_ADAPTER=0 to generate this block\n"
+              "again (the integration assembler then drops it after the fact,\n"
+              "which is what this retirement replaces).\n",
+            encoding="utf-8")
+    except OSError:
+        pass
+    return record

--- a/orchestrator/daemon/server.py
+++ b/orchestrator/daemon/server.py
@@ -77,6 +77,74 @@ _STALL_THRESHOLD_S = float(os.environ.get("CORESMITH_INTERRUPT_STALL_S", "1800")
 _STALL_POLL_S = float(os.environ.get("CORESMITH_INTERRUPT_STALL_POLL_S", "300"))
 
 # ---------------------------------------------------------------------------
+# When was each interrupt RAISED? (first observed pending, which is the closest
+# thing to a raise time available -- LangGraph interrupts carry no timestamp.)
+# ---------------------------------------------------------------------------
+# Both staleness answers used to be keyed to the wrong clock:
+#
+#   * ``_driver_liveness_watch`` measured "idle" as time since the last
+#     /run/resume. On a HANDS-OFF run there is no resume after /run/start, so
+#     the stall clock is already an hour old the moment the first interrupt is
+#     raised -- the daemon logged STALLED_INTERRUPT for an interrupt that was
+#     15 minutes old and dropped the marker file with idle_seconds=4488.
+#   * ``_shape_state`` labelled an interrupt "stale_suspected" purely because
+#     its block appears in the append-only ``completed_blocks``. In a two-pass
+#     run EVERY block completes pass 1, so EVERY pass-2 interrupt is born
+#     stale: the parked raster run reported ``stale_suspected: true`` and
+#     ``live_interrupt_count: 0`` on a freshly raised, entirely live
+#     ``contract_conformance_unrepairable`` -- and an automated consumer
+#     reading ``live_interrupt_count == 0`` concludes there is nothing to act
+#     on.
+#
+# A just-raised interrupt must read LIVE. So both are keyed to the interrupt
+# itself: the stall clock runs from when THIS interrupt was raised, and the
+# leftover suspicion needs the block's completion to be NEWER than the
+# interrupt (i.e. the graph really did move past it) rather than merely present.
+_interrupt_first_seen: dict[str, float] = {}
+
+
+def _note_interrupts_seen(ids: set[str], now: float | None = None) -> None:
+    """Record first-observation time for each pending interrupt id.
+
+    Ids that are no longer pending are forgotten, so an id LangGraph reuses
+    after a resume is timed from its new appearance rather than its old one.
+    """
+    t = time.time() if now is None else now
+    for i in ids:
+        _interrupt_first_seen.setdefault(i, t)
+    for gone in set(_interrupt_first_seen) - ids:
+        _interrupt_first_seen.pop(gone, None)
+
+
+def _interrupt_raised_ts(intr_id: str, now: float | None = None) -> float:
+    """When this interrupt was first seen pending. Unknown ids read as NOW --
+    an interrupt we have never observed before is, by definition, new."""
+    return _interrupt_first_seen.get(
+        intr_id, time.time() if now is None else now)
+
+
+def _completion_times(completed: list) -> dict:
+    """block -> the time of its LATEST completion event (0.0 when unstamped).
+
+    ``block_done_node`` stamps ``completed_at``; checkpoints written before that
+    have none, and an unstamped completion is treated as NO EVIDENCE rather
+    than as proof an interrupt is a leftover.
+    """
+    out: dict = {}
+    for b in completed or []:
+        if not isinstance(b, dict):
+            continue
+        name = b.get("name")
+        if not name:
+            continue
+        try:
+            ts = float(b.get("completed_at") or 0.0)
+        except (TypeError, ValueError):
+            ts = 0.0
+        out[name] = max(ts, out.get(name, 0.0))
+    return out
+
+# ---------------------------------------------------------------------------
 # D5: interrupt ids this daemon has already forwarded a resume for.
 # ---------------------------------------------------------------------------
 # `aget_state` reads the CHECKPOINT. Between a consumed `/run/resume` and the
@@ -138,9 +206,17 @@ async def _count_pending_interrupts() -> int | None:
         )
         consumed = _consumed_now()
         n = 0
+        ids: set[str] = set()
         if snap and snap.tasks:
             for t in snap.tasks:
-                n += sum(1 for i in t.interrupts if i.id not in consumed)
+                for i in t.interrupts:
+                    ids.add(i.id)
+                    if i.id not in consumed:
+                        n += 1
+        # Stamp first-seen here too: this poll runs every _STALL_POLL_S whether
+        # or not anyone calls /run/state, so an unattended run still learns when
+        # its interrupt was raised.
+        _note_interrupts_seen(ids)
         return n
     except Exception as exc:  # noqa: BLE001
         log.warning(
@@ -163,20 +239,33 @@ async def _driver_liveness_watch() -> None:
                     "zero -- inspect the run.", _PROJECT_ROOT)
                 continue
             if pending > 0:
-                idle = time.time() - _last_resume_ts
+                # Measure how long THIS interrupt has gone unanswered, not how
+                # long since the last resume. On a hands-off run the only
+                # resume is /run/start, so the old clock declared every
+                # interrupt stalled the moment it was raised (observed:
+                # idle_seconds=4488 on an interrupt 15 minutes old).
+                now = time.time()
+                oldest = min(
+                    (_interrupt_first_seen[i] for i in _interrupt_first_seen),
+                    default=now)
+                # A resume after the interrupt appeared also restarts the clock:
+                # the driver is demonstrably alive.
+                unanswered_since = max(oldest, _last_resume_ts)
+                idle = now - unanswered_since
                 if idle >= _STALL_THRESHOLD_S:
                     log.warning(
-                        "STALLED_INTERRUPT: %d pending interrupt(s) with no "
-                        "/run/resume for %.0f min (project_root=%s). The outer "
-                        "driver may be dead -- resume or restart it.",
+                        "STALLED_INTERRUPT: %d pending interrupt(s) unanswered "
+                        "for %.0f min (project_root=%s). The outer driver may "
+                        "be dead -- resume or restart it.",
                         pending, idle / 60.0, _PROJECT_ROOT,
                     )
                     try:
                         marker.write_text(json.dumps({
                             "pending_interrupt_count": pending,
                             "idle_seconds": round(idle),
+                            "interrupt_raised_ts": oldest,
                             "last_resume_ts": _last_resume_ts,
-                            "noted_at": time.time(),
+                            "noted_at": now,
                         }, indent=2))
                     except OSError:
                         pass
@@ -1228,7 +1317,26 @@ def _shape_state(state_snapshot) -> dict:
     # `status: running` and drove outer agents to resume the same interrupt
     # twice. Discounted by ID, only while the runner task is in flight, and
     # still LISTED (with `consumed_by_resume`) so nothing is hidden.
+    #
+    # But "the block is in completed_blocks" alone is not evidence of a
+    # leftover -- in a two-pass run EVERY block completes pass 1, so EVERY
+    # pass-2 interrupt was born ``stale_suspected: true`` with
+    # ``live_interrupt_count: 0``, and an automated driver reading that
+    # concludes there is nothing to act on. The suspicion is now keyed to WHEN
+    # THE INTERRUPT WAS RAISED: a leftover is an interrupt the graph has since
+    # moved PAST, so the block's completion must be NEWER than the interrupt.
+    # A just-raised interrupt reads LIVE, and an unstamped completion (a
+    # checkpoint predating ``completed_at``) is no evidence at all -- absence of
+    # evidence is not evidence of absence, which is this file's whole thesis.
     consumed = _consumed_now()
+    now_ts = time.time()
+    completion_ts = _completion_times(completed)
+    _note_interrupts_seen(
+        {intr.id
+         for task in (state_snapshot.tasks or [])
+         for intr in task.interrupts},
+        now=now_ts,
+    )
     interrupts: list[dict] = []
     suspected_stale = 0
     consumed_count = 0
@@ -1236,10 +1344,24 @@ def _shape_state(state_snapshot) -> dict:
         for task in state_snapshot.tasks:
             for intr in task.interrupts:
                 payload = intr.value
+                raised_ts = _interrupt_raised_ts(intr.id, now=now_ts)
                 stale = False
+                basis = "not_a_block_interrupt"
                 if isinstance(payload, dict):
                     blk = payload.get("block", payload.get("block_name", ""))
-                    stale = bool(blk) and blk in completed_names
+                    if not blk:
+                        basis = "not_a_block_interrupt"
+                    elif blk not in completed_names:
+                        basis = "block_not_completed"
+                    else:
+                        done_ts = completion_ts.get(blk, 0.0)
+                        if not done_ts:
+                            basis = "completion_unstamped"
+                        elif raised_ts > done_ts:
+                            basis = "raised_after_block_completed"
+                        else:
+                            basis = "raised_before_block_completed"
+                            stale = True
                 if stale:
                     suspected_stale += 1
                 was_consumed = intr.id in consumed
@@ -1249,6 +1371,9 @@ def _shape_state(state_snapshot) -> dict:
                     "id": intr.id,
                     "payload": payload,
                     "stale_suspected": stale,
+                    "stale_basis": basis,
+                    "raised_ts": raised_ts,
+                    "age_seconds": round(max(0.0, now_ts - raised_ts), 3),
                     "consumed_by_resume": was_consumed,
                 })
 

--- a/orchestrator/daemon/server.py
+++ b/orchestrator/daemon/server.py
@@ -90,7 +90,7 @@ _STALL_POLL_S = float(os.environ.get("CORESMITH_INTERRUPT_STALL_POLL_S", "300"))
 #   * ``_shape_state`` labelled an interrupt "stale_suspected" purely because
 #     its block appears in the append-only ``completed_blocks``. In a two-pass
 #     run EVERY block completes pass 1, so EVERY pass-2 interrupt is born
-#     stale: the parked raster run reported ``stale_suspected: true`` and
+#     stale: a parked graded run reported ``stale_suspected: true`` and
 #     ``live_interrupt_count: 0`` on a freshly raised, entirely live
 #     ``contract_conformance_unrepairable`` -- and an automated consumer
 #     reading ``live_interrupt_count == 0`` concludes there is nothing to act

--- a/orchestrator/harness/blocks.py
+++ b/orchestrator/harness/blocks.py
@@ -21,8 +21,33 @@ import os
 from pathlib import Path
 
 
+def _retire_pin_mapped(project_root: str | Path, queue: list[dict]) -> list[dict]:
+    """Drop a pad-adapter block a declared PRD pin map fully covers.
+
+    The graph retires it at ``init_tier`` (and owns the partial-coverage park);
+    this mirrors ONLY the unambiguous full-coverage case so every other reader
+    of the queue -- the conformance stage's sibling list, ``coresmith verify``,
+    the MCP status views -- reports the same block set the pipeline runs. Never
+    parks and never raises: a bookkeeping helper must not gate anything.
+    """
+    try:
+        from orchestrator.architecture import pin_map_retire as _pmr
+        if not _pmr.retirement_enabled():
+            return queue
+        plan = _pmr.plan_retirement(project_root, queue)
+        return _pmr.apply_retirement(queue, plan) if plan.retire else queue
+    except Exception:  # noqa: BLE001
+        return queue
+
+
 def load_block_queue(project_root: str | Path) -> list[dict]:
     """Return the resolved block queue (list of block spec dicts)."""
+    root = Path(project_root)
+    return _retire_pin_mapped(root, _load_block_queue_raw(root))
+
+
+def _load_block_queue_raw(project_root: str | Path) -> list[dict]:
+    """The queue exactly as the architecture phase / config declared it."""
     root = Path(project_root)
 
     specs = root / ".coresmith" / "block_specs.json"

--- a/orchestrator/harness/cli.py
+++ b/orchestrator/harness/cli.py
@@ -260,9 +260,19 @@ def cmd_golden_check(args) -> int:
         return EXIT_INFRA
     res = check_golden_feasibility(str(root), args.block)
     ran, passed, skipped = res.get("ran"), res.get("passed"), res.get("skipped")
-    status = ("SKIP" if skipped or not ran else "PASS" if passed else "FAIL")
+    # The WORDS follow the probe's tri-state verdict: PASS only when a
+    # discriminating check concluded, NOT RUN when the probe ran but nothing
+    # capable of returning the other answer did. Exit codes are deliberately
+    # unchanged -- this probe is advisory by design (see
+    # golden_feasibility_gate_enabled), and a caller keying on EXIT_PASS should
+    # not start seeing EXIT_SKIP because the report got more precise.
+    status = ("SKIP" if skipped or not ran else
+              "PASS" if res.get("verdict") == "pass" else
+              "NOT RUN" if passed else "FAIL")
     reach = (res.get("checks", {}) or {}).get("slice_reachability", {}) or {}
     human = f"golden-check {args.block}: {status}  ({res.get('reason') or 'ok'})"
+    if res.get("not_run_reason"):
+        human += f"\n  {res['not_run_reason']}"
     if reach:
         human += (f"\n  slice reachability: {reach.get('verdict')} -- "
                   f"{reach.get('reason', '')}")

--- a/orchestrator/langchain/agents/contract_audit_agent.py
+++ b/orchestrator/langchain/agents/contract_audit_agent.py
@@ -40,8 +40,8 @@ class ContractAuditAgent:
         The output path is stage-derived and therefore STABLE across failures,
         so a file left by a PREVIOUS audit is already sitting there when this
         call begins -- and the "did the agent write the result?" check was a
-        bare ``out.exists()``, which that stale file satisfies. Observed on the
-        raster run: a 0.99-confidence TESTBENCH_BUG audit for an already-fixed
+        bare ``out.exists()``, which that stale file satisfies. Observed on a
+        validation run: a 0.99-confidence TESTBENCH_BUG audit for an already-fixed
         crash was adopted verbatim as the verdict on a new and completely
         different failure.
 

--- a/orchestrator/langchain/agents/model_integration_generator.py
+++ b/orchestrator/langchain/agents/model_integration_generator.py
@@ -41,6 +41,25 @@ from .coresmith_llm import ClaudeLLM
 
 _tracer = trace.get_tracer(__name__)
 
+
+def _chip_model_attempts() -> int:
+    """Chip-model generation rounds (default 2).
+
+    A rejected model leaves the composition gate with nothing to compose, so it
+    NO-OPS for the whole run -- an expensive outcome for a fault the validator
+    already localised to one line. One retry carrying that exact complaint back
+    is cheap next to losing the gate. ``CORESMITH_CHIP_MODEL_ATTEMPTS=1``
+    restores single-shot.
+    """
+    import os as _os
+
+    try:
+        return max(1, int(
+            _os.environ.get("CORESMITH_CHIP_MODEL_ATTEMPTS", "2") or "2"))
+    except ValueError:
+        return 2
+
+
 _PROMPT_FILE = (
     Path(__file__).resolve().parent.parent
     / "prompts"
@@ -204,14 +223,6 @@ class ModelIntegrationGenerator:
                 ]
             )
 
-            content = await self.llm.call(
-                system=SYSTEM_PROMPT,
-                prompt=user_message,
-                run_name="Generate Model Integration [chip_model]",
-            )
-
-            code = self._extract_python(content)
-
             out = Path(output_path)
             out.parent.mkdir(parents=True, exist_ok=True)
 
@@ -222,30 +233,60 @@ class ModelIntegrationGenerator:
                 except OSError:
                     on_disk = ""
 
-            chosen = self._choose_chip_model(code, on_disk, block_models_dir)
-            if not chosen:
-                raise RuntimeError(
-                    "Model integration generation produced no usable Python "
-                    f"(no fenced code block and no on-disk file at {output_path})."
+            # RETRY ONCE with the rejection quoted back. A rejected chip model
+            # leaves the composition gate with nothing to compose, so the gate
+            # NO-OPS -- the most expensive possible outcome for a fault the
+            # validator has already localised to one line. The rules were in
+            # the prompt the first time; what was missing was the feedback.
+            problem = None
+            _attempts = _chip_model_attempts()
+            for _round in range(_attempts):
+                prompt = user_message if problem is None else "\n".join([
+                    user_message,
+                    "\n--- YOUR PREVIOUS ATTEMPT WAS REJECTED ---",
+                    problem,
+                    "Fix EXACTLY that and re-emit the COMPLETE _chip_model.py. "
+                    "Do not change anything else, and do not respond with a "
+                    "diff or a partial file.",
+                ])
+                content = await self.llm.call(
+                    system=SYSTEM_PROMPT,
+                    prompt=prompt,
+                    run_name=("Generate Model Integration [chip_model]"
+                              + (f" retry {_round}" if _round else "")),
                 )
+                code = self._extract_python(content)
+                chosen = self._choose_chip_model(code, on_disk, block_models_dir)
+                if not chosen:
+                    raise RuntimeError(
+                        "Model integration generation produced no usable Python "
+                        f"(no fenced code block and no on-disk file at "
+                        f"{output_path})."
+                    )
 
-            # Gate-observation hardening (the internal-memory snoop the
-            # reference output keys require, and the frame-done/tlast count) is
-            # implemented inside the generated Amaranth model via real Signals /
-            # debug ports -- the engine no longer post-processes the generated
-            # source to inject an observation shim.
+                # Gate-observation hardening (the internal-memory snoop the
+                # reference output keys require, and the frame-done/tlast count)
+                # is implemented inside the generated Amaranth model via real
+                # Signals / debug ports -- the engine no longer post-processes
+                # the generated source to inject an observation shim.
 
-            out.write_text(chosen, encoding="utf-8")
+                out.write_text(chosen, encoding="utf-8")
 
-            problem = _validate_chip_model_file(
-                str(out), block_models_dir, reference_entry_name
-            )
+                problem = _validate_chip_model_file(
+                    str(out), block_models_dir, reference_entry_name
+                )
+                if problem is None:
+                    break
+                span.set_attribute(f"rejected_round_{_round}", problem[:300])
+
             if problem is not None:
                 raise RuntimeError(
-                    f"Integrated chip model at {output_path} is invalid: {problem}"
+                    f"Integrated chip model at {output_path} is invalid after "
+                    f"{_attempts} attempt(s): {problem}"
                 )
 
             span.set_attribute("path", str(out))
+            span.set_attribute("attempts", _round + 1)
             return {"path": str(out)}
 
     @staticmethod
@@ -313,6 +354,25 @@ def _validate_chip_model_text(
         return "chip_model must inherit amaranth.Elaboratable"
 
     ren = (reference_entry_name or "").strip().lower()
+
+    # Which names in this module are bound to a LOCAL object? A chip model
+    # writes ``sim = Simulator(m)`` and then ``sim.run()`` -- and when the
+    # reference entry happens to be called ``run``, the blanket attribute-name
+    # match below read that as "the chip model calls the oracle" and rejected
+    # the model. The composition gate then no-op'd, on two consecutive runs,
+    # over the Amaranth simulator API. A method call on an object this module
+    # constructed cannot be the oracle: reaching the oracle needs an import,
+    # and importing it is already rejected above.
+    #
+    # The relaxation is scoped hard. Only an attribute call whose receiver is a
+    # plain local name is spared, and only when the receiver is not itself
+    # oracle-shaped and the module does no dynamic importing -- a module that
+    # touches importlib/__import__/exec/eval could bind the oracle to a local,
+    # so it keeps the strict rule. A bare ``run(...)``, an unbound receiver
+    # (``mod.run()``), and a chained one (``a.b.run()``) all still fail.
+    _local_names = _locally_bound_names(tree)
+    _dynamic = bool(re.search(r"\b(?:importlib|__import__|exec|eval)\b", text))
+
     for node in ast.walk(tree):
         # No import of a *_golden module (the reference implementation).
         if isinstance(node, ast.Import):
@@ -349,13 +409,75 @@ def _validate_chip_model_text(
             if isinstance(node, ast.Call):
                 fn = node.func
                 called = getattr(fn, "id", None) or getattr(fn, "attr", None)
-                if called and called.lower().strip("_") == ren:
-                    return (
-                        f"ANTI-CHEAT: chip model calls {called!r}, matching the "
-                        f"reference entry {reference_entry_name!r}. Never call "
-                        f"the oracle from the chip model."
-                    )
+                if not called or called.lower().strip("_") != ren:
+                    continue
+                recv = (fn.value.id
+                        if isinstance(fn, ast.Attribute)
+                        and isinstance(fn.value, ast.Name) else None)
+                if (recv and not _dynamic and recv in _local_names
+                        and recv.lower().strip("_") not in _ORACLE_RECEIVERS):
+                    continue    # method on a locally-built object, not the oracle
+                return (
+                    f"ANTI-CHEAT: chip model calls {called!r}, matching the "
+                    f"reference entry {reference_entry_name!r}. Never call "
+                    f"the oracle from the chip model."
+                )
     return None
+
+
+#: Receiver names that read as the reference even when locally bound, so
+#: ``golden.run()`` is never spared by the local-object exception above.
+_ORACLE_RECEIVERS = frozenset({
+    "golden", "gold", "ref", "reference", "oracle", "impl", "model_ref",
+    "reference_impl", "reference_module", "ref_mod", "golden_mod",
+})
+
+
+def _locally_bound_names(tree) -> set:
+    """Names this module BINDS to a value it constructed.
+
+    Assignment targets, walrus targets, ``with ... as``, ``for`` targets,
+    comprehension targets, ``except ... as`` and function parameters. Import
+    bindings are deliberately EXCLUDED -- an imported handle is exactly the way
+    the oracle would arrive, and importing it is rejected separately.
+    """
+    import ast
+
+    out: set = set()
+
+    def _bind(target) -> None:
+        if isinstance(target, ast.Name):
+            out.add(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for e in target.elts:
+                _bind(e)
+        elif isinstance(target, ast.Starred):
+            _bind(target.value)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                _bind(t)
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            _bind(node.target)
+        elif isinstance(node, ast.NamedExpr):
+            _bind(node.target)
+        elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
+            _bind(node.target)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    _bind(item.optional_vars)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            out.add(node.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                               ast.Lambda)):
+            a = node.args
+            for arg in (list(a.posonlyargs) + list(a.args) + list(a.kwonlyargs)
+                        + [a.vararg, a.kwarg]):
+                if arg is not None:
+                    out.add(arg.arg)
+    return out
 
 
 def _validate_chip_model_file(

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -449,7 +449,7 @@ class UarchSpecGenerator:
             # used to append the section unconditionally, so a block whose
             # python_source resolved to "" got `--- Python Golden Model ---`
             # followed by an empty code fence -- indistinguishable, to the spec
-            # author, from a golden that says nothing. Measured on the raster
+            # author, from a golden that says nothing. Measured on a
             # validation run: all 8 uArch calls carried an empty golden block,
             # silently. Say what actually happened instead.
             if python_source.strip():

--- a/orchestrator/langchain/prompts/backend_synth_llm.md
+++ b/orchestrator/langchain/prompts/backend_synth_llm.md
@@ -62,9 +62,14 @@ All outputs go in: `{output_dir}/`
    - Writes netlist: `write_verilog -noattr {output_dir}/{design_name}_netlist.v`
    - Generates stats: `stat -liberty $lib`
 
-2. Run `yosys -s <script_path>` via Bash
+2. Run `yosys -s <script_path>` via Bash, TEEING the output to a log file in
+   `{output_dir}/` (e.g. `yosys -s <script> 2>&1 | tee {output_dir}/synth_attempt1.log`).
+   Use a NEW numbered log per attempt -- never overwrite a failed attempt's log.
 
-3. If Yosys fails, read the error, fix the script, and retry (up to 3 times)
+3. If Yosys fails, read the error, fix the script, and retry (up to 3 times).
+   RECORD every failed attempt: its number and the error that ended it. A retry
+   whose reason is not written down teaches nobody, and the same script defect
+   recurs on the next run.
 
 4. Generate the SDC file with:
    ```
@@ -87,9 +92,18 @@ All outputs go in: `{output_dir}/`
   "gate_count": 150,
   "area_um2": 12345.6,
   "cell_count": 42,
-  "report_path": "{output_dir}/{design_name}_report.txt"
+  "report_path": "{output_dir}/{design_name}_report.txt",
+  "attempt_history": [
+    {{"attempt": 1, "error_summary": "ERROR: Module `cs_sram_1rw' referenced in module `top' is not part of the design"}}
+  ]
 }}
 ```
+
+`attempt_history` is REQUIRED whenever you retried, **including when a later
+attempt succeeded** -- one entry per FAILED attempt, with the error that ended
+it. Omit the key (or use `[]`) only when the FIRST attempt succeeded. Reporting
+"succeeded on attempt 2" in prose while leaving attempt 1's reason out of the
+JSON is the exact silence this field exists to end.
 
 If synthesis fails after all retries:
 ```json
@@ -97,7 +111,11 @@ If synthesis fails after all retries:
   "success": false,
   "error": "description of the failure",
   "gate_count": 0,
-  "area_um2": 0
+  "area_um2": 0,
+  "attempt_history": [
+    {{"attempt": 1, "error_summary": "..."}},
+    {{"attempt": 2, "error_summary": "..."}}
+  ]
 }}
 ```
 

--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -116,6 +116,10 @@ class BackendState(TypedDict):
     chip_gate_sim_status: str
     chip_gate_sim_reason: str
     flat_sdc_path: str                   # syn/output/<design>/<design>.sdc
+    # Per-attempt synthesis failure reasons retained even when a LATER attempt
+    # succeeded ([{attempt, error_summary, source, timestamp, unrecorded}]).
+    # Empty when nothing failed. Also merged into synth_result.json.
+    synth_attempt_history: list[dict]
     synth_gate_count: int
     synth_area_um2: float
     macro_bindings: list                 # Part C: [{name,lef,gds,lib,...}] bound shells
@@ -239,6 +243,7 @@ async def _run_llm_eda_step(
     context: dict,
     result_json_path: str,
     timeout: int = 1200,
+    capture_reply: bool = False,
 ) -> dict:
     """Run an EDA step entirely within the inner Claude LLM.
 
@@ -252,6 +257,12 @@ async def _run_llm_eda_step(
         context: Dict of template variables to fill into the prompt.
         result_json_path: Path where the LLM must write the result JSON.
         timeout: Max seconds for the LLM call.
+        capture_reply: Attach the step's own summary text under ``_llm_reply``.
+            Default OFF so every other EDA step's result dict is byte-identical
+            (these dicts land in graph state and the final report). The
+            synthesis driver opts in because a step that RETRIED internally says
+            so only in that text -- the transcript is otherwise discarded, which
+            is how "succeeded on attempt 2" left no record of attempt 1.
 
     Returns:
         Parsed result dict from the JSON file, or a failure dict.
@@ -269,23 +280,33 @@ async def _run_llm_eda_step(
 
     llm = ClaudeLLM(model=DEFAULT_MODEL, timeout=timeout)
 
+    reply = ""
     try:
-        await llm.call(
+        reply = await llm.call(
             system=system_prompt,
             prompt=user_message,
             run_name=step_name,
-        )
+        ) or ""
     except Exception as e:
         return {"success": False, "error": f"LLM call failed: {e}"}
 
     result_path = Path(result_json_path)
     if result_path.exists():
         try:
-            return json.loads(result_path.read_text(encoding="utf-8"))
+            parsed = json.loads(result_path.read_text(encoding="utf-8"))
+            if capture_reply and isinstance(parsed, dict):
+                parsed.setdefault("_llm_reply", str(reply)[:4000])
+            return parsed
         except (json.JSONDecodeError, OSError):
             pass
 
-    return {"success": False, "error": f"LLM did not write result JSON to {result_json_path}"}
+    failed = {
+        "success": False,
+        "error": f"LLM did not write result JSON to {result_json_path}",
+    }
+    if capture_reply:
+        failed["_llm_reply"] = str(reply)[:4000]
+    return failed
 
 
 def _block_name(state: BackendState) -> str:
@@ -855,16 +876,43 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
                 "sram_wrapper_lib": _sram_wrapper_lib or "(already in inputs)",
             },
             result_json_path=result_json_path,
+            # the driver retries Yosys internally -- its own summary is the only
+            # place that says so (see collect_synth_attempt_history)
+            capture_reply=True,
         )
 
         span.set_attribute("success", result.get("success", False))
         if result.get("success"):
             span.set_attribute("gate_count", result.get("gate_count", 0))
 
+    # SELF-RECOVERY MUST NOT BE SILENT. The driver retries Yosys internally; a
+    # live run logged "Synthesis succeeded on attempt 2" and attempt 1's reason
+    # survived nowhere -- not in attempt_history, not in previous_error, not in
+    # synth_result.json. Retain every attempt's failure reason (driver-reported,
+    # harvested from the Yosys logs on disk, and the node's own prior failure),
+    # and record EXPLICITLY when the driver claims a retry we cannot account for.
+    from orchestrator.langgraph.backend_helpers import (
+        collect_synth_attempt_history,
+        describe_synth_attempt_history,
+        persist_synth_attempt_history,
+    )
+    _synth_history = collect_synth_attempt_history(
+        result,
+        output_dir=output_dir,
+        llm_reply=str(result.get("_llm_reply", "")),
+        prior_error=str(state.get("previous_error", "")),
+        node_attempt=int(state.get("attempt", 1) or 1),
+    )
+    if _synth_history:
+        persist_synth_attempt_history(result_json_path, _synth_history)
+        log("  [FLAT-SYNTH] " + describe_synth_attempt_history(_synth_history),
+            YELLOW)
+
     write_graph_event(pr, "Flat Top Synthesis", "graph_node_exit", {
         "design_name": design_name,
         "success": result.get("success", False),
         "gate_count": result.get("gate_count", 0),
+        "synth_attempt_failures": len(_synth_history),
         "graph": "backend",
     })
 
@@ -885,6 +933,7 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
             })
             return {
                 "phase": "synth",
+                "synth_attempt_history": _synth_history,
                 "previous_error": _bind_err,
                 "flat_netlist_path": "",
                 "flat_sdc_path": "",
@@ -892,6 +941,7 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
         _gs_ok, _gs_status, _gs_reason = _run_chip_top_gate_sim(state, _netlist)
         return {
             "phase": "synth",
+            "synth_attempt_history": _synth_history,
             "flat_netlist_path": _netlist,
             "flat_sdc_path": result.get("sdc_path", ""),
             "synth_gate_count": result.get("gate_count", 0),
@@ -906,9 +956,15 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
                 f"chip_top gate-sim FAIL: {_gs_reason}"} if _gs_ok is False else {}),
         }
     else:
+        # A FAILED synthesis carries its per-attempt history into previous_error
+        # too: diagnose reads that string, and "attempt 3 failed" without the two
+        # reasons before it is what made the same script defect recur every run.
+        _err = result.get("error", "Flat synthesis failed")
+        _hist_txt = describe_synth_attempt_history(_synth_history)
         return {
             "phase": "synth",
-            "previous_error": result.get("error", "Flat synthesis failed"),
+            "synth_attempt_history": _synth_history,
+            "previous_error": (f"{_err}\n\n{_hist_txt}" if _hist_txt else _err),
             "flat_netlist_path": "",
             "flat_sdc_path": "",
         }

--- a/orchestrator/langgraph/backend_helpers.py
+++ b/orchestrator/langgraph/backend_helpers.py
@@ -155,6 +155,227 @@ def render_layout_image(
 
 
 # ---------------------------------------------------------------------------
+# Synthesis attempt history (self-recovery must never be silent)
+# ---------------------------------------------------------------------------
+#
+# The flat-synth driver runs Yosys inside an LLM step that retries on its own.
+# On a live run it reported "Synthesis succeeded on attempt 2" -- and attempt 1's
+# failure reason was retained NOWHERE: not in ``attempt_history``, not in
+# ``previous_error``, not in ``synth_result.json``. A driver that heals itself in
+# silence teaches nobody: the same script defect recurs every run, and the only
+# trace is a sentence in a chat transcript that is discarded.
+#
+# Everything below is a PURE function of (result dict, on-disk logs, reply text)
+# so it can be unit-tested without an LLM, and it NEVER raises: retaining history
+# is diagnostics, and diagnostics must not be able to fail a synthesis that
+# succeeded.
+
+#: Yosys prints hard failures as ``ERROR: ...``; Verilog front-end syntax errors
+#: come through as ``... syntax error ...``. Both are attempt-ending.
+_SYNTH_ERROR_RE = re.compile(
+    r"^(?:\s*)(ERROR:.*|.*\bsyntax error\b.*)$", re.MULTILINE | re.IGNORECASE
+)
+#: "succeeded on attempt 3", "attempt 2 succeeded", "on the 2nd attempt", ...
+_ATTEMPT_CLAIM_RE = re.compile(r"attempt\s*#?\s*(\d+)", re.IGNORECASE)
+_SYNTH_LOG_GLOBS = ("*.log", "*.txt", "*.out")
+_MAX_SUMMARY_CHARS = 800
+
+
+def _clip(text: str, limit: int = _MAX_SUMMARY_CHARS) -> str:
+    t = " ".join(str(text or "").split())
+    return t if len(t) <= limit else t[: limit - 3] + "..."
+
+
+def _first_error_line(text: str) -> str:
+    m = _SYNTH_ERROR_RE.search(str(text or ""))
+    return _clip(m.group(1)) if m else ""
+
+
+def collect_synth_attempt_history(
+    result: dict | None,
+    *,
+    output_dir: str = "",
+    llm_reply: str = "",
+    prior_error: str = "",
+    node_attempt: int = 1,
+    now: str = "",
+) -> list[dict]:
+    """Per-attempt failure records for ONE synthesis-driver invocation.
+
+    Merges every source of attempt evidence that exists, de-duplicated and
+    ordered by attempt number. Each record is
+    ``{attempt, error_summary, source, timestamp}``.
+
+      * ``result["attempt_history"]`` / ``["attempts"]`` -- what the driver
+        itself recorded (the prompt now asks for it explicitly).
+      * on-disk logs under ``output_dir`` -- any log carrying a Yosys ``ERROR:``
+        line. Deterministic evidence that does not depend on the driver being
+        honest about its own retries.
+      * ``prior_error`` -- the failure this NODE-level attempt is retrying, which
+        otherwise only survives until the next node overwrites it.
+      * ``llm_reply`` -- the driver's own summary. When it claims success on
+        attempt N and fewer than N-1 failures were recovered above, the missing
+        attempts are recorded EXPLICITLY as ``not retained``. That entry is the
+        point: a gap we can see beats a gap we cannot.
+
+    Returns ``[]`` when nothing failed and nothing claims anything did.
+    """
+    try:
+        return _collect_synth_attempt_history(
+            result or {}, output_dir, llm_reply, prior_error, node_attempt, now)
+    except Exception:  # noqa: BLE001 - diagnostics never fail a synthesis
+        return []
+
+
+def _collect_synth_attempt_history(
+    result: dict, output_dir: str, llm_reply: str, prior_error: str,
+    node_attempt: int, now: str,
+) -> list[dict]:
+    import time as _time
+
+    stamp = now or _time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    by_attempt: dict[int, dict] = {}
+
+    def _record(attempt: int, summary: str, source: str, timestamp: str = "") -> None:
+        summary = _clip(summary)
+        if not summary:
+            return
+        n = max(1, int(attempt))
+        prev = by_attempt.get(n)
+        # First writer wins per attempt, EXCEPT that a real error summary always
+        # displaces a "not retained" placeholder.
+        if prev is not None and not prev.get("unrecorded"):
+            return
+        by_attempt[n] = {
+            "attempt": n,
+            "error_summary": summary,
+            "source": source,
+            "timestamp": timestamp or stamp,
+            "unrecorded": source == "unrecorded",
+        }
+
+    # 1. What the driver recorded about itself.
+    declared = result.get("attempt_history")
+    if not isinstance(declared, list):
+        declared = result.get("attempts")
+    if isinstance(declared, list):
+        for i, entry in enumerate(declared):
+            if isinstance(entry, dict):
+                n = entry.get("attempt", entry.get("n", i + 1))
+                summary = (
+                    entry.get("error_summary") or entry.get("error")
+                    or entry.get("reason") or entry.get("summary") or ""
+                )
+                try:
+                    n = int(n)
+                except (TypeError, ValueError):
+                    n = i + 1
+                _record(n, summary, "driver_reported",
+                        str(entry.get("timestamp", "")))
+            elif isinstance(entry, str):
+                _record(i + 1, entry, "driver_reported")
+
+    # 2. Deterministic on-disk evidence.
+    log_hits: list[tuple[float, str, str]] = []
+    if output_dir:
+        d = Path(output_dir)
+        if d.is_dir():
+            seen: set[str] = set()
+            for pattern in _SYNTH_LOG_GLOBS:
+                for p in sorted(d.glob(pattern)):
+                    if str(p) in seen or not p.is_file():
+                        continue
+                    seen.add(str(p))
+                    try:
+                        line = _first_error_line(
+                            p.read_text(encoding="utf-8", errors="replace"))
+                    except OSError:
+                        continue
+                    if line:
+                        log_hits.append((p.stat().st_mtime, p.name, line))
+    log_hits.sort()
+    for i, (mtime, name, line) in enumerate(log_hits):
+        import time as _t
+        _record(i + 1, f"{line}  [{name}]", "yosys_log",
+                _t.strftime("%Y-%m-%dT%H:%M:%S", _t.localtime(mtime)))
+
+    # 3. The node-level failure this invocation is retrying.
+    if prior_error and str(prior_error).strip().lower() not in ("", "none"):
+        _record(max(1, int(node_attempt) - 1), prior_error, "node_previous_error")
+
+    # 4. The driver's own claim about how many attempts it took.
+    claimed = 0
+    for m in _ATTEMPT_CLAIM_RE.finditer(str(llm_reply or "")):
+        try:
+            claimed = max(claimed, int(m.group(1)))
+        except ValueError:
+            continue
+    if claimed > 1:
+        for n in range(1, claimed):
+            if n not in by_attempt:
+                _record(
+                    n,
+                    f"(not retained) the synthesis driver reported reaching "
+                    f"attempt {claimed}, so attempt {n} failed, but no error "
+                    f"text for it was written to the result JSON or to any log "
+                    f"under the output dir",
+                    "unrecorded",
+                )
+
+    return [by_attempt[k] for k in sorted(by_attempt)]
+
+
+def persist_synth_attempt_history(
+    result_json_path: str, history: list[dict]
+) -> bool:
+    """Merge ``history`` into the synthesis result artifact. True when written.
+
+    The artifact is the thing a later reader (diagnose, the final report, a
+    human) actually opens, so the record has to live THERE and not only in
+    graph state that dies with the process. Never raises.
+    """
+    if not result_json_path or not history:
+        return False
+    try:
+        import json as _json
+
+        p = Path(result_json_path)
+        data: dict = {}
+        if p.exists():
+            try:
+                loaded = _json.loads(p.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    data = loaded
+            except (OSError, ValueError):
+                data = {}
+        data["attempt_history"] = history
+        data["attempt_failures"] = len(history)
+        data["attempt_history_unrecorded"] = sum(
+            1 for h in history if h.get("unrecorded"))
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_json.dumps(data, indent=2), encoding="utf-8")
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def describe_synth_attempt_history(history: list[dict]) -> str:
+    """One-line-per-attempt human summary ('' when nothing failed)."""
+    if not history:
+        return ""
+    lines = [
+        f"{len(history)} failed synthesis attempt(s) BEFORE the reported outcome:"
+    ]
+    for h in history:
+        tag = " [NOT RETAINED]" if h.get("unrecorded") else ""
+        lines.append(
+            f"  attempt {h.get('attempt')}{tag} ({h.get('source')}, "
+            f"{h.get('timestamp')}): {h.get('error_summary')}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Flat Top-Level Synthesis (Yosys)
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/langgraph/bfm_lib/__init__.py
+++ b/orchestrator/langgraph/bfm_lib/__init__.py
@@ -55,6 +55,8 @@ from .codegen import (
     render_conformance_test_fn,
     render_contract_literal,
     render_integration_tb,
+    render_maxgeo_case_marker,
+    render_maxgeo_functional_test_fn,
     render_maxgeo_markers,
     render_maxgeo_probe_block,
     render_rom_bfm_module,
@@ -62,14 +64,29 @@ from .codegen import (
 )
 from .maxgeo import (
     BusMaxgeoCoverage,
+    MaxgeoDemand,
     bus_maxgeo_coverage,
     classify_dim_role,
+    declared_dimensional_maxima,
+    functional_maxgeo_dims,
     max_burst_bytes,
+    maxgeo_demand,
+    schema_dimensional_maxima,
+    token_match,
 )
 from .qspi_contract import QSPIContract
 from .qspi_master_bfm import QSPIMasterBFM
 from .qspi_rom_bfm import QSPIRomContract, QSPIRomResponderBFM
-from .stimulus import StimulusPlan, build_plan_from_run
+from .stimulus import (
+    MaxGeoCase,
+    StimulusPlan,
+    build_max_geometry_case,
+    build_plan_from_run,
+    load_acceptance_cases,
+    map_stimulus,
+    select_max_geometry_case,
+    stimulus_scalars,
+)
 
 __all__ = [
     "STATUS_BOUNDARY_OFF_TOP",
@@ -78,6 +95,8 @@ __all__ = [
     "STATUS_QSPI_TOP",
     "BusMaxgeoCoverage",
     "BusVerdict",
+    "MaxGeoCase",
+    "MaxgeoDemand",
     "PinBoundary",
     "QSPIContract",
     "QSPIMasterBFM",
@@ -86,28 +105,40 @@ __all__ = [
     "StimulusPlan",
     "arch_indicates_qspi_slave",
     "boundary_gate_enabled",
+    "build_max_geometry_case",
     "build_plan_from_run",
     "bus_maxgeo_coverage",
     "classify_bus_verdict",
     "classify_chip_bus",
     "classify_dim_role",
     "conformance_enabled",
+    "declared_dimensional_maxima",
     "describe_unmodeled_roles",
     "detect_bus_roles",
     "detect_dut_mastered_buses",
     "deterministic_bfm_enabled",
     "find_pin_boundary",
+    "functional_maxgeo_dims",
+    "load_acceptance_cases",
+    "map_stimulus",
     "max_burst_bytes",
+    "maxgeo_demand",
     "plan_deterministic_dv",
     "render_bfm_module",
     "render_conformance_tb",
     "render_conformance_test_fn",
     "render_contract_literal",
     "render_integration_tb",
+    "render_maxgeo_case_marker",
+    "render_maxgeo_functional_test_fn",
     "render_maxgeo_markers",
     "render_maxgeo_probe_block",
     "render_rom_bfm_module",
     "render_rom_contract_literal",
+    "schema_dimensional_maxima",
+    "select_max_geometry_case",
+    "stimulus_scalars",
+    "token_match",
     "write_deterministic_integration_tb",
     "write_qspi_conformance_tb",
 ]
@@ -231,18 +262,43 @@ def write_deterministic_integration_tb(
 
     ``declared_dims`` is the design's dimensional maxima; the bus-drivable subset
     is driven at maximum extent and advertised with a ``# MAXGEO`` marker.
+
+    The MAX-CONFIGURATION acceptance case is selected + baked here too (see
+    :func:`stimulus.build_max_geometry_case`): the primary plan is whichever case
+    the run declared FIRST -- the small canonical KAT -- so on its own it proves
+    nothing about the declared maxima. When a larger case exists it becomes a
+    second host-flow test in the same module, and the dims it drives at their
+    declared maximum are subtracted from the confession (and only those).
     """
+    maxgeo_case = None
+    schema_dims: dict = {}
+    try:
+        maxgeo_case = build_max_geometry_case(
+            project_root, contract, plan.case_name)
+    except Exception:  # noqa: BLE001 - a max case we cannot bake is simply absent
+        maxgeo_case = None
+    try:
+        schema_dims = schema_dimensional_maxima(project_root)
+    except Exception:  # noqa: BLE001
+        schema_dims = {}
     tb_src = render_integration_tb(
         contract, design_name, plan, include_conformance=include_conformance,
-        declared_dims=declared_dims,
+        declared_dims=declared_dims, maxgeo_case=maxgeo_case,
+        schema_dims=schema_dims,
+    )
+    functional = (
+        functional_maxgeo_dims(
+            maxgeo_case.scalars, schema_dims or declared_dims)
+        if maxgeo_case is not None else {}
     )
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(tb_src, encoding="utf-8")
+    extra_test = 1 if (maxgeo_case is not None and not maxgeo_case.is_primary) else 0
     return {
         "tb_path": str(out),
         "testbench_path": str(out),
-        "test_count": 2 if include_conformance else 1,
+        "test_count": (2 if include_conformance else 1) + extra_test,
         "deterministic_bfm": True,
         "qspi_conformance": bool(include_conformance),
         "contract_fingerprint": contract.fingerprint(),
@@ -250,6 +306,21 @@ def write_deterministic_integration_tb(
         # testbench was CAPABLE of driving instead of trusting what it claimed.
         "contract": contract.to_dict(),
         "case_name": plan.case_name,
+        # The MAX-CONFIGURATION case, so the gate reads the generator's record
+        # rather than re-deriving it (and can tell "no larger case exists" from
+        # "the generator skipped it").
+        "maxgeo_case": (
+            {
+                "name": maxgeo_case.plan.case_name,
+                "cfg0": maxgeo_case.cfg0,
+                "in_bytes": maxgeo_case.in_bytes,
+                "out_bytes": maxgeo_case.out_bytes,
+                "is_primary": maxgeo_case.is_primary,
+                "emitted_test": bool(extra_test),
+            }
+            if maxgeo_case is not None else None
+        ),
+        "maxgeo_functional": functional,
     }
 
 

--- a/orchestrator/langgraph/bfm_lib/codegen.py
+++ b/orchestrator/langgraph/bfm_lib/codegen.py
@@ -20,13 +20,15 @@ from __future__ import annotations
 
 import inspect
 
+import re as _re
+
 from . import qspi_contract as _contract_mod
 from . import qspi_master_bfm as _bfm_mod
 from . import qspi_rom_bfm as _rom_mod
-from .maxgeo import BusMaxgeoCoverage, bus_maxgeo_coverage
+from .maxgeo import BusMaxgeoCoverage, bus_maxgeo_coverage, functional_maxgeo_dims
 from .qspi_contract import QSPIContract
 from .qspi_rom_bfm import QSPIRomContract
-from .stimulus import StimulusPlan
+from .stimulus import MaxGeoCase, StimulusPlan
 
 # ---------------------------------------------------------------------------
 # CFG read-back probe patterns (bus-protocol conformance, phase A)
@@ -352,34 +354,191 @@ async def qspi_slave_protocol_conformance(dut):
 {op_probe}{maxgeo_block}'''
 
 
-def render_maxgeo_markers(coverage: BusMaxgeoCoverage | None) -> str:
+def marker_token(text: str) -> str:
+    """Collapse free-form text to a single whitespace-free marker token.
+
+    Marker lines are whitespace-separated ``key=value`` records; a case name
+    carrying a space would silently split into two bogus records.
+    """
+    tok = _re.sub(r"\s+", "_", str(text).strip())
+    return tok or "(unnamed)"
+
+
+def render_maxgeo_case_marker(case: MaxGeoCase | None) -> str:
+    """The ``# MAXGEO_CASE:`` marker naming the max-configuration host-flow case.
+
+    ``# MAXGEO_CASE: name=<case> cfg0=<value> in_bytes=<n> out_bytes=<n>``
+
+    Like ``MAXGEO_NOT_COVERED`` and ``MAXGEO_SCOPE``, the underscore form does
+    NOT match the gate's ``#\\s*MAXGEO\\b`` coverage regex, so the case record
+    can never be misparsed as a coverage claim for a dim literally named
+    ``cfg0``/``in_bytes``/``out_bytes``. It is a provenance record: WHICH case
+    the max-geometry functional test drives, and at what magnitudes.
+    """
+    if case is None:
+        return ""
+    return (
+        "# MAXGEO_CASE: name=%s cfg0=%d in_bytes=%d out_bytes=%d"
+        % (marker_token(case.plan.case_name), int(case.cfg0),
+           int(case.in_bytes), int(case.out_bytes))
+    )
+
+
+def render_maxgeo_markers(
+    coverage: BusMaxgeoCoverage | None,
+    functional: dict | None = None,
+    case: MaxGeoCase | None = None,
+) -> str:
     """The ``# MAXGEO`` header block for a generated testbench.
 
-    Three lines, all machine-readable:
+    Machine-readable, all of it:
 
-      ``# MAXGEO: <dim>=<max> ...``       -- ONLY dims this TB drives at maximum
+      ``# MAXGEO: <dim>=<max> ...``       -- BUS dims driven at maximum extent
+      ``# MAXGEO: <dim>=<max> ...``       -- COMPUTE-LANE dims the max-geometry
+                                             functional case drives at maximum
+                                             (omitted when there are none)
+      ``# MAXGEO_CASE: name=... ...``     -- which acceptance case that is
       ``# MAXGEO_SCOPE: ...``             -- what kind of coverage this is
       ``# MAXGEO_NOT_COVERED: <dim>=<max> ...`` -- what it does NOT reach
 
-    The last two deliberately do NOT match the gate's ``# MAXGEO\\b`` marker
-    regex (``MAXGEO_`` has no word boundary after ``MAXGEO``), so recording an
-    UNCOVERED dim can never be misread as coverage. A marker is a claim; a claim
-    without the traffic behind it is worse than no claim at all.
+    Only the ``# MAXGEO:`` lines match the gate's marker regex; every other tag
+    carries an underscore right after ``MAXGEO`` (no word boundary), so a
+    confession or a provenance record can never be misread as coverage. A marker
+    is a claim; a claim without the traffic behind it is worse than no claim.
+
+    ``functional`` dims are SUBTRACTED from the confession -- and only those: a
+    dim the functional case does not drive at its declared maximum stays
+    confessed, however large the case is.
     """
-    if coverage is None:
+    covered_line = coverage.marker_line() if coverage is not None else ""
+    func = {str(k): int(v) for k, v in (functional or {}).items()}
+    uncovered = {}
+    if coverage is not None:
+        uncovered = {n: v for n, v in coverage.uncovered.items() if n not in func}
+    case_line = render_maxgeo_case_marker(case)
+    if not (covered_line or func or uncovered or case_line):
         return ""
-    lines = [ln for ln in (coverage.marker_line(),) if ln]
-    if not lines and not coverage.uncovered:
-        return ""
-    lines.append(
-        "# MAXGEO_SCOPE: bus-contract-only -- this testbench is the deterministic "
-        "QSPI-slave\n#   conformance DV. It has NO compute oracle, so it drives the "
-        "BUS dimensions at\n#   their declared maxima and cannot drive compute-lane "
-        "geometry at all."
-    )
-    if coverage.uncovered_line():
-        lines.append(coverage.uncovered_line())
+
+    lines: list[str] = []
+    if covered_line:
+        lines.append(covered_line)
+    if func:
+        lines.append(
+            "# MAXGEO: "
+            + " ".join(f"{n}={v}" for n, v in sorted(func.items()))
+        )
+    if case_line:
+        lines.append(case_line)
+    if func or case is not None:
+        lines.append(
+            ("# MAXGEO_SCOPE: bus contract at declared maxima PLUS the "
+             if covered_line else
+             "# MAXGEO_SCOPE: no bus-maxima probes in this testbench; the ")
+            + "max-configuration\n#   host-flow case named in MAXGEO_CASE, whose "
+            "golden was evaluated at\n#   GENERATION time and is asserted "
+            "byte-exact. Compute-lane dimensions the\n#   selected case does not "
+            "drive at their declared maximum stay in\n#   MAXGEO_NOT_COVERED."
+        )
+    else:
+        lines.append(
+            "# MAXGEO_SCOPE: bus-contract-only -- this testbench is the deterministic "
+            "QSPI-slave\n#   conformance DV. It has NO compute oracle, so it drives the "
+            "BUS dimensions at\n#   their declared maxima and cannot drive compute-lane "
+            "geometry at all."
+        )
+    if uncovered:
+        pairs = " ".join(f"{n}={v}" for n, v in sorted(uncovered.items()))
+        lines.append(f"# MAXGEO_NOT_COVERED: {pairs}")
     return "\n".join(lines) + "\n"
+
+
+def render_maxgeo_functional_test_fn(
+    contract: QSPIContract, case: MaxGeoCase, marked: dict | None = None
+) -> str:
+    """Emit the MAX-CONFIGURATION host-flow ``@cocotb.test()`` as source.
+
+    Same shape as the primary host-flow test -- CFG writes, IN burst, START,
+    poll DONE, read OUT, byte-exact vs the golden -- but for the acceptance case
+    that drives the LARGEST geometry, with its golden baked at GENERATION time
+    exactly like the primary's. No runtime import of the reference model: the
+    emitted testbench stays hermetic.
+
+    The point is the counters, not a second correctness sample: a length/index
+    width sized below the declared maximum survives the small canonical case and
+    wraps here, and the first-differing-byte message says where.
+    """
+    plan = case.plan
+    clk = contract.clk_name
+    cfg_lits = ", ".join(f"({a}, {v}, {w})" for (a, v, w) in plan.cfg)
+    write_lits = ", ".join(
+        f"({a}, bytes.fromhex({d.hex()!r}))" for (a, d) in plan.writes
+    )
+    marked_txt = (
+        " ".join(f"{n}={v}" for n, v in sorted((marked or {}).items()))
+        or "(bus dimensions only)"
+    )
+    return f'''
+
+# ---- MAX-CONFIGURATION host-flow plan (largest acceptance case; baked here) --
+# Selected GENERICALLY: the acceptance case maximizing (IN payload bytes, CFG0).
+# Declared maxima this case drives directly: {marked_txt}
+MAXGEO_CFG_WRITES = [{cfg_lits}]      # (addr, value, width_bytes)
+MAXGEO_IN_WRITES = [{write_lits}]     # (addr, data)
+MAXGEO_OUT_LEN = {plan.out_len}
+MAXGEO_EXPECTED = bytes.fromhex({plan.expected.hex()!r})
+MAXGEO_CASE_NAME = {plan.case_name!r}
+
+
+@cocotb.test()
+async def deterministic_qspi_dv_max_geometry(dut):
+    """MAX-GEOMETRY host-flow DV for case {plan.case_name!r} (byte-exact vs golden).
+
+    A chip can pass every fixed-small-geometry test and still ship an index /
+    length / address counter that wraps at a 2^n boundary BELOW the declared
+    maximum. This test drives the largest configuration the acceptance suite
+    declares ({case.in_bytes} IN bytes, CFG0={case.cfg0}, {case.out_bytes} OUT
+    bytes) and asserts the full OUT window byte-for-byte.
+    """
+    c = CONTRACT
+    cocotb.start_soon(Clock(dut.{clk}, c.clk_period_ns, unit="ns").start())
+    bfm = QSPIMasterBFM(dut, c)
+    await bfm.reset_dut(10)
+
+    for addr, value, width in MAXGEO_CFG_WRITES:
+        await bfm.write_reg(addr, value, width)
+    for addr, data in MAXGEO_IN_WRITES:
+        await bfm.write(addr, data)
+
+    await bfm.start()
+    done = await bfm.wait_done()
+    assert done, (
+        "MAX-GEOMETRY: DUT never signalled STATUS.DONE for the max-configuration "
+        "op (case %s, {case.in_bytes} IN bytes, CFG0={case.cfg0}). It completes "
+        "the small case, so this is a counter/state machine that does not survive "
+        "the declared maximum." % MAXGEO_CASE_NAME
+    )
+
+    out = await bfm.read(OUT_ADDR, MAXGEO_OUT_LEN)
+    dut._log.info("[det-bfm/maxgeo] case=%s expected_len=%d observed_len=%d",
+                  MAXGEO_CASE_NAME, len(MAXGEO_EXPECTED), len(out))
+    if out != MAXGEO_EXPECTED:
+        _fd = next(
+            (i for i in range(min(len(out), len(MAXGEO_EXPECTED)))
+             if out[i] != MAXGEO_EXPECTED[i]),
+            min(len(out), len(MAXGEO_EXPECTED)),
+        )
+        raise AssertionError(
+            "MAX-GEOMETRY: OUT != golden reference at maximum configuration "
+            "(case %s). first_diff_byte=%d exp=0x%02x got=0x%02x "
+            "(exp_len=%d got_len=%d). The small canonical case passes, so look "
+            "for an index/length/address width that wraps below the declared "
+            "maximum." % (
+                MAXGEO_CASE_NAME, _fd,
+                MAXGEO_EXPECTED[_fd] if _fd < len(MAXGEO_EXPECTED) else 0,
+                out[_fd] if _fd < len(out) else 0,
+                len(MAXGEO_EXPECTED), len(out))
+        )
+'''
 
 
 def render_conformance_tb(
@@ -445,6 +604,8 @@ def render_integration_tb(
     *,
     include_conformance: bool = False,
     declared_dims: dict | None = None,
+    maxgeo_case: MaxGeoCase | None = None,
+    schema_dims: dict | None = None,
 ) -> str:
     """Emit a hermetic deterministic cocotb integration testbench.
 
@@ -467,15 +628,28 @@ def render_integration_tb(
 
     ``declared_dims`` (with ``include_conformance``) additionally drives the
     design's BUS maxima at maximum extent and emits the matching ``# MAXGEO``
-    marker. It never invents coverage for the compute lane: the golden host-flow
-    case above is whatever geometry the golden reference chose, and this
-    testbench does not claim otherwise.
+    marker.
+
+    ``maxgeo_case`` is the MAX-CONFIGURATION acceptance case (see
+    :func:`stimulus.build_max_geometry_case`). When supplied -- and when it is
+    not already the primary case -- a SECOND host-flow test is emitted for it,
+    with its golden baked at generation time exactly like the primary's, plus a
+    ``# MAXGEO_CASE`` provenance marker. Compute-lane dims that case drives at
+    their declared maximum (matched against ``schema_dims``, the typed ERS
+    parameter table, by name-token AND value) join the ``# MAXGEO`` marker;
+    everything else stays in the ``MAXGEO_NOT_COVERED`` confession. ``None``
+    keeps the emitted testbench byte-identical to before this existed.
     """
     coverage = (
         bus_maxgeo_coverage(contract, declared_dims)
         if (declared_dims and include_conformance) else None
     )
-    maxgeo_markers = render_maxgeo_markers(coverage)
+    functional = (
+        functional_maxgeo_dims(
+            maxgeo_case.scalars, schema_dims if schema_dims else declared_dims)
+        if maxgeo_case is not None else {}
+    )
+    maxgeo_markers = render_maxgeo_markers(coverage, functional, maxgeo_case)
     bfm_src = render_bfm_module(contract)
     cfg_lits = ", ".join(f"({a}, {v}, {w})" for (a, v, w) in plan.cfg)
     write_lits = ", ".join(f"({a}, bytes.fromhex({d.hex()!r}))" for (a, d) in plan.writes)
@@ -583,6 +757,12 @@ async def deterministic_qspi_dv(dut):
         f"exp={{EXPECTED.hex()}} got={{out.hex()}}"
     )
 '''
+    if maxgeo_case is not None and not maxgeo_case.is_primary:
+        # The MAX-CONFIGURATION functional case. Emitted only when it is a
+        # DIFFERENT case from the primary: when the largest case already IS the
+        # primary, a second identical test would prove nothing (the marker still
+        # records that the primary is the max-geometry case).
+        tb += render_maxgeo_functional_test_fn(contract, maxgeo_case, functional)
     if include_conformance:
         # Append the compute-lane-independent bus-protocol conformance test to the
         # SAME module: the golden host-flow test above already started the clock

--- a/orchestrator/langgraph/bfm_lib/maxgeo.py
+++ b/orchestrator/langgraph/bfm_lib/maxgeo.py
@@ -11,11 +11,11 @@ and still ship an index/address width that wraps at a 2^n boundary below the
 declared maximum.
 
 The deterministic QSPI conformance testbench is COMPUTE-LANE INDEPENDENT: it has
-no golden model, so it cannot render a frame, rasterize a triangle or transform a
-block. What it CAN do is drive the *bus* at maximum extent -- the full-width
-address, the longest legal write burst, the longest legal read burst, the largest
-command opcode -- and those are real dimensional maxima with real index widths
-behind them.
+no golden model, so it cannot evaluate any compute-lane transform at all. What it
+CAN do is drive the *bus* at maximum extent -- the full-width address, the
+longest legal write burst, the longest legal read burst, the largest command
+opcode -- and those are real dimensional maxima with real index widths behind
+them.
 
 This module decides, from the bus contract plus the design's declared maxima,
 exactly which dims fall in that set. Two callers use it, and they must agree:
@@ -27,6 +27,23 @@ exactly which dims fall in that set. Two callers use it, and they must agree:
 
 That split is the point. If only codegen decided, the testbench would be marking
 its own homework -- the failure mode this repo keeps paying for.
+
+SINGLE SOURCE (dimension-registry alignment). Three numbers used to disagree on
+a live run: the gate ENFORCED 9 dims, the testbench CONFESSED 13 uncovered, and
+the design's own declared table had 18. Nothing was lying -- the three were
+derived three different ways. They are now derived here, once:
+
+  * :func:`declared_dimensional_maxima` -- THE declared table (param schema
+    first, the legacy generic harvest folded in), for gate and generator alike.
+  * :func:`bus_maxgeo_coverage` -- THE classification (bus-drivable vs
+    compute-lane), for the generator's confession and the gate's demand alike.
+  * :func:`maxgeo_demand` -- THE marker verdict: which declared maxima the
+    testbench actually PROVED (name AND value), which merely collide in VALUE
+    with some other dim's marker (weak evidence -- the old gate silently counted
+    these as covered, which is the whole 13-vs-9 delta), and which are missing.
+
+``proven + value_only + missing`` is always the full declared table, so the
+three numbers now reconcile by construction.
 
 **A marker is a claim about coverage that EXISTS.** Nothing here ever reports a
 dim as covered unless the emitted testbench actually drives that value on the
@@ -43,9 +60,11 @@ the protocol knowledge lives in the protocol layer.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from .qspi_contract import QSPIContract
 
@@ -228,3 +247,195 @@ def bus_maxgeo_coverage(
 
 def _is_pos_int(v) -> bool:
     return isinstance(v, int) and not isinstance(v, bool) and v > 0
+
+
+# ---------------------------------------------------------------------------
+# THE declared-dimension registry (one derivation, two consumers)
+# ---------------------------------------------------------------------------
+
+#: Machine-readable spec artifacts the legacy generic ``{name, extent}`` harvest
+#: reads. Identical to ``pipeline_graph``'s list, deliberately: this function
+#: exists to REPLACE that one, not to disagree with it.
+DIM_SOURCE_FILES = (
+    "ers_spec.json", "prd_spec.json", "block_specs.json", "block_queue.json",
+)
+
+
+def declared_dimensional_maxima(project_root: str) -> dict[str, int]:
+    """``{dim_name: max}`` -- the design's declared dimensional maxima.
+
+    ONE derivation, for both the generator (what may I claim / what must I
+    confess?) and the gate (what do I demand?). Two sources, merged max-wise,
+    exactly as the gate's own ``_declared_dimensions`` merged them:
+
+      * PRIMARY -- the typed ERS ``parameters`` block (``role`` in
+        ``dimension``/``range`` carries an extent). Authoritative and
+        deterministic; ``mode`` parameters are control-selects, not geometry,
+        and are excluded.
+      * FOLDED IN -- the legacy generic ``{name-role, extent-role}`` harvest
+        over the ERS/PRD/block-spec JSON plus the FRD FUNC vectors, so a legacy
+        prose ERS (no ``parameters`` block) behaves exactly as before.
+
+    Returns ``{}`` when the design declares nothing dimensional (the gate then
+    no-ops). NEVER raises: a dimensional registry that can throw would take a
+    run down over an unreadable spec file.
+    """
+    dims: dict[str, int] = {}
+    root = Path(project_root)
+    try:
+        from orchestrator.architecture import param_schema as _psch
+    except Exception:  # noqa: BLE001 - no schema module -> no registry
+        return dims
+    try:
+        for name, mx in _psch.declared_maxima(
+                _psch.parameters_from_ers(project_root)).items():
+            dims[str(name)] = max(int(mx), dims.get(str(name), 0))
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        for fname in DIM_SOURCE_FILES:
+            p = root / ".coresmith" / fname
+            if not p.exists():
+                continue
+            try:
+                _psch._harvest_candidate_dims(
+                    json.loads(p.read_text(encoding="utf-8")), dims)
+            except (OSError, json.JSONDecodeError, ValueError, TypeError):
+                continue
+        frd = root / "arch" / "frd_spec.md"
+        if frd.exists():
+            try:
+                from orchestrator.architecture.composition import (
+                    parse_func_vectors,
+                )
+                _psch._harvest_candidate_dims(
+                    parse_func_vectors(frd.read_text(encoding="utf-8")), dims)
+            except Exception:  # noqa: BLE001
+                pass
+    except Exception:  # noqa: BLE001
+        return {k: int(v) for k, v in dims.items() if _is_pos_int(int(v))}
+    return {k: int(v) for k, v in dims.items() if _is_pos_int(int(v))}
+
+
+def schema_dimensional_maxima(project_root: str) -> dict[str, int]:
+    """``{name: max}`` from the typed ERS ``parameters`` block ONLY.
+
+    The subset of :func:`declared_dimensional_maxima` whose names are
+    design-AFFIRMED parameter identifiers rather than free-form strings scraped
+    out of arbitrary spec JSON. Functional max-geometry coverage is claimed
+    against THIS table (see :func:`functional_maxgeo_dims`) because the claim
+    rests on matching a declared parameter to a stimulus key by name, and a
+    scraped name is not a declared parameter. ``{}`` for a legacy prose ERS.
+    """
+    try:
+        from orchestrator.architecture import param_schema as _psch
+        return {
+            str(n): int(v) for n, v in _psch.declared_maxima(
+                _psch.parameters_from_ers(project_root)).items()
+            if _is_pos_int(int(v))
+        }
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+@dataclass(frozen=True)
+class MaxgeoDemand:
+    """What a testbench's ``# MAXGEO`` marker actually PROVES about the table.
+
+    ``proven``     -- the marker names the dim AND carries its declared maximum.
+                      Real, attributable evidence.
+    ``value_only`` -- the declared maximum appears in the marker, but under some
+                      OTHER dim's name. Two dims of the same extent (a 4096-deep
+                      framebuffer and a 4096-byte read burst) make this happen
+                      constantly, and the name-agnostic gate counted it as
+                      coverage -- claiming a compute-lane maximum was exercised
+                      because a bus burst happened to be the same number.
+    ``missing``    -- no marker evidence of any kind.
+
+    The three partition the declared table, which is the point: the gate's demand
+    (``missing``), the generator's confession (``value_only | missing``) and the
+    declared table (all three) are now three views of ONE computation.
+    """
+
+    proven: dict[str, int] = field(default_factory=dict)
+    value_only: dict[str, int] = field(default_factory=dict)
+    missing: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def unproven(self) -> dict[str, int]:
+        """Everything without name-attributable evidence -- the honest confession."""
+        return {**self.value_only, **self.missing}
+
+    def describe(self) -> str:
+        return (
+            f"proven={self.proven} value_only(weak)={self.value_only} "
+            f"missing={self.missing}"
+        )
+
+
+def maxgeo_demand(declared_dims: dict | None, marker: dict | None) -> MaxgeoDemand:
+    """Split a declared table against a testbench's parsed ``# MAXGEO`` pairs.
+
+    Pure function -- no disk, no testbench text, no DUT. ``marker`` is
+    ``{name: value}`` as parsed from the artifact's ``# MAXGEO:`` lines.
+    """
+    dims = {str(k): int(v) for k, v in (declared_dims or {}).items()
+            if _is_pos_int(v)}
+    pairs = {str(k): int(v) for k, v in (marker or {}).items()
+             if _is_pos_int(v)}
+    values = set(pairs.values())
+    proven: dict[str, int] = {}
+    value_only: dict[str, int] = {}
+    missing: dict[str, int] = {}
+    for name, mx in sorted(dims.items()):
+        if pairs.get(name) == mx:
+            proven[name] = mx
+        elif mx in values:
+            value_only[name] = mx
+        else:
+            missing[name] = mx
+    return MaxgeoDemand(proven=proven, value_only=value_only, missing=missing)
+
+
+def token_match(dim_name: str, key: str) -> bool:
+    """True when a declared dimension NAME and a stimulus KEY name the same axis.
+
+    Subset in either direction, never a bare intersection: ``frame_width`` and
+    ``burst_width`` share the token ``width`` yet are different axes, so an
+    intersection rule would let a driven burst width claim coverage of a frame
+    width. ``{width} <= {frame, width}`` (key ``width`` for dim ``frame_width``)
+    and an exact match both pass; ``{burst,width}`` vs ``{frame,width}`` does not.
+    """
+    a, b = _tokens(dim_name), _tokens(key)
+    if not a or not b:
+        return False
+    return a <= b or b <= a
+
+
+def functional_maxgeo_dims(
+    scalars: dict | None, declared_dims: dict | None
+) -> dict[str, int]:
+    """Declared maxima a FUNCTIONAL host-flow case DRIVES, by direct evidence.
+
+    ``scalars`` is the integer-valued subset of the chosen acceptance case's
+    stimulus dict -- the numbers the generated testbench actually writes onto the
+    pins for that case. A dim is claimed only when BOTH hold:
+
+      * some scalar key :func:`token_match`-es the dimension name, and
+      * that scalar's VALUE equals the declared maximum.
+
+    Everything else stays in the ``MAXGEO_NOT_COVERED`` confession. A marker is a
+    claim about traffic that exists; a dimension we merely believe is implied by
+    a big case is not driven evidence and is not claimed.
+    """
+    dims = {str(k): int(v) for k, v in (declared_dims or {}).items()
+            if _is_pos_int(v)}
+    vals = {str(k): int(v) for k, v in (scalars or {}).items()
+            if _is_pos_int(v)}
+    out: dict[str, int] = {}
+    for name, mx in sorted(dims.items()):
+        for key, val in sorted(vals.items()):
+            if val == mx and token_match(name, key):
+                out[name] = mx
+                break
+    return out

--- a/orchestrator/langgraph/bfm_lib/stimulus.py
+++ b/orchestrator/langgraph/bfm_lib/stimulus.py
@@ -17,15 +17,26 @@ following the QSPI-slave *host flow*:
 The stimulus->pins mapping is the documented QSPI-slave convention (PROTOCOL.md
 "Per-design mapping"): a stimulus ``dict`` contributes its ``key`` bytes (if
 any) followed by its ``data``/``plaintext``/``payload`` bytes to the IN window,
-and a block/length scalar to CFG0. This covers the aes exemplar and the
-data-in/result-out designs (fft/raster). Anything that does not fit returns
-``None`` so the caller falls back to the LLM BFM with a loud advisory.
+and a block/length scalar to CFG0. This covers the block-cipher exemplar and the
+data-in/result-out designs. Anything that does not fit returns ``None`` so the
+caller falls back to the LLM BFM with a loud advisory.
+
+TWO cases, not one. The canonical (first) acceptance case is the KAT: small,
+deterministic, representative -- and therefore NOT a max-geometry test. A run
+that ships only that case can pass every fixed-small-geometry check and still
+carry an index/length counter that wraps below the declared maximum. So this
+module also selects, GENERICALLY, the case that drives the largest geometry
+(:func:`select_max_geometry_case`, ranked by IN-payload bytes then the CFG0
+scalar) and bakes its golden the same generation-time way. No case-name
+literals, no design-specific keys: the ranking is over magnitudes the host flow
+actually drives on the pins.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -70,11 +81,33 @@ def _flatten_bytes(value: Any) -> bytes:
 
 
 def _import_from_path(path: Path, mod_name: str):
+    """Import a run-input module by path, with its OWN directory importable.
+
+    The acceptance stimulus routinely imports its sibling golden by bare module
+    name (``from <design>_golden import make_stimulus``). Loading it by path
+    alone leaves that sibling unresolvable, so whether the plan builds at all
+    depended on whether some EARLIER engine step happened to have put
+    ``inputs/`` on ``sys.path`` first -- an import-order coincidence, and a
+    silent fallback to the LLM BFM when it did not hold. The parent directory is
+    inserted for the duration of the exec and removed after, so nothing leaks
+    into the process's import path.
+    """
     spec = importlib.util.spec_from_file_location(mod_name, str(path))
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot load {path}")
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    parent = str(path.resolve().parent)
+    injected = parent not in sys.path
+    if injected:
+        sys.path.insert(0, parent)
+    try:
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    finally:
+        if injected:
+            try:
+                sys.path.remove(parent)
+            except ValueError:  # pragma: no cover - another thread removed it
+                pass
     return mod
 
 
@@ -102,52 +135,63 @@ def _load_reference(project_root: str) -> Callable | None:
     return None
 
 
+def load_acceptance_cases(project_root: str) -> list[tuple[str, Any]]:
+    """EVERY acceptance case ``(name, stimulus)`` for this run, in declared order.
+
+    ``[]`` when the run declares no acceptance stimulus at all. A single-stimulus
+    module (``stimulus = ...`` rather than ``cases = [...]``) yields one entry, so
+    callers never special-case the shape.
+    """
+    p = Path(project_root) / "inputs" / "acceptance_stimulus.py"
+    if not p.exists():
+        p2 = Path(project_root) / "inputs" / "model_stimulus.py"
+        if not p2.exists():
+            return []
+        try:
+            mod = _import_from_path(p2, "_cs_model_stim")
+        except Exception:  # noqa: BLE001
+            return []
+        stim = getattr(mod, "stimulus", None)
+        return [("model_stimulus", stim)] if stim is not None else []
+    try:
+        mod = _import_from_path(p, "_cs_accept_stim")
+    except Exception:  # noqa: BLE001
+        return []
+    cases = getattr(mod, "cases", None)
+    out: list[tuple[str, Any]] = []
+    if cases:
+        for entry in cases:
+            try:
+                name, stim = entry
+            except (TypeError, ValueError):
+                continue
+            out.append((str(name), stim))
+        return out
+    stim = getattr(mod, "stimulus", None)
+    return [("stimulus", stim)] if stim is not None else []
+
+
 def _load_acceptance_case(project_root: str) -> tuple[str, Any] | None:
     """Load the FIRST acceptance case ``(name, stimulus)`` for this run.
 
     The deterministic DV uses the first acceptance case (the KAT) as its
     canonical vector -- deterministic and representative.
     """
-    p = Path(project_root) / "inputs" / "acceptance_stimulus.py"
-    if not p.exists():
-        p2 = Path(project_root) / "inputs" / "model_stimulus.py"
-        if not p2.exists():
-            return None
-        try:
-            mod = _import_from_path(p2, "_cs_model_stim")
-        except Exception:  # noqa: BLE001
-            return None
-        stim = getattr(mod, "stimulus", None)
-        return ("model_stimulus", stim) if stim is not None else None
-    try:
-        mod = _import_from_path(p, "_cs_accept_stim")
-    except Exception:  # noqa: BLE001
-        return None
-    cases = getattr(mod, "cases", None)
-    if cases:
-        name, stim = cases[0]
-        return (str(name), stim)
-    stim = getattr(mod, "stimulus", None)
-    return ("stimulus", stim) if stim is not None else None
+    cases = load_acceptance_cases(project_root)
+    return cases[0] if cases else None
 
 
-def build_plan_from_run(
-    project_root: str, contract: QSPIContract
-) -> StimulusPlan | None:
-    """Build a deterministic host-flow plan + oracle from the run artifacts.
+def map_stimulus(stim: Any) -> tuple[bytes, int | None]:
+    """``(IN-window bytes, CFG0 scalar)`` for one stimulus -- the host-flow
+    convention, in ONE place so case selection and plan construction rank and
+    drive the same magnitudes.
 
-    Returns None when a contract-faithful, self-contained plan cannot be
-    derived (no acceptance stimulus, no pure reference, or a stimulus shape the
-    host-flow convention does not cover) -- the caller then falls back to the
-    LLM BFM with a loud advisory.
+    A stimulus ``dict`` contributes ``key`` bytes then ``data``/``plaintext``/
+    ``payload`` bytes; the CFG0 scalar comes from the first of ``n_blocks``,
+    ``length``, ``count``, ``mode``, ``cfg0`` that is present, else defaults to
+    the number of 16-byte blocks in the data window. A non-dict stimulus is
+    flattened whole into the IN window.
     """
-    case = _load_acceptance_case(project_root)
-    ref = _load_reference(project_root)
-    if case is None or ref is None:
-        return None
-    case_name, stim = case
-
-    # Map stimulus -> IN-window bytes + CFG0 scalar (host-flow convention).
     key_bytes = b""
     data_bytes = b""
     cfg0_val: int | None = None
@@ -166,23 +210,72 @@ def build_plan_from_run(
     else:
         data_bytes = _flatten_bytes(stim)
 
-    in_bytes = key_bytes + data_bytes
+    if cfg0_val is None and data_bytes:
+        cfg0_val = max(1, (len(data_bytes) + 15) // 16)
+    return key_bytes + data_bytes, cfg0_val
+
+
+def stimulus_scalars(stim: Any) -> dict[str, int]:
+    """The integer-valued entries of a stimulus dict (``{}`` for other shapes).
+
+    These are the design's OWN parameter names carrying the values this case
+    drives -- the evidence a functional max-geometry marker is allowed to rest
+    on. Names are opaque data: nothing here knows any design's vocabulary.
+    """
+    if not isinstance(stim, dict):
+        return {}
+    out: dict[str, int] = {}
+    for k, v in stim.items():
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, int):
+            out[str(k)] = v
+        elif isinstance(v, float) and float(v).is_integer():
+            out[str(k)] = int(v)
+    return out
+
+
+def select_max_geometry_case(
+    cases: list[tuple[str, Any]]
+) -> tuple[str, Any] | None:
+    """The acceptance case that drives the LARGEST geometry, chosen generically.
+
+    Ranked by ``(len(IN payload bytes), CFG0 scalar)`` -- the two magnitudes the
+    QSPI host flow actually puts on the pins, so the winner is the case whose
+    length/index counters run furthest. Ties keep the earlier-declared case, so
+    selection is deterministic for a given acceptance module. ``None`` for an
+    empty list.
+    """
+    best: tuple[str, Any] | None = None
+    best_key: tuple[int, int] | None = None
+    for name, stim in cases or []:
+        try:
+            in_bytes, cfg0 = map_stimulus(stim)
+        except Exception:  # noqa: BLE001 - a malformed case is skipped, not fatal
+            continue
+        key = (len(in_bytes), int(cfg0 or 0))
+        if best_key is None or key > best_key:
+            best_key, best = key, (str(name), stim)
+    return best
+
+
+def _plan_from_case(
+    case_name: str, stim: Any, ref: Callable, contract: QSPIContract
+) -> StimulusPlan | None:
+    """One acceptance case -> a concrete host-flow plan with a BAKED oracle.
+
+    The golden reference is evaluated HERE, at generation time, exactly once per
+    case -- the emitted testbench carries bytes, never an import of the model.
+    """
+    in_bytes, cfg0_val = map_stimulus(stim)
     if not in_bytes:
         return None
-
-    # Reference oracle (pure). Must return bytes-like.
     try:
         expected = bytes(_flatten_bytes(ref(stim)))
     except Exception:  # noqa: BLE001
         return None
     if not expected:
         return None
-
-    # CFG0 default: number of 16-byte blocks in the data window (aes/stream
-    # convention) when the design did not name a scalar explicitly.
-    if cfg0_val is None and data_bytes:
-        cfg0_val = max(1, (len(data_bytes) + 15) // 16)
-
     plan = StimulusPlan(
         out_addr=contract.out_addr,
         out_len=len(expected),
@@ -193,6 +286,76 @@ def build_plan_from_run(
         plan.cfg.append((contract.cfg0_addr, cfg0_val, 4))
     plan.writes.append((contract.in_addr, in_bytes))
     return plan
+
+
+@dataclass
+class MaxGeoCase:
+    """The largest acceptance case, with its baked plan and driven scalars.
+
+    ``is_primary`` is True when the largest case IS the canonical first case --
+    the generator then emits no second test (there is nothing extra to drive)
+    but still advertises the ``# MAXGEO_CASE`` marker, because the primary test
+    genuinely IS the max-geometry case and the artifact should say so.
+    """
+
+    plan: StimulusPlan
+    scalars: dict[str, int] = field(default_factory=dict)
+    in_bytes: int = 0
+    out_bytes: int = 0
+    cfg0: int = 0
+    is_primary: bool = False
+
+
+def build_max_geometry_case(
+    project_root: str, contract: QSPIContract, primary_case_name: str = ""
+) -> MaxGeoCase | None:
+    """Select + bake the maximum-configuration acceptance case for this run.
+
+    ``None`` when the run declares no acceptance cases, no pure reference, or the
+    winning case's stimulus shape the host-flow convention does not cover -- the
+    generator then emits exactly what it emitted before this existed.
+    """
+    cases = load_acceptance_cases(project_root)
+    if not cases:
+        return None
+    ref = _load_reference(project_root)
+    if ref is None:
+        return None
+    chosen = select_max_geometry_case(cases)
+    if chosen is None:
+        return None
+    case_name, stim = chosen
+    plan = _plan_from_case(case_name, stim, ref, contract)
+    if plan is None:
+        return None
+    in_bytes = sum(len(d) for (_a, d) in plan.writes)
+    cfg0 = plan.cfg[0][1] if plan.cfg else 0
+    return MaxGeoCase(
+        plan=plan,
+        scalars=stimulus_scalars(stim),
+        in_bytes=in_bytes,
+        out_bytes=plan.out_len,
+        cfg0=int(cfg0),
+        is_primary=bool(primary_case_name) and case_name == primary_case_name,
+    )
+
+
+def build_plan_from_run(
+    project_root: str, contract: QSPIContract
+) -> StimulusPlan | None:
+    """Build a deterministic host-flow plan + oracle from the run artifacts.
+
+    Returns None when a contract-faithful, self-contained plan cannot be
+    derived (no acceptance stimulus, no pure reference, or a stimulus shape the
+    host-flow convention does not cover) -- the caller then falls back to the
+    LLM BFM with a loud advisory.
+    """
+    case = _load_acceptance_case(project_root)
+    ref = _load_reference(project_root)
+    if case is None or ref is None:
+        return None
+    case_name, stim = case
+    return _plan_from_case(case_name, stim, ref, contract)
 
 
 def load_plan_json(path: str) -> StimulusPlan:

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -39,10 +39,17 @@ So this is deterministic and it runs per block, right after RTL generation --
 not at integration. An integration-time failure has already paid for seven other
 blocks; a block-time failure is one cheap regeneration with an exact expected
 name to fix.
+
+:func:`run_conformance_stage` is the production entry point the per-block RTL
+flow calls (see ``generate_testbench_node``): check -> unambiguous repair ->
+re-check, with the testbench's port references carried along. Everything here is
+pure file I/O and returns a record; the caller owns logging, the block verdict
+and the park.
 """
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -374,3 +381,152 @@ def repair_block_ports(project_root, block_name: str, rtl_path,
     out["after"] = len(after.missing)
     out["conforms"] = after.ok
     return out
+
+
+# ---------------------------------------------------------------------------
+# Production stage: check -> repair -> re-check, wired into the block RTL flow
+# ---------------------------------------------------------------------------
+
+def conformance_gate_enabled() -> bool:
+    """Contract-conformance stage in the per-block RTL flow (default ON).
+
+    ``CORESMITH_CONTRACT_CONFORMANCE_GATE=0`` disables it -- the same env-gate
+    convention as the storage / ifdef / stage lints.
+    """
+    return (os.environ.get("CORESMITH_CONTRACT_CONFORMANCE_GATE", "1")
+            or "1").strip().lower() not in {"0", "false", "no", "off"}
+
+
+#: How a cocotb testbench names a DUT port. A rename is applied to THESE forms
+#: only. A blanket word-boundary substitution over the TB would also rewrite a
+#: local variable that happens to share a generic signal name (`read_enable` is
+#: not distinctive), and corrupting a testbench to fix a port name trades a
+#: loud failure for a silent one.
+def _tb_ref_patterns(old: str) -> list[tuple[str, str]]:
+    o = re.escape(old)
+    return [
+        (rf"(?<![\w.])dut\.{o}\b", "dut.{new}"),
+        (rf"(?<![\w.])dut\._id\(\s*(['\"]){o}\1", 'dut._id("{new}"'),
+        (rf"getattr\(\s*dut\s*,\s*(['\"]){o}\1", 'getattr(dut, "{new}"'),
+    ]
+
+
+def repair_testbench_refs(tb_path, renames: dict) -> dict:
+    """Rewrite a testbench's DUT port references after a port rename.
+
+    Returns ``{"applied": {old: n_sites}, "residual": [old, ...],
+    "changed": bool, "needs_regen": bool}``. ``residual`` lists renamed ports
+    whose OLD name still appears as a bare word in the testbench after the
+    narrow rewrite -- either a harmless local, or a port reference in a form
+    this function deliberately does not touch (a generated testbench really does
+    drive ``getattr(dut, field)`` over a tuple of port-name STRINGS, and the
+    same strings key its stimulus dict, which is also how it feeds the Amaranth
+    block model; blanket-renaming quoted strings would corrupt the model side).
+
+    So residual references are not guessed at -- they set ``needs_regen``, and
+    the caller regenerates the testbench against the repaired RTL. That is one
+    cheap testbench call instead of a sim failure that costs an RTL attempt,
+    and it never invents a mapping the checker cannot prove.
+    """
+    out: dict = {"applied": {}, "residual": [], "changed": False,
+                 "needs_regen": False}
+    p = Path(tb_path)
+    if not renames or not tb_path or not p.exists():
+        return out
+    try:
+        text = original = p.read_text(errors="ignore")
+    except OSError:
+        return out
+    for old, new in renames.items():
+        n = 0
+        for pat, repl in _tb_ref_patterns(old):
+            text, k = re.subn(pat, repl.format(new=new), text)
+            n += k
+        if n:
+            out["applied"][old] = n
+        if re.search(r"\b" + re.escape(old) + r"\b", text):
+            out["residual"].append(old)
+    out["needs_regen"] = bool(out["residual"])
+    if text != original:
+        try:
+            Path(str(tb_path) + ".pre_portrepair").write_text(original)
+            p.write_text(text)
+            out["changed"] = True
+        except OSError:
+            return {"applied": {}, "residual": sorted(renames),
+                    "changed": False, "needs_regen": True}
+    return out
+
+
+def run_conformance_stage(project_root, block_name: str, rtl_path,
+                          siblings=(), tb_path: str = "") -> dict:
+    """Check one block against its contract, repair what is unambiguous, re-check.
+
+    This is what the per-block flow calls. It NEVER decides the block's fate --
+    it returns the record and the caller (``generate_testbench_node``) logs it,
+    fails the block, or parks.
+
+    Returns::
+
+        {ran, ok, reason, checked_edges, renames{old:new}, rename_channels,
+         before_missing, after_missing, deviations[], feedback, tb{...}}
+
+    ``ran`` is False (and ``ok`` True) when the stage does not apply: no
+    contract edge names this block, or the RTL is unreadable. Those are other
+    gates' jobs -- this one must not invent a verdict it has no evidence for.
+    """
+    out: dict = {
+        "block": block_name, "ran": False, "ok": True, "reason": "",
+        "checked_edges": 0, "renames": {}, "rename_channels": {},
+        "before_missing": 0, "after_missing": 0, "deviations": [],
+        "feedback": "",
+        "tb": {"applied": {}, "residual": [], "changed": False,
+               "needs_regen": False},
+    }
+    before = check_block(project_root, block_name, rtl_path, siblings=siblings)
+    if before.reason:
+        out["reason"] = before.reason
+        return out
+    out["checked_edges"] = before.checked_edges
+    if not before.checked_edges:
+        out["reason"] = ("no interface contract edge names this block -- "
+                         "nothing to conform to")
+        return out
+
+    out["ran"] = True
+    out["before_missing"] = len(before.missing)
+    out["deviations"] = _deviation_lines(before)
+    if before.ok:
+        out["ok"] = True
+        return out
+
+    # Repair only the unambiguous renames, then let the checker -- not the
+    # repairer -- say whether the block conforms.
+    want_channel = {port: chan for chan, port in before.missing}
+    rep = repair_block_ports(project_root, block_name, rtl_path,
+                             siblings=siblings, apply=True)
+    renames = rep.get("renames") or {}
+    out["renames"] = dict(renames)
+    out["rename_channels"] = {
+        old: want_channel.get(new, "") for old, new in renames.items()
+    }
+
+    after = check_block(project_root, block_name, rtl_path, siblings=siblings)
+    out["after_missing"] = len(after.missing)
+    out["ok"] = after.ok
+    if not after.ok:
+        out["deviations"] = _deviation_lines(after)
+        out["feedback"] = after.as_feedback()
+
+    if renames:
+        out["tb"] = repair_testbench_refs(tb_path, renames)
+    return out
+
+
+def _deviation_lines(res: ConformanceResult) -> list[str]:
+    """One flat, greppable line per deviation (for logs + the run artifact)."""
+    lines = [f"missing {port} (channel '{chan}')" for chan, port in res.missing]
+    lines += [f"undeclared port {p}" for p in res.undeclared]
+    lines += [f"ambiguous channel '{c}': {why}" for c, why in res.ambiguous]
+    lines += [f"instantiates sibling block {s}" for s in res.instantiates]
+    return lines

--- a/orchestrator/langgraph/drc_verdict.py
+++ b/orchestrator/langgraph/drc_verdict.py
@@ -11,7 +11,7 @@ DRC run that produced NO REPORT AT ALL as::
 
     {"pass": false, "violation_count": -1}   ->   stage {"ok": false, "violations": -1}
 
-Two real macros in ``exp-raster-macro-20260727`` (``w32_d64``, ``w9_d512``)
+Two real macros from a validation run (``w32_d64``, ``w9_d512``)
 carry exactly that, and the ``precheck_magic_drc.rpt`` those verdicts name was
 never written -- Magic produced nothing even though the binary was on PATH.
 ``-1`` was *intended* as a "could not measure" sentinel, but every consumer read

--- a/orchestrator/langgraph/final_report.py
+++ b/orchestrator/langgraph/final_report.py
@@ -104,6 +104,25 @@ def _carried_forward_defects(project_root: str) -> list:
     return []
 
 
+def _retired_blocks(state: dict, project_root: str) -> list:
+    """Blocks a declared PRD pin map RETIRED before µarch/RTL.
+
+    Without this the scorecard reads as "7 blocks" with no account of the
+    eighth: a reader comparing it to the architecture's 8-block diagram cannot
+    tell a deliberate retirement from a block that silently vanished. State
+    first (authoritative for the run that just executed), then the carried
+    artifact (so a report built from a bare project root still explains it).
+    """
+    rows = state.get("retired_blocks") or []
+    if isinstance(rows, list) and rows:
+        return [r for r in rows if isinstance(r, dict)]
+    try:
+        from orchestrator.architecture.pin_map_retire import read_retired_blocks
+        return read_retired_blocks(project_root)
+    except Exception:  # noqa: BLE001
+        return []
+
+
 def _chip_throughput(project_root: str) -> dict:
     """Chip-level measured-throughput record (v3): read the persisted
     ``.coresmith/chip_throughput.json`` (from the deterministic-BFM integration
@@ -494,6 +513,10 @@ def build_final_report(state: dict, project_root: str, *,
     # a quantified divergence.
     carried_defects = _carried_forward_defects(project_root)
 
+    # Blocks a declared pin map retired before µarch/RTL: deliberately absent
+    # from the chip, so the block count below is short by design, not by defect.
+    retired_blocks = _retired_blocks(state, project_root)
+
     # Section 7a: engine provenance -- which engine build produced this run, and
     # whether the code was hot-swapped mid-run.
     engine_prov = _engine_provenance(project_root)
@@ -535,12 +558,14 @@ def build_final_report(state: dict, project_root: str, *,
             "integration_dv": _verdict_word(integ_ok, integ_stage["ran"]),
             "validation_dv": _verdict_word(valid_ok, valid_stage["ran"]),
             "carried_forward_defect_count": len(carried_defects),
+            "retired_block_count": len(retired_blocks),
             "throughput_blocks_gated": len(tput_gated),
             "throughput_blocks_failed": tput_failed,
             "chip_measured_cyc_per_op": chip_throughput.get(
                 "measured_cyc_per_op_chip"),
         },
         "carried_forward_defects": carried_defects,
+        "retired_blocks": retired_blocks,
         "blocks": blocks_out,
         "chip": {
             "integration_dv": integ_stage,
@@ -684,7 +709,34 @@ def render_markdown(report: dict) -> str:
     if cfd:
         lines.append(f"- Carried-forward defects: **{len(cfd)}** "
                      f"(advisory bypasses that did not hard-block)")
+    rtb = report.get("retired_blocks", []) or []
+    if rtb:
+        lines.append(
+            f"- Retired blocks: **{len(rtb)}** "
+            f"({', '.join(str(r.get('block', '?')) for r in rtb)}) — "
+            f"deliberately absent, not missing"
+        )
     lines.append("")
+
+    # ---- retired blocks (a pin map replaced them) ----
+    if rtb:
+        lines.append("## Retired blocks (replaced by the PRD pin map)")
+        lines.append("")
+        lines.append(
+            "These blocks were NOT microarchitected, generated, simulated or "
+            "synthesized, and are deliberately ABSENT from the assembled chip. "
+            "The block count above is short by exactly this many, by design."
+        )
+        lines.append("")
+        lines.append("| Block | Reason | Signals routed by the top instead |")
+        lines.append("|---|---|---|")
+        for r in rtb:
+            sigs = ", ".join(str(s) for s in (r.get("covered_signals") or []))
+            lines.append(
+                f"| `{r.get('block', '?')}` | {r.get('reason', '')} | "
+                f"{sigs or 'n/a'} |"
+            )
+        lines.append("")
 
     # ---- carried-forward defects (advisory-bypass observations) ----
     if cfd:

--- a/orchestrator/langgraph/final_report.py
+++ b/orchestrator/langgraph/final_report.py
@@ -701,7 +701,11 @@ def render_markdown(report: dict) -> str:
                 + (f", first at `{d.get('first_divergence_block')}`"
                    if d.get('first_divergence_block') else "")
             )
-            if d.get("unmodeled"):
+            # The explanation first -- a gate/kind pair with a violation count
+            # tells a reader nothing they can act on.
+            if d.get("detail"):
+                lines.append(f"  - {d['detail']}")
+            if d.get("unmodeled") and d.get("unmodeled") != d.get("detail"):
                 lines.append(f"  - unmodeled: {d['unmodeled']}")
         lines.append("")
 

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -87,7 +87,7 @@ def parse_verilog_ports(rtl_path: str, module: str | None = None) -> VerilogModu
 
     ``module`` selects WHICH module to parse; without it the first one wins,
     which is frequently the wrong answer. A generated block file commonly
-    declares its internal stages first -- raster_scan_pipeline.v declares four
+    declares its internal stages first -- one measured block file declared four
     sub-stages before the block itself at line 668 -- so integration judged a
     sub-stage's ports as the block's interface and raised 22 wiring hazards for
     a block that conforms perfectly. Callers that know the block name should

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -1091,6 +1091,18 @@ def generate_caravel_wrapper_top(
     #
     # The contract edges that reference it describe that same translation, so
     # they are dropped with it: they are no longer block-to-block channels.
+    #
+    # Two ways to arrive here with no adapter, and BOTH must assemble:
+    #   1. the adapter exists and is dropped below (`dropped_adapter` set), and
+    #   2. it never existed, because `pin_map_retire` retired it from the block
+    #      queue before any µarch/RTL was generated -- so `wrapper_block` is
+    #      None and `modules` never contained it.
+    # Case 2 needs no special handling and must not grow any: every edge loop
+    # below already skips an edge whose producer or consumer is absent from
+    # `modules` (see the `pb not in modules` guards), which is exactly the
+    # edge-dropping case 1 does explicitly. The postcondition in
+    # integration_check is likewise satisfied for free -- a block that is not
+    # in `modules` cannot be reported as an un-instantiated one.
     dropped_adapter = ""
     if (pin_map is not None and getattr(pin_map, "ok", False)
             and wrapper_block is not None):

--- a/orchestrator/langgraph/macro_prebind.py
+++ b/orchestrator/langgraph/macro_prebind.py
@@ -168,7 +168,7 @@ def macro_ports(verilog_path) -> set[str]:
     A missing name here is read by ``_ports_for`` as "the macro has no such pin",
     so the binder leaves it unconnected and it floats low -- a dropped ``addr0``
     is a memory stuck at word zero, and a dropped ``wmask0`` is what suppressed
-    every framebuffer write in exp-raster-macro-20260727. The previous regex
+    every write to a wrapped memory on a validation run. The previous regex
     (``[^;)]*``) could not cross a ``)``, so it lost the name in
     ``input [$clog2(DEPTH)-1:0] addr0;`` -- a form the sky130 macro family and
     plenty of generated models use.

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -344,6 +344,13 @@ class OrchestratorState(TypedDict):
     # Results (accumulated via reducer from all Send branches) ──────────────
     completed_blocks: Annotated[list[dict], operator.add]
 
+    # Blocks a declared PRD pin map RETIRED before µarch/RTL (init_tier_node).
+    # Each record is {block, reason: "retired_by_pin_map", skipped: True,
+    # contract_signals, pin_map_signals, covered_signals, explanation}. They are
+    # NOT failures and NOT missing: the chip top emits their routing itself, so
+    # they are deliberately absent from block_queue and from the assembly.
+    retired_blocks: Annotated[list[dict], _last]
+
     # Integration review decision (set by integration_review_node) ────────
     integration_review_action: str | None
 
@@ -5521,9 +5528,156 @@ def _current_phase_completed(state: OrchestratorState) -> list[dict]:
     return list(seen.values())
 
 
+#: Defensive ceiling on consecutive partial-pin-map re-parks, mirroring
+#: ``_INTEGRATION_REPARK_CAP``. In production each re-park is a real
+#: ``interrupt()`` that SUSPENDS the graph, so this is never a CPU loop -- it
+#: bounds an operator/outer-agent that keeps sending ``retry`` without fixing
+#: the map, and stops a plain-return ``interrupt`` test double from spinning.
+_PINMAP_REPARK_CAP = 20
+
+
+async def _retire_pin_mapped_blocks(
+    state: OrchestratorState, pr: str, block_queue: list,
+) -> tuple[list, list[dict]]:
+    """Drop pad-adapter blocks a declared PRD pin map already covers.
+
+    Runs at the HEAD of the dispatch path, so a retired block is never
+    microarchitected, generated, linted or gated -- the flow simply does not ask
+    for a module the design does not contain. Returns ``(block_queue,
+    retirement_records)``; the queue is returned unchanged when nothing is
+    retired, and the records are what state / the final report carry.
+
+    PARTIAL coverage never retires: it raises an interrupt so an operator
+    resolves the contradiction (see ``pin_map_retire.plan_retirement``).
+    """
+    from orchestrator.architecture import pin_map_retire as _pmr
+
+    if not _pmr.retirement_enabled():
+        return block_queue, []
+
+    already = {r.get("block") for r in (state.get("retired_blocks") or [])
+               if isinstance(r, dict)}
+    records: list[dict] = list(state.get("retired_blocks") or [])
+    rounds = 0
+
+    while True:
+        try:
+            plan = _pmr.plan_retirement(pr, block_queue)
+        except Exception as _pe:  # noqa: BLE001 - never crash the dispatch path
+            log(f"  [PIN-MAP] retirement check skipped ({_pe})", YELLOW)
+            return block_queue, records
+
+        if plan.retire:
+            if plan.block in already:
+                # Already retired on an earlier tier entry; the queue in state
+                # no longer carries it, so this is the idempotent no-op path.
+                return _pmr.apply_retirement(block_queue, plan), records
+            log(f"\n{'='*60}", YELLOW)
+            log(f"  [PIN-MAP] RETIRING block '{plan.block}' from the flow: "
+                f"{plan.message}", YELLOW)
+            log(f"  [PIN-MAP] it will NOT be microarchitected, generated or "
+                f"gated, and it is DELIBERATELY absent from the assembled chip "
+                f"(reason={_pmr.RETIRE_REASON})", YELLOW)
+            log(f"{'='*60}\n", YELLOW)
+            records.append(_pmr.record_retirement(pr, plan))
+            already.add(plan.block)
+            write_graph_event(pr, "Init Tier", "block_retired_by_pin_map", {
+                "block": plan.block,
+                "reason": _pmr.RETIRE_REASON,
+                "covered_signals": plan.covered,
+                "pin_map_signals": plan.pin_map_signals,
+            })
+            return _pmr.apply_retirement(block_queue, plan), records
+
+        if not plan.park:
+            if plan.reason and plan.block:
+                log(f"  [PIN-MAP] '{plan.block}' NOT retired: {plan.reason}",
+                    YELLOW)
+            return block_queue, records
+
+        # ---- partial coverage: a half-routed boundary, so PARK ----
+        rounds += 1
+        log(f"\n{'='*60}", RED)
+        log(f"  [PIN-MAP] PARTIAL COVERAGE for '{plan.block}' -- refusing to "
+            f"retire it AND refusing to pretend the boundary is whole", RED)
+        log(f"  [PIN-MAP] {plan.message}", RED)
+        log(f"{'='*60}\n", RED)
+        write_graph_event(pr, "Init Tier", "pin_map_partial_coverage", {
+            "block": plan.block,
+            "covered_signals": plan.covered,
+            "uncovered_signals": plan.uncovered,
+            "round": rounds,
+        })
+        if rounds > _PINMAP_REPARK_CAP:
+            raise RuntimeError(
+                f"pin_map partially covers '{plan.block}' and the contradiction "
+                f"was not resolved after {_PINMAP_REPARK_CAP} re-parks "
+                f"(uncovered: {plan.uncovered}). Fix prd.pin_map or remove it.")
+        response = interrupt({
+            "type": "pin_map_partial_coverage",
+            "block": plan.block,
+            "reason": plan.reason,
+            "message": plan.message,
+            "contract_signals": plan.contract_signals,
+            "pin_map_signals": plan.pin_map_signals,
+            "covered_signals": plan.covered,
+            "uncovered_signals": plan.uncovered,
+            "supported_actions": ["retry", "override", "keep_block"],
+            "outer_agent_guidance": (
+                "The PRD's structured pin_map routes SOME of the signals this "
+                "pad-adapter block is contracted to translate, and not the "
+                "rest. The chip top emits routing for the mapped bits while "
+                "the block would route the others -- two drivers on one pad "
+                "bus, and no gate downstream can tell which was intended. "
+                "Resolve it: (a) extend prd.pin_map in "
+                ".coresmith/prd_spec.json to cover the uncovered signals and "
+                "resume `retry`; or (b) resume `keep_block` to generate the "
+                "adapter as before and leave the pin map to the assembler; or "
+                "(c) resume `override` to retire the block anyway -- ONLY when "
+                "you have verified the uncovered signals are genuinely routed "
+                "elsewhere."
+            ),
+            "reference_files": {
+                "prd": ".coresmith/prd_spec.json",
+                "interface_contracts": ".coresmith/interface_contracts.json",
+            },
+        }) or {}
+        action = (response.get("action") if isinstance(response, dict)
+                  else "retry") or "retry"
+        write_graph_event(pr, "Init Tier", "pin_map_partial_coverage_resume", {
+            "block": plan.block, "action": action,
+        })
+        if action == "keep_block":
+            log(f"  [PIN-MAP] operator KEPT '{plan.block}' in the flow despite "
+                f"partial pin-map coverage -- generating it as before", YELLOW)
+            return block_queue, records
+        if action == "override":
+            log(f"  [PIN-MAP] operator OVERRIDE: retiring '{plan.block}' with "
+                f"{len(plan.uncovered)} signal(s) NOT covered by the pin map "
+                f"({plan.uncovered})", YELLOW)
+            plan.retire = True
+            plan.message = (plan.message
+                            + " -- RETIRED ANYWAY by operator override")
+            records.append(_pmr.record_retirement(pr, plan))
+            return _pmr.apply_retirement(block_queue, plan), records
+        # retry -> re-plan against the (hopefully amended) PRD and loop
+
+
 async def init_tier_node(state: OrchestratorState) -> dict:
     """Compute the tier list (once) and log the current tier."""
+    pr = state.get("project_root", str(PROJECT_ROOT))
+
+    # A declared pin map REPLACES the pad-adapter block, so the flow must not
+    # ask for it. Done here -- the head of the dispatch path, before tier_list
+    # and before any Send() -- so the block is skipped ahead of µarch/RTL rather
+    # than generated, refused by the conformance gate and dropped at assembly.
+    # Idempotent, so every tier re-entry and checkpoint resume agrees.
     block_queue = state["block_queue"]
+    _retired_before = len(block_queue)
+    block_queue, _retired_records = await _retire_pin_mapped_blocks(
+        state, pr, block_queue)
+    _queue_reduced = len(block_queue) != _retired_before
+
     tier_list = state.get("tier_list") or sorted(
         set(b.get("tier", 1) for b in block_queue)
     )
@@ -5531,8 +5685,6 @@ async def init_tier_node(state: OrchestratorState) -> dict:
 
     tier = tier_list[current_idx]
     tier_blocks = [b for b in block_queue if b.get("tier", 1) == tier]
-
-    pr = state.get("project_root", str(PROJECT_ROOT))
 
     # Section 7a: stamp the engine git SHA at run start + WARN in the daemon log
     # if it changes mid-run (a hot-swap that flipped behavior under the run).
@@ -5586,6 +5738,15 @@ async def init_tier_node(state: OrchestratorState) -> dict:
     })
 
     out = {"tier_list": tier_list}
+    # Publish the reduced queue + the retirement record so EVERY downstream
+    # consumer agrees the block is deliberately absent rather than missing:
+    # pipeline_complete / integration_check size `expected` off block_queue,
+    # discover_block_rtl + missing_from work off the same set, and the daemon's
+    # total_blocks / remaining_count stop waiting on it.
+    if _queue_reduced:
+        out["block_queue"] = block_queue
+    if _retired_records:
+        out["retired_blocks"] = _retired_records
     # Seed the two-pass phase on the FIRST entry only. fan_out_tier defaults an
     # unset pipeline_phase to "rtl", so without this a block-goldens run would
     # send every block straight down the single-pass RTL path and pass 1

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -288,6 +288,12 @@ class BlockState(TypedDict):
     preserve_testbench: bool
     force_regen_tb: bool
 
+    # Contract-conformance stage: {old_port: contract_port} the stage renamed
+    # in this block's generated RTL (empty when it already conformed). Carried
+    # in state as well as on disk so a reader of the block result can see that
+    # the engine edited the design, not just that the block passed.
+    conformance_renames: dict
+
     # Human interaction ─────────────────────────────────────────────────────
     human_response: dict | None
 
@@ -625,6 +631,138 @@ def _persist_block_throughput(project_root: str, block_name: str,
         (block_dir / "throughput.json").write_text(json.dumps(rec, indent=2))
     except Exception:  # noqa: BLE001
         pass
+
+
+#: Post-repair contract-conformance failures for ONE block before the flow
+#: stops spending regeneration attempts on it and parks instead. Two is the
+#: cap because the first failure is news and the second is a pattern: the
+#: feedback names the EXACT required port, so a generator that misses it twice
+#: is not going to find it on attempt three.
+_CONFORMANCE_MAX_FAILURES = 2
+
+
+def _conformance_failures_path(project_root: str, block_name: str) -> Path:
+    return (Path(project_root) / ".coresmith" / "blocks" / block_name
+            / "_conformance_failures.txt")
+
+
+def _record_block_conformance(project_root: str, block_name: str,
+                              record: dict) -> None:
+    """Persist the block's contract-conformance record (a git-visible artifact).
+
+    Applied renames MUTATE generated RTL, so they are written down where the
+    final report and a reviewer can see them -- an engine that silently edits
+    the design it is grading is exactly the failure this whole stage exists to
+    stop. Never raises: a record, not a gate.
+    """
+    try:
+        bdir = Path(project_root) / ".coresmith" / "blocks" / block_name
+        bdir.mkdir(parents=True, exist_ok=True)
+        (bdir / "contract_conformance.json").write_text(
+            json.dumps(record, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+    renames = record.get("renames") or {}
+    if not renames:
+        return
+    try:
+        _chans = record.get("rename_channels") or {}
+        record_carried_forward_defect(project_root, {
+            "gate": "contract_conformance",
+            "kind": "block_port_renamed",
+            "advisory": True,
+            "first_divergence_block": block_name,
+            "violation_count": len(renames),
+            "unmodeled": (
+                f"block '{block_name}' declared "
+                + ", ".join(f"{o} (contract wants {n}, channel "
+                            f"'{_chans.get(o) or '?'}')"
+                            for o, n in sorted(renames.items()))
+                + " -- the engine RENAMED the generated ports to the contract "
+                  "names so the design could be wired deterministically"),
+            "detail": (
+                "The RTL generator did not spell this block's channel signals "
+                "the way the frozen interface contract declares them. The "
+                "renames were unambiguous (one candidate port per declared "
+                "signal) and were applied in place, with the pre-repair file "
+                "kept alongside as <rtl>.pre_portrepair. The block's own "
+                "simulation ran AFTER the rename."),
+            "note": "",
+        })
+    except Exception:  # noqa: BLE001 - reporting must never block the flow
+        pass
+
+
+def _bump_conformance_failures(project_root: str, block_name: str) -> int:
+    """Count consecutive post-repair conformance failures for one block."""
+    p = _conformance_failures_path(project_root, block_name)
+    n = 0
+    try:
+        if p.exists():
+            n = int((p.read_text().strip() or "0"))
+    except (OSError, ValueError):
+        n = 0
+    n += 1
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(str(n))
+    except OSError:
+        pass
+    return n
+
+
+def _reset_conformance_failures(project_root: str, block_name: str) -> None:
+    """Drop the counter once the block conforms (or after a park)."""
+    p = _conformance_failures_path(project_root, block_name)
+    try:
+        if p.exists():
+            p.unlink()
+    except OSError:
+        pass
+
+
+def _park_conformance_unrepairable(state: BlockState, block_name: str,
+                                   record: dict, failures: int) -> None:
+    """PARK when regeneration will not converge on the block's contract.
+
+    The stage already told the generator the exact required port names, twice.
+    Burning the remaining attempt budget on a third identical rediscovery buys
+    nothing; an operator (or the outer agent) can fix the RTL, amend the
+    contract, or accept a hand-wired top. The node re-executes on resume, so the
+    stage re-checks the possibly-hand-fixed file: if it now conforms the block
+    proceeds normally, and if it does not the block still fails (loudly) rather
+    than reaching integration deviating.
+    """
+    pr = _pr(state)
+    log(f"  [CONFORM] {block_name}: {failures} post-repair conformance "
+        f"failures -- PARKING instead of spending more regeneration attempts",
+        RED)
+    write_graph_event(pr, "Contract Conformance", "interrupt", {
+        "block": block_name, "consecutive_failures": failures,
+        "deviations": (record.get("deviations") or [])[:16],
+    })
+    interrupt({
+        "type": "contract_conformance_unrepairable",
+        "block_name": block_name,
+        "consecutive_failures": failures,
+        "deviations": (record.get("deviations") or [])[:16],
+        "renames_applied": record.get("renames") or {},
+        "expected_ports": record.get("feedback", ""),
+        "supported_actions": ["retry", "proceed"],
+        "outer_agent_guidance": (
+            f"'{block_name}' has now failed the deterministic "
+            f"contract-conformance check {failures} times AFTER the engine "
+            f"applied every unambiguous port rename it could prove. Its RTL "
+            f"does not expose the ports .coresmith/interface_contracts.json "
+            f"declares, so the deterministic chip assembler cannot wire it and "
+            f"the design would fall back to an LLM-authored top. The exact "
+            f"required names are in the payload's expected_ports (and in "
+            f".coresmith/blocks/<block>/previous_error.txt). Either edit the "
+            f"block RTL to use them, or amend the contract if the CONTRACT is "
+            f"what is wrong -- then resume. The check re-runs on resume; it "
+            f"passes the block only if the RTL actually conforms."
+        ),
+    })
 
 
 def _guard_rtl_phase(state: BlockState, node_name: str) -> None:
@@ -2417,13 +2555,136 @@ async def generate_testbench_node(state: BlockState) -> dict:
                     "phase": "sim", "force_regen_tb": False,
                     "step_log_paths": existing_logs}
 
+    # --- CONTRACT-CONFORMANCE stage: check + repair the block's PORT NAMES ---
+    # Sibling of the width gate above, and for the same reason: the contract
+    # already says what every channel signal is called, and a block that spells
+    # one differently is unwireable. The deterministic Caravel assembler
+    # resolves edges BY NAME, so a deviation makes the edge unresolvable, the
+    # assembler correctly refuses, and the whole chip falls back to an
+    # LLM-authored top. Measured on the first hands-off run: 8/8 blocks passed
+    # every per-block gate on attempt 1, then assembly reported 10 wiring
+    # hazards and the LLM fallback miswired 4 nets that lint blessed.
+    #
+    # The checker and the repairer already existed; nothing CALLED them. Here
+    # is where they belong -- a block-time failure costs one regeneration with
+    # the exact expected name, an integration-time failure has already paid for
+    # every other block.
+    #
+    # Placed pre-TB deliberately. A repair that renames a port must be followed
+    # by the block's own simulation, and running here means the sim below is
+    # that re-run: the testbench is generated (or its DUT references rewritten)
+    # AFTER the rename, never before it. Default-on; CORESMITH_CONTRACT_
+    # CONFORMANCE_GATE=0 disables.
+    _conform: dict = {}
+    _conform_force_tb = False
+    try:
+        from orchestrator.langgraph.contract_conformance import (
+            conformance_gate_enabled,
+            run_conformance_stage,
+        )
+        _conform_on = conformance_gate_enabled()
+    except Exception as _cie:  # noqa: BLE001 - gate must never crash the node
+        log(f"  [CONFORM] {block_name}: stage unavailable ({_cie})", YELLOW)
+        _conform_on = False
+    if _conform_on:
+        try:
+            from orchestrator.harness.blocks import block_names as _queue_names
+            _sibs = _queue_names(_pr(state))
+        except Exception:  # noqa: BLE001 - siblings are best-effort
+            _sibs = []
+        try:
+            _conform = await asyncio.to_thread(
+                run_conformance_stage, _pr(state), block_name, rtl_path,
+                _sibs, str(tb_path_obj),
+            )
+        except Exception as _ce:  # noqa: BLE001 - gate must never crash the node
+            log(f"  [CONFORM] {block_name}: stage error (skipped): {_ce}",
+                YELLOW)
+            _conform = {}
+    if _conform.get("ran"):
+        _renames = _conform.get("renames") or {}
+        _chans = _conform.get("rename_channels") or {}
+        for _old, _new in _renames.items():
+            log(f"  [CONFORM] renamed {_old} -> {_new} "
+                f"(contract: channel {_chans.get(_old) or '?'})", YELLOW)
+        _tbrep = _conform.get("tb") or {}
+        if _tbrep.get("changed"):
+            log(f"  [CONFORM] {block_name}: rewrote "
+                f"{sum((_tbrep.get('applied') or {}).values())} testbench DUT "
+                f"reference(s) to match "
+                f"(backup at {Path(tb_path_obj).name}.pre_portrepair)", YELLOW)
+        if _renames and _tbrep.get("needs_regen"):
+            _conform_force_tb = True
+            log(f"  [CONFORM] {block_name}: the testbench still mentions "
+                f"{', '.join(_tbrep['residual'])} in a form this stage will "
+                f"NOT rewrite blind (a generated TB drives getattr(dut, "
+                f"<name-string>) and keys its model stimulus with the same "
+                f"strings) -- REGENERATING the testbench against the repaired "
+                f"RTL", YELLOW)
+        _record_block_conformance(_pr(state), block_name, _conform)
+        if _renames:
+            log(f"  [CONFORM] {block_name}: repaired {len(_renames)} "
+                f"contract deviation(s) in the generated RTL", YELLOW)
+        if _conform.get("ok"):
+            if not _renames:
+                log(f"  [CONFORM] {block_name}: ports match the contract "
+                    f"({_conform.get('checked_edges')} edge(s))", GREEN)
+        else:
+            _cf_n = _bump_conformance_failures(_pr(state), block_name)
+            for _d in (_conform.get("deviations") or [])[:8]:
+                log(f"  [CONFORM] {block_name}: {_d}", RED)
+            log(f"  [CONFORM] {block_name}: RTL does NOT conform to the "
+                f"interface contract after repair "
+                f"({_conform.get('after_missing')} missing, failure "
+                f"{_cf_n}/{_CONFORMANCE_MAX_FAILURES}) -- FAILING before "
+                f"TB/sim; a deviating block must not reach integration", RED)
+            try:
+                _bd = Path(_pr(state)) / ".coresmith" / "blocks" / block_name
+                _bd.mkdir(parents=True, exist_ok=True)
+                (_bd / "previous_error.txt").write_text(
+                    "DETERMINISTIC CONTRACT-CONFORMANCE FAILURE (no sim was "
+                    "run). The RTL does not expose the ports the FROZEN "
+                    "interface contract declares, and the deviation is not one "
+                    "the engine can rename unambiguously. Regenerate the RTL "
+                    "with these EXACT port names:\n\n"
+                    + _conform.get("feedback", ""), encoding="utf-8")
+            except OSError:
+                pass
+            write_graph_event(_pr(state), "Contract Conformance",
+                              "gate_failed", {
+                                  "block": block_name,
+                                  "after_missing": _conform.get("after_missing"),
+                                  "renames": _renames,
+                                  "deviations": (
+                                      _conform.get("deviations") or [])[:8],
+                                  "consecutive_failures": _cf_n,
+                              })
+            if _cf_n >= _CONFORMANCE_MAX_FAILURES:
+                # Cap: regeneration is not converging on the contract. PARK
+                # with the exact expected names rather than burn the rest of
+                # the attempt budget rediscovering the same deviation.
+                _park_conformance_unrepairable(state, block_name, _conform,
+                                               _cf_n)
+                _reset_conformance_failures(_pr(state), block_name)
+            return {"tb_path": str(tb_path_obj), "sim_passed": False,
+                    "phase": "sim", "force_regen_tb": False,
+                    "conformance_renames": _renames,
+                    "step_log_paths": existing_logs}
+        _reset_conformance_failures(_pr(state), block_name)
+    elif _conform_on and _conform.get("reason"):
+        log(f"  [CONFORM] {block_name}: NOT RUN -- {_conform['reason']}",
+            YELLOW)
+
     with _tracer.start_as_current_span(
         f"Generate Testbench + Sim [{block_name}]"
     ) as span:
         span.set_attribute("block_name", block_name)
 
         # --- Step 1: Generate or reuse testbench ---
-        force_regen = state.get("force_regen_tb", False)
+        # A conformance repair that renamed a port makes an EXISTING testbench
+        # stale by construction, so it also forces regeneration (the reuse
+        # branches below key on freshness, which a rename does not change).
+        force_regen = state.get("force_regen_tb", False) or _conform_force_tb
         if not force_regen and (
             (state.get("preserve_testbench") and tb_path_obj.exists()) or
             (attempt == 1 and tb_path_obj.exists() and _file_is_fresh(tb_path_obj, state))
@@ -2770,6 +3031,7 @@ async def generate_testbench_node(state: BlockState) -> dict:
         "sim_passed": sim_passed,
         "phase": "sim" if not sim_passed else "tb",
         "force_regen_tb": False,
+        "conformance_renames": _conform.get("renames") or {},
         "step_log_paths": existing_logs,
     }
 

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -512,8 +512,20 @@ def record_carried_forward_defect(project_root: str, defect: dict) -> None:
     second bus), not a generic single-role label. De-dups on (gate, kind,
     unmodeled, first_divergence_block) so a re-entered node does not spam the
     ledger. Never raises -- this is a record, never a gate.
+
+    Every entry leaves here with a ``detail``: the EXPLANATION a reader needs
+    to act on it. Most recorders had built that sentence and then dropped it
+    (or stored it under a key nothing rendered), so the ledger's entries read
+    ``detail: None`` and the final report printed a gate/kind pair with no
+    account of what happened. Callers that supply one keep it; the rest fall
+    back to the most specific text the entry does carry.
     """
     try:
+        if not str(defect.get("detail") or "").strip():
+            defect = dict(defect)
+            defect["detail"] = (str(defect.get("unmodeled") or "").strip()
+                                or str(defect.get("note") or "").strip()
+                                or str(defect.get("reason") or "").strip())
         existing = read_carried_forward_defects(project_root)
         key = (defect.get("gate"), defect.get("kind"),
                defect.get("unmodeled"), defect.get("first_divergence_block"))
@@ -10331,8 +10343,10 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
                     f"{d.get('violation_count',0)} violation(s)"
                     + (f", first at {d.get('first_divergence_block')}"
                        if d.get('first_divergence_block') else "")
+                    + (f"; {d.get('detail')}" if d.get('detail') else "")
                     + (f"; UNMODELED: {d.get('unmodeled')}"
-                       if d.get('unmodeled') else ""))
+                       if d.get('unmodeled')
+                       and d.get('unmodeled') != d.get('detail') else ""))
             ers_context = ers_context + "\n".join(_cfd_lines)
             log(f"  [VALIDATION-DV] {len(_cfd)} carried-forward defect(s) added "
                 f"to validation context", YELLOW)

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -3483,6 +3483,26 @@ def _evaluate_ppa_gate(
                     f"buffered {mf.get('buffered_wns_ns')}); gating on "
                     f"max(unbuffered={_meta.get('wns_ns_base_unbuffered')}, "
                     f"buffered)={_eff_wns:+.2f} ns", GREEN)
+            else:
+                # The fan-out-aware measurement produced NO timing (both
+                # sub-flows errored, or both answered with OpenSTA's
+                # no-endpoints sentinel). That used to be silent -- and silence
+                # is how +1e39 ns of "slack" got compared to a budget and
+                # called "within budget". Say what it saw; and when the base
+                # measurement is absent too, hand the reason to the gate so the
+                # timing dimension fails CLOSED as unmeasured rather than
+                # skipped.
+                _mf_err = str(mf.get("sta_error") or "no measurement")
+                _meta["sta_maxfanout_error"] = _mf_err
+                if _eff_wns is None:
+                    _eff_sta_error = _eff_sta_error or _mf_err
+                    log(f"  [PPA] {block_name}: fan-out-aware STA produced NO "
+                        f"timing and there is no base measurement either -- "
+                        f"timing is UNMEASURED: {_mf_err[:220]}", RED)
+                else:
+                    log(f"  [PPA] {block_name}: fan-out-aware STA produced NO "
+                        f"timing ({_mf_err[:220]}) -- keeping the base "
+                        f"measurement {_eff_wns:+.2f} ns", YELLOW)
     _meta["wns_ns"] = _eff_wns
     verdict = evaluate_ppa(
         actual_ff=actual_ff,

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -7739,8 +7739,32 @@ async def _maybe_generate_chip_model(pr: str) -> None:
         )
         log(f"  [MODEL-INTEGRATION] Wrote {chip_model_path}", GREEN)
     except Exception as exc:  # noqa: BLE001 - best-effort; gate is the backstop
+        # A rejected chip model means the composition gate has nothing to
+        # compose: it NO-OPS, and the run proceeds with its strongest
+        # model-vs-golden check silently absent. On the two runs that hit this,
+        # the only trace was this one line, 400 lines up a daemon log. Carry it
+        # forward so the final report and the validation-DV context both say a
+        # gate did not run, and why.
         log(f"  [MODEL-INTEGRATION] chip-model generation failed ({exc}); the "
-            f"gate will no-op or flag any divergence", YELLOW)
+            f"COMPOSITION GATE will NO-OP (no _chip_model.py to compose) -- "
+            f"the run loses its model-vs-golden check", RED)
+        record_carried_forward_defect(pr, {
+            "gate": "model_integration",
+            "kind": "chip_model_generation_failed",
+            "advisory": True,
+            "first_divergence_block": "",
+            "violation_count": 0,
+            "unmodeled": (
+                "the integrated chip model (_chip_model.py) was not produced, "
+                "so the composition gate no-opped: NOTHING compared the wired "
+                "block models against the golden reference on this run"),
+            "detail": (
+                f"chip-model generation failed: {exc}. The composition gate is "
+                f"the run's model-vs-golden check; with no composed model it "
+                f"returns 'not applicable' and every downstream verdict rests "
+                f"on per-block DV alone."),
+            "note": "",
+        })
 
 
 async def model_integration_node(state: OrchestratorState) -> dict:

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -6768,7 +6768,7 @@ async def integration_check_node(state: OrchestratorState) -> dict:
 
         # BLOCK-RTL COMPLETENESS GATE: refuse to assemble a chip that is MISSING
         # a block. `discover_block_rtl` used to drop an unresolvable block
-        # SILENTLY, which structurally DELETES it from the chip: the raster run
+        # SILENTLY, which structurally DELETES it from the chip: one graded run
         # lost its locked Caravel pad adapter (whose file is
         # rtl/user_project_wrapper.v, NOT <block_name>.v, because an interface
         # contract locks the module name), so `detect_wrapper_block` returned
@@ -8608,9 +8608,14 @@ async def begin_rtl_pass_node(state: OrchestratorState) -> dict:
     the already-computed list (R8).
     """
     pr = state.get("project_root", str(PROJECT_ROOT))
-    log(f"\n{'='*60}", CYAN)
-    log("  µARCH GATE CLEAN -> beginning RTL pass (pass 2)", CYAN)
-    log(f"{'='*60}", CYAN)
+    # run3-followups: the banner reflects the ACTUAL gate outcome -- a green
+    # CLEAN was printed four lines after an advisory-dismissed model mismatch,
+    # suppressing a true early detection for ~2.5 h of downstream work.
+    from orchestrator.langgraph.pipeline_helpers import uarch_gate_banner
+    _banner, _colour = uarch_gate_banner(state.get("model_integration_result"))
+    log(f"\n{'='*60}", _colour)
+    log(f"  {_banner}", _colour)
+    log(f"{'='*60}", _colour)
     write_graph_event(pr, "Begin RTL Pass", "graph_node_exit", {
         "pipeline_phase": "rtl",
     })
@@ -9357,7 +9362,7 @@ def _maxgeo_conformance_scope(
         the gate exactly as before.
 
     What it relaxes is only this: a compute-lane dimension (frame_width,
-    num_triangles, ...) cannot be driven by a testbench that has no compute
+    record counts, coordinate extents, ...) cannot be driven by a testbench that has no compute
     oracle, so demanding it makes the gate a permanent brick wall for that whole
     class of run rather than a defect detector. Those dims are reported, logged
     loudly, and carried forward as a defect -- never silently dropped.
@@ -9450,19 +9455,27 @@ def _maxgeo_gate_verdict(
     try:
         if not _maxgeo_gate_enabled():
             return None
-        dims = _declared_dimensions(project_root)
+        # run3-followups: single-sourced declared table (byte-equality with
+        # the legacy _declared_dimensions is pinned by test).
+        from orchestrator.langgraph.bfm_lib import maxgeo as _maxgeo_lib
+        dims = _maxgeo_lib.declared_dimensional_maxima(project_root)
         if not dims:
             return None
         marker = _tb_maxgeo_pairs(tb_path)
-        marker_values = set(marker.values())
-        missing = {
-            name: mx for name, mx in dims.items() if mx not in marker_values
-        }
+        # run3-followups: single-sourced demand partition (bfm_lib.maxgeo).
+        # `missing` is provably identical to the old value-set computation;
+        # `value_only` newly NAMES the dims whose only evidence is a value
+        # collision with another marker pair, so the gate's number and the
+        # TB's confession finally agree.
+        _demand = _maxgeo_lib.maxgeo_demand(dims, marker)
+        missing = _demand.missing
+        value_only = _demand.value_only
         if not missing:
             # run3-followups: an evaluated PASS is a verdict, not a silence --
             # the caller logs it so a suppressed gate can never read as green.
             return {"verdict": "pass", "declared_dims": dims,
-                    "marker_pairs": marker}
+                    "marker_pairs": marker,
+                    "value_only_dims": value_only}
         scoped = _maxgeo_conformance_scope(
             project_root, tb_path, tb_result, dims, marker, missing)
         if scoped is not None:
@@ -9487,6 +9500,7 @@ def _maxgeo_gate_verdict(
                     "advisory": True,
                     "scope": "functional-max-case",
                     "uncovered_dims": missing,
+                    "value_only_dims": value_only,
                     "declared_dims": dims,
                     "marker_pairs": marker,
                     "functional_max_case": case,
@@ -9512,13 +9526,15 @@ def _maxgeo_gate_verdict(
             f"  declared maxima : {dims}\n"
             f"  marker pairs    : {marker or '(no # MAXGEO marker found)'}\n"
             f"  uncovered dims  : {missing}\n"
+            f"  value-collision-only (not individually proven): {value_only}\n"
             "Fix: regenerate/edit the testbench to drive a max-geometry case "
             "(sparse/short content at the maximum dimensions is acceptable if a "
             "full workload is too slow -- the point is to exercise the index/"
             "address widths at maximum extent) and emit the marker."
         )
         return {"reason": reason, "declared_dims": dims,
-                "marker_pairs": marker, "uncovered_dims": missing}
+                "marker_pairs": marker, "uncovered_dims": missing,
+                "value_only_dims": value_only}
     except Exception:  # noqa: BLE001
         return None
 
@@ -9744,7 +9760,7 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                         # advisory and PROCEEDED on the LLM-authored, DUT-co-tuned
                         # BFM: DV was silently downgraded exactly when the design
                         # is most likely to be non-conformant, and the run still
-                        # reported "INTEGRATION DV PASSED" (exp-raster-macro-
+                        # reported "INTEGRATION DV PASSED" (observed live on a graded run
                         # 20260727). It is now the run's normal tb_generation
                         # interrupt (retry/fix_rtl/fix_tb/abort), per the local
                         # honest-gate idiom.
@@ -10378,7 +10394,7 @@ def _load_ers_validation_context(project_root: str) -> tuple[str, int]:
 # therefore STABLE, path: every integration-DV failure of the same stage writes
 # the same filename. So a failed or skipped audit leaves the PREVIOUS failure's
 # verdict lying in the exact place the next one is read from. Observed on the
-# raster run: a 0.99-confidence TESTBENCH_BUG audit describing an already-fixed
+# graded run: a 0.99-confidence TESTBENCH_BUG audit describing an already-fixed
 # crash sat next to a new, different failure and was quoted as its diagnosis.
 #
 # A verdict is only about the failure it actually read, so it now carries that

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -9297,6 +9297,33 @@ def _tb_maxgeo_pairs(tb_path: str) -> dict:
     return pairs
 
 
+_MAXGEO_CASE_RE = re.compile(r"#\s*MAXGEO_CASE:\s*(.+)$")
+
+
+def _tb_maxgeo_case(tb_path: str) -> dict:
+    """Parse the ``# MAXGEO_CASE: name=<s> cfg0=<int> in_bytes=<int>
+    out_bytes=<int>`` marker the deterministic codegen emits for its
+    maximum-configuration functional test. ``{}`` when absent."""
+    out: dict = {}
+    try:
+        text = Path(tb_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return out
+    for line in text.splitlines():
+        m = _MAXGEO_CASE_RE.search(line)
+        if not m:
+            continue
+        for tok in m.group(1).split():
+            if "=" not in tok:
+                continue
+            k, _, v = tok.partition("=")
+            try:
+                out[k] = int(v)
+            except ValueError:
+                out[k] = v
+    return out
+
+
 def _maxgeo_conformance_scope_enabled() -> bool:
     """Scope the MAX-GEOMETRY demand for the ENGINE'S OWN compute-lane-independent
     conformance testbench. Default ON; ``CORESMITH_MAXGEO_CONFORMANCE_SCOPE=0``
@@ -9401,9 +9428,12 @@ def _maxgeo_conformance_scope(
 def _maxgeo_gate_verdict(
     project_root: str, tb_path: str, tb_result: dict | None = None
 ) -> dict | None:
-    """``None`` -> gate passes / no-ops. Otherwise a violation dict: the design
-    declares dimensional maxima but the testbench's ``# MAXGEO`` marker does not
-    prove a max-geometry case for every declared dimension.
+    """``None`` -> gate disabled or no declared dims (a true no-op).
+    ``{"verdict": "pass", ...}`` -> evaluated and fully covered (callers LOG
+    it). ``{"advisory": True, ...}`` -> covered in scope with a loud recorded
+    gap. Anything else -> violation dict: the design declares dimensional
+    maxima but the testbench's ``# MAXGEO`` marker does not prove a
+    max-geometry case for every declared dimension.
 
     NAME-AGNOSTIC: each declared dimension's max VALUE must appear as a marker
     ``key=value`` pair (the key name is free-form data). Testing at the declared
@@ -9429,11 +9459,47 @@ def _maxgeo_gate_verdict(
             name: mx for name, mx in dims.items() if mx not in marker_values
         }
         if not missing:
-            return None
+            # run3-followups: an evaluated PASS is a verdict, not a silence --
+            # the caller logs it so a suppressed gate can never read as green.
+            return {"verdict": "pass", "declared_dims": dims,
+                    "marker_pairs": marker}
         scoped = _maxgeo_conformance_scope(
             project_root, tb_path, tb_result, dims, marker, missing)
         if scoped is not None:
             return scoped
+        # run3-followups: a functional MAXIMUM-CONFIGURATION case (baked by the
+        # deterministic codegen, advertised via # MAXGEO_CASE) drives the max
+        # config register value and the full IN/OUT payload extents end-to-end
+        # against the golden -- the 2^n index/address wrap class this gate
+        # exists to catch IS exercised. Remaining per-dimension attainment is
+        # downgraded to a LOUD advisory gap (carried-forward defect), the same
+        # treatment as the bus-scoped conformance path. The gate stays HARD
+        # when no such case exists or its extents miss the declared maxima.
+        case = _tb_maxgeo_case(tb_path)
+        if case:
+            dim_values = set(dims.values())
+            attained = all(
+                isinstance(case.get(k), int) and case[k] in dim_values
+                for k in ("cfg0", "in_bytes", "out_bytes")
+            )
+            if attained:
+                return {
+                    "advisory": True,
+                    "scope": "functional-max-case",
+                    "uncovered_dims": missing,
+                    "declared_dims": dims,
+                    "marker_pairs": marker,
+                    "functional_max_case": case,
+                    "reason": (
+                        "MAX-GEOMETRY gate: functional max-configuration case "
+                        f"{case} drives the maximum configuration and full "
+                        "payload extents end-to-end against the golden "
+                        "reference, exercising the 2^n index/address wrap "
+                        "class. Per-dimension attainment for "
+                        f"{sorted(missing)} is not individually proven -- "
+                        "recorded as a loud advisory gap, not a hard failure."
+                    ),
+                }
         reason = (
             "MAX-GEOMETRY DV GATE FAILED: the design declares dimensional "
             "maxima but the testbench does not exercise them. A chip can pass "
@@ -9835,6 +9901,7 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                 sim_log=error_msg,
                 sim_log_path="",
                 block_rtl_paths=block_rtl_paths,
+                            supported_actions=["retry", "fix_rtl", "fix_tb", "abort"],
             )
             payload = {
                 "type": "integration_dv_failure",
@@ -9872,35 +9939,28 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                     "contract_audit": contract_audit.get("audit_path", ""),
                 },
             }
-            response = interrupt(payload)
-            action = response.get("action", "abort")
+            # run3-followups: park in integration_dv_decision instead of a
+            # tail interrupt() (see the sim-failure branch for the
+            # one-cycle-late defect).
             write_graph_event(pr, "Integration DV", "graph_node_exit", {
                 "error": str(e),
                 "phase": "tb_generation",
-                "action": action,
+                "action": "pending_decision",
             })
-            dv_result = {
-                "passed": False,
-                "error": error_msg,
-                "phase": "tb_generation",
-                "test_count": 0,
-                "testbench_path": "",
-                "design_name": design_name,
-                "action_taken": action,
-                "contract_audit": contract_audit,
-                "contract_audit_path": contract_audit.get("audit_path", ""),
-            }
-            if action == "abort":
-                dv_result["aborted"] = True
-                log("  [INTEG-DV] Aborted", RED)
-            elif action in ("retry", "fix_rtl", "fix_tb"):
-                fix_desc = response.get("rtl_fix_description", "")
-                dv_result["fix_applied"] = fix_desc
-                log(f"  [INTEG-DV] Fix applied: {fix_desc}", GREEN)
             return {
-                "integration_dv_result": dv_result,
+                "integration_dv_result": {
+                    "passed": False,
+                    "pending_decision": True,
+                    "interrupt_payload": payload,
+                    "error": error_msg,
+                    "phase": "tb_generation",
+                    "test_count": 0,
+                    "testbench_path": "",
+                    "design_name": design_name,
+                    "contract_audit": contract_audit,
+                    "contract_audit_path": contract_audit.get("audit_path", ""),
+                },
                 "pipeline_done": False,
-                "pipeline_aborted": action == "abort",
             }
 
         tb_path = tb_result.get("testbench_path", "")
@@ -9955,26 +10015,46 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                     f"(non-blocking): {chip_equiv_result.get('reason','')}", YELLOW)
 
         # MAX-GEOMETRY gate (rung3-fixes-2): a green sim is NOT sufficient when
-        # the design declares dimensional maxima but the (freshly generated) TB
-        # never exercised them -- that is how a truncated index-width bug ships
-        # in a "verified" chip. Flip the DV to failed -> existing failure
-        # interrupt. Operator-reused TBs (fix_tb/fix_rtl) are trusted as-is.
-        if passed and not reuse_existing_tb:
+        # the design declares dimensional maxima but the TB never exercised
+        # them -- that is how a truncated index-width bug ships in a "verified"
+        # chip. Flip the DV to failed -> existing failure interrupt.
+        # run3-followups: the gate runs on EVERY passing cycle, including
+        # operator-reused TBs (fix_tb/fix_rtl). "Trusted as-is" silently
+        # DISARMED the gate on exactly the cycles that deserve more scrutiny --
+        # proven live when a clobbered 2-test TB passed DV with no MAXGEO line
+        # at all. Every evaluated outcome logs a verdict; silence now means
+        # only "gate disabled or no declared dims".
+        if passed:
             _mg = _maxgeo_gate_verdict(pr, tb_path, tb_result)
-            if _mg is not None and _mg.get("advisory"):
-                # SCOPED, not silent. The engine's own compute-lane-independent
-                # conformance TB drove every BUS maximum and cannot drive the
-                # compute lane; the gap is logged RED, written to the event
-                # stream, and carried forward as a defect so the final report
-                # and validation DV both see it.
-                log("  [INTEG-DV] MAX-GEOMETRY gate SCOPED to the bus contract "
-                    "(deterministic conformance TB, compute lane UNMODELED) -- "
-                    "this is NOT full max-geometry coverage. NOT COVERED: "
-                    f"{_mg['uncovered_dims']}", RED)
+            if reuse_existing_tb and _mg is not None:
+                log("  [INTEG-DV] MAX-GEOMETRY gate: evaluating an OPERATOR-"
+                    "REUSED testbench (fix_tb/fix_rtl) -- operator edits get "
+                    "more scrutiny, not less.", YELLOW)
+            if _mg is not None and _mg.get("verdict") == "pass":
+                log("  [INTEG-DV] MAX-GEOMETRY gate PASS -- every declared "
+                    f"maximum appears in the TB markers: "
+                    f"{_mg.get('marker_pairs', {})}", GREEN)
+                write_graph_event(pr, "Integration DV", "maxgeo_gate_pass", {
+                    "gate": "maxgeo",
+                    "marker_pairs": _mg.get("marker_pairs", {}),
+                })
+            elif _mg is not None and _mg.get("advisory"):
+                # SCOPED, not silent. Either the engine's compute-lane-
+                # independent conformance TB drove every BUS maximum and cannot
+                # drive the compute lane, or a functional max-configuration
+                # case covered the wrap class without per-dimension proof; the
+                # gap is logged RED, written to the event stream, and carried
+                # forward as a defect so the final report and validation DV
+                # both see it.
+                _mg_scope = _mg.get("scope", "bus-contract-only")
+                log("  [INTEG-DV] MAX-GEOMETRY gate ADVISORY "
+                    f"(scope={_mg_scope}) -- this is NOT full max-geometry "
+                    f"coverage. NOT COVERED: {_mg['uncovered_dims']}", RED)
                 write_graph_event(pr, "Integration DV", "maxgeo_gate_scoped", {
                     "gate": "maxgeo",
-                    "scope": "bus-contract-only",
+                    "scope": _mg_scope,
                     "bus_covered": _mg.get("bus_covered", {}),
+                    "functional_max_case": _mg.get("functional_max_case", {}),
                     "uncovered_dims": _mg.get("uncovered_dims", {}),
                 })
                 record_carried_forward_defect(pr, {
@@ -9982,10 +10062,9 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                     "kind": "max_geometry_not_covered",
                     "advisory": True,
                     "unmodeled": (
-                        "compute-lane dimensional maxima never driven at "
+                        "dimensional maxima never individually driven at "
                         f"maximum extent: {_mg.get('uncovered_dims', {})} "
-                        "(integration DV is the deterministic QSPI conformance "
-                        "TB -- no compute oracle)"
+                        f"(scope={_mg_scope})"
                     ),
                     "first_divergence_block": "",
                     "note": _mg["reason"],
@@ -10078,6 +10157,7 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
             sim_log=sim_log,
             sim_log_path=sim_result.get("log_path", ""),
             block_rtl_paths=block_rtl_paths,
+                    supported_actions=["retry", "fix_rtl", "fix_tb", "abort"],
         )
         _record_dv_row(
             pr, block=design_name, scope="chip", source="gate", passed=False,
@@ -10138,56 +10218,116 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
         ):
             payload["supported_actions"].insert(-1, "skip")
 
-        response = interrupt(payload)
-
-        action = response.get("action", "abort")
+        # run3-followups: do NOT call interrupt() here. LangGraph re-executes
+        # this entire node from the top on resume, so a response delivered to
+        # a tail interrupt() is consumed ONE FULL CYCLE LATE -- the intervening
+        # default cycle regenerates the testbench and destroys operator fix_tb
+        # edits (proven live: three consecutive clobbers, then a false PASS on
+        # the clobbered TB). The failure parks in integration_dv_decision,
+        # whose re-execution is just the interrupt() call: the response lands
+        # immediately and the TB on disk at decision time is the TB the next
+        # cycle sees.
         write_graph_event(pr, "Integration DV", "graph_node_exit", {
-            "action": action,
+            "action": "pending_decision",
             "passed": False,
             "test_count": test_count,
         })
-
-        dv_result = {
-            "passed": False,
-            "test_count": test_count,
-            "testbench_path": tb_path,
-            "sim_log_path": sim_result.get("log_path", ""),
-            "design_name": design_name,
-            "action_taken": action,
-            "contract_audit": contract_audit,
-            "contract_audit_path": contract_audit.get("audit_path", ""),
-            "chip_equiv_result": chip_equiv_result,
-        }
-
-        if action == "skip":
-            dv_result["skipped_by_user"] = True
-            log("  [INTEG-DV] Skipped by user/agent", YELLOW)
-        elif action == "abort":
-            dv_result["aborted"] = True
-            log("  [INTEG-DV] Aborted", RED)
-        elif action in ("retry", "fix_rtl", "fix_tb"):
-            fix_desc = response.get("rtl_fix_description", "")
-            log(f"  [INTEG-DV] Fix applied: {fix_desc}", GREEN)
-            dv_result["fix_applied"] = fix_desc
-            if action == "fix_tb":
-                # A-Fix 5(c): the operator hand-edited the testbench. The chip
-                # sim will re-run trusting that TB, but the chip-top equivalence
-                # gate (A-Fix 5d) remains the gate of record -- record + LOUDLY
-                # flag the operator TB edit so a loosened TB can't quietly pass.
-                dv_result["tb_operator_edited"] = True
-                log(
-                    "  [INTEG-DV] fix_tb: operator EDITED the testbench "
-                    "(tb_operator_edited=True). A green sim on an operator-edited "
-                    "TB is NOT sufficient -- the chip-top RTL-vs-model "
-                    "equivalence gate is the gate of record.",
-                    YELLOW,
-                )
-
         return {
-            "integration_dv_result": dv_result,
+            "integration_dv_result": {
+                "passed": False,
+                "pending_decision": True,
+                "interrupt_payload": payload,
+                "test_count": test_count,
+                "testbench_path": tb_path,
+                "sim_log_path": sim_result.get("log_path", ""),
+                "design_name": design_name,
+                "contract_audit": contract_audit,
+                "contract_audit_path": contract_audit.get("audit_path", ""),
+                "chip_equiv_result": chip_equiv_result,
+            },
             "pipeline_done": False,
-            "pipeline_aborted": action == "abort",
         }
+
+
+async def integration_dv_decision_node(state: OrchestratorState) -> dict:
+    """Consume the operator's decision for a parked integration-DV failure.
+
+    Split out of ``integration_dv_node`` (run3-followups): a LangGraph resume
+    re-executes the interrupted node from the top, so an ``interrupt()`` at the
+    tail of the big DV node consumed its response one full default cycle late,
+    regenerating the testbench over operator edits before the action landed.
+    This node's body is ONLY the interrupt + response handling: re-execution is
+    free, the response lands immediately, and a fix_tb reuse sees the disk
+    state as of decision time."""
+    pr = state["project_root"]
+    dv = dict(state.get("integration_dv_result") or {})
+    payload = dv.get("interrupt_payload") or {
+        "type": "integration_dv_failure",
+        "supported_actions": ["retry", "fix_rtl", "fix_tb", "abort"],
+    }
+    response = interrupt(payload) or {}
+    action = response.get("action", "abort")
+    test_count = dv.get("test_count", 0)
+    write_graph_event(pr, "Integration DV", "graph_node_exit", {
+        "action": action,
+        "passed": False,
+        "test_count": test_count,
+    })
+
+    dv_result = dict(dv)
+    dv_result.pop("interrupt_payload", None)
+    dv_result["passed"] = False
+    dv_result["pending_decision"] = False
+    dv_result["action_taken"] = action
+
+    if action == "skip":
+        dv_result["skipped_by_user"] = True
+        log("  [INTEG-DV] Skipped by user/agent", YELLOW)
+    elif action == "abort":
+        dv_result["aborted"] = True
+        log("  [INTEG-DV] Aborted", RED)
+    elif action in ("retry", "fix_rtl", "fix_tb"):
+        fix_desc = response.get("rtl_fix_description", "")
+        log(
+            f"  [INTEG-DV] Fix applied (action={action}): "
+            f"{fix_desc or '(no description provided)'}",
+            GREEN,
+        )
+        dv_result["fix_applied"] = fix_desc
+        if action == "fix_tb":
+            # A-Fix 5(c): the operator hand-edited the testbench. The chip sim
+            # re-runs trusting that TB, and the MAX-GEOMETRY + chip-top
+            # equivalence gates evaluate it with MORE scrutiny -- record +
+            # LOUDLY flag the operator TB edit so a loosened TB can't quietly
+            # pass.
+            dv_result["tb_operator_edited"] = True
+            log(
+                "  [INTEG-DV] fix_tb: operator EDITED the testbench "
+                "(tb_operator_edited=True). A green sim on an operator-edited "
+                "TB is NOT sufficient -- the MAX-GEOMETRY and chip-top "
+                "equivalence gates still evaluate it.",
+                YELLOW,
+            )
+
+    return {
+        "integration_dv_result": dv_result,
+        "pipeline_done": False,
+        "pipeline_aborted": action == "abort",
+    }
+
+
+def route_after_integration_dv_decision(state: OrchestratorState) -> str:
+    """Route the operator's decision back into integration DV or terminate."""
+    result = state.get("integration_dv_result") or {}
+    if result.get("action_taken") in ("retry", "fix_rtl", "fix_tb"):
+        return "integration_dv"
+    return END
+
+
+route_after_integration_dv_decision.__edge_labels__ = {
+    "integration_dv": "RETRY / FIX",
+    END: "DONE",
+}
 
 
 def _load_ers_validation_context(project_root: str) -> tuple[str, int]:
@@ -10320,6 +10460,7 @@ async def _run_top_level_contract_audit(
     sim_log: str = "",
     sim_log_path: str = "",
     block_rtl_paths: dict[str, str] | None = None,
+    supported_actions: list[str] | None = None,
 ) -> dict:
     """Run contract audit for a top-level DV failure.
 
@@ -10402,6 +10543,28 @@ async def _run_top_level_contract_audit(
     )
     if stale:
         log(f"  [CONTRACT-AUDIT] {stale}", RED)
+    # run3-followups: the audit's SEMANTIC recommendation (e.g. revise_uarch,
+    # forced by the agent for spec-level categories) may not be an offerable
+    # resume action for the parked interrupt -- the operator was told to take
+    # an action the resume endpoint rejects. Keep the semantic recommendation,
+    # and add the closest OFFERABLE action plus how to use it.
+    rec = str(result.get("recommended_action", "") or "")
+    if supported_actions and rec and rec not in supported_actions:
+        resume_action = ("retry" if "retry" in supported_actions
+                         else supported_actions[0])
+        result["recommended_resume_action"] = resume_action
+        result["recommended_action_note"] = (
+            f"'{rec}' is the audit's semantic recommendation but is not an "
+            "offerable resume action for this interrupt "
+            f"(offerable: {supported_actions}). Apply the fix at its source "
+            f"(spec/uarch documents), then resume with '{resume_action}' -- "
+            "regeneration will read the corrected documents."
+        )
+        log(
+            f"  [CONTRACT-AUDIT] recommended '{rec}' is not an offerable "
+            f"resume action; operator path: fix at source + '{resume_action}'",
+            YELLOW,
+        )
     result["audit_path"] = str(output_path)
     result["context_path"] = str(context_path)
     return result
@@ -10412,6 +10575,8 @@ def route_after_integration_dv(state: OrchestratorState) -> str:
     result = state.get("integration_dv_result") or {}
     if result.get("passed") is True:
         return "validation_dv"
+    if result.get("pending_decision"):
+        return "integration_dv_decision"
     if result.get("action_taken") in ("retry", "fix_rtl", "fix_tb"):
         return "integration_dv"
     return END
@@ -10419,6 +10584,7 @@ def route_after_integration_dv(state: OrchestratorState) -> str:
 
 route_after_integration_dv.__edge_labels__ = {
     "validation_dv": "Validation DV",
+    "integration_dv_decision": "Park for decision",
     "integration_dv": "Retry",
     END: "DONE",
 }
@@ -10642,6 +10808,7 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
                 sim_log=error_msg,
                 sim_log_path="",
                 block_rtl_paths=block_rtl_paths,
+                            supported_actions=["retry", "fix_rtl", "fix_tb", "abort"],
             )
             payload = {
                 "type": "validation_dv_failure",
@@ -10682,36 +10849,28 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
                     "contract_audit": contract_audit.get("audit_path", ""),
                 },
             }
-            response = interrupt(payload)
-            action = response.get("action", "abort")
+            # run3-followups: park in validation_dv_decision instead of a tail
+            # interrupt() (see integration_dv for the one-cycle-late defect).
             write_graph_event(pr, "Validation DV", "graph_node_exit", {
                 "error": str(e),
                 "phase": "tb_generation",
-                "action": action,
+                "action": "pending_decision",
             })
-            dv_result = {
-                "passed": False,
-                "error": error_msg,
-                "phase": "tb_generation",
-                "requirement_count": requirement_count,
-                "test_count": 0,
-                "testbench_path": "",
-                "design_name": design_name,
-                "action_taken": action,
-                "contract_audit": contract_audit,
-                "contract_audit_path": contract_audit.get("audit_path", ""),
-            }
-            if action == "abort":
-                dv_result["aborted"] = True
-                log("  [VALIDATION-DV] Aborted", RED)
-            elif action in ("retry", "fix_rtl", "fix_tb"):
-                fix_desc = response.get("rtl_fix_description", "")
-                dv_result["fix_applied"] = fix_desc
-                log(f"  [VALIDATION-DV] Fix applied: {fix_desc}", GREEN)
             return {
-                "validation_dv_result": dv_result,
+                "validation_dv_result": {
+                    "passed": False,
+                    "pending_decision": True,
+                    "interrupt_payload": payload,
+                    "error": error_msg,
+                    "phase": "tb_generation",
+                    "requirement_count": requirement_count,
+                    "test_count": 0,
+                    "testbench_path": "",
+                    "design_name": design_name,
+                    "contract_audit": contract_audit,
+                    "contract_audit_path": contract_audit.get("audit_path", ""),
+                },
                 "pipeline_done": False,
-                "pipeline_aborted": action == "abort",
             }
 
         tb_path = tb_result.get("testbench_path", "")
@@ -10861,6 +11020,7 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
             sim_log=sim_log,
             sim_log_path=sim_result.get("log_path", ""),
             block_rtl_paths=block_rtl_paths,
+                    supported_actions=["retry", "fix_rtl", "fix_tb", "abort"],
         )
         _record_dv_row(
             pr, block=design_name, scope="validation", source="gate", passed=False,
@@ -10914,54 +11074,106 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
         ):
             payload["supported_actions"].insert(-1, "skip")
 
-        response = interrupt(payload)
-        action = response.get("action", "abort")
+        # run3-followups: park in validation_dv_decision instead of a tail
+        # interrupt() (see integration_dv for the one-cycle-late defect).
         write_graph_event(pr, "Validation DV", "graph_node_exit", {
-            "action": action,
+            "action": "pending_decision",
             "passed": False,
             "test_count": test_count,
             "requirement_count": requirement_count,
         })
-
-        dv_result = {
-            "passed": False,
-            "test_count": test_count,
-            "requirement_count": requirement_count,
-            "testbench_path": tb_path,
-            "sim_log_path": sim_result.get("log_path", ""),
-            "design_name": design_name,
-            "action_taken": action,
-            "contract_audit": contract_audit,
-            "contract_audit_path": contract_audit.get("audit_path", ""),
-        }
-
-        if action == "skip":
-            dv_result["skipped_by_user"] = True
-            log("  [VALIDATION-DV] Skipped by explicit configuration", YELLOW)
-        elif action == "abort":
-            dv_result["aborted"] = True
-            log("  [VALIDATION-DV] Aborted", RED)
-        elif action in ("retry", "fix_rtl", "fix_tb"):
-            fix_desc = response.get("rtl_fix_description", "")
-            log(f"  [VALIDATION-DV] Fix applied: {fix_desc}", GREEN)
-            dv_result["fix_applied"] = fix_desc
-
         return {
-            "validation_dv_result": dv_result,
+            "validation_dv_result": {
+                "passed": False,
+                "pending_decision": True,
+                "interrupt_payload": payload,
+                "test_count": test_count,
+                "requirement_count": requirement_count,
+                "testbench_path": tb_path,
+                "sim_log_path": sim_result.get("log_path", ""),
+                "design_name": design_name,
+                "contract_audit": contract_audit,
+                "contract_audit_path": contract_audit.get("audit_path", ""),
+            },
             "pipeline_done": False,
-            "pipeline_aborted": action == "abort",
         }
 
 
-def route_after_validation_dv(state: OrchestratorState) -> str:
-    """Route after validation DV: terminal frontend pipeline."""
+async def validation_dv_decision_node(state: OrchestratorState) -> dict:
+    """Consume the operator's decision for a parked validation-DV failure.
+
+    Same split as ``integration_dv_decision_node`` (run3-followups): the
+    interrupt lives in its own node so the resume response is consumed
+    immediately instead of one regeneration cycle late."""
+    pr = state["project_root"]
+    dv = dict(state.get("validation_dv_result") or {})
+    payload = dv.get("interrupt_payload") or {
+        "type": "validation_dv_failure",
+        "supported_actions": ["retry", "fix_rtl", "fix_tb", "abort"],
+    }
+    response = interrupt(payload) or {}
+    action = response.get("action", "abort")
+    write_graph_event(pr, "Validation DV", "graph_node_exit", {
+        "action": action,
+        "passed": False,
+        "phase": dv.get("phase", "simulation"),
+        "test_count": dv.get("test_count", 0),
+        "requirement_count": dv.get("requirement_count", 0),
+    })
+
+    dv_result = dict(dv)
+    dv_result.pop("interrupt_payload", None)
+    dv_result["pending_decision"] = False
+    dv_result["action_taken"] = action
+
+    if action == "skip":
+        dv_result["skipped_by_user"] = True
+        log("  [VALIDATION-DV] Skipped by explicit configuration", YELLOW)
+    elif action == "abort":
+        dv_result["aborted"] = True
+        log("  [VALIDATION-DV] Aborted", RED)
+    elif action in ("retry", "fix_rtl", "fix_tb"):
+        fix_desc = response.get("rtl_fix_description", "")
+        log(
+            f"  [VALIDATION-DV] Fix applied (action={action}): "
+            f"{fix_desc or '(no description provided)'}",
+            GREEN,
+        )
+        dv_result["fix_applied"] = fix_desc
+
+    return {
+        "validation_dv_result": dv_result,
+        "pipeline_done": False,
+        "pipeline_aborted": action == "abort",
+    }
+
+
+def route_after_validation_dv_decision(state: OrchestratorState) -> str:
+    """Route the operator's decision back into validation DV or terminate."""
     result = state.get("validation_dv_result") or {}
     if result.get("action_taken") in ("retry", "fix_rtl", "fix_tb"):
         return "validation_dv"
     return END
 
 
+route_after_validation_dv_decision.__edge_labels__ = {
+    "validation_dv": "RETRY / FIX",
+    END: "DONE",
+}
+
+
+def route_after_validation_dv(state: OrchestratorState) -> str:
+    """Route after validation DV: terminal frontend pipeline."""
+    result = state.get("validation_dv_result") or {}
+    if result.get("pending_decision"):
+        return "validation_dv_decision"
+    if result.get("action_taken") in ("retry", "fix_rtl", "fix_tb"):
+        return "validation_dv"
+    return END
+
+
 route_after_validation_dv.__edge_labels__ = {
+    "validation_dv_decision": "Park for decision",
     "validation_dv": "Retry",
     END: "DONE",
 }
@@ -11070,7 +11282,13 @@ def build_pipeline_graph(checkpointer=None):
     orchestrator.add_node("pipeline_complete", pipeline_complete_node)
     orchestrator.add_node("integration_check", integration_check_node)
     orchestrator.add_node("integration_dv", integration_dv_node)
+    # run3-followups: interrupts live in dedicated decision nodes so a resume
+    # re-executes only the interrupt() call -- the big DV nodes never replay a
+    # default cycle over an operator's response (the one-cycle-late defect).
+    orchestrator.add_node(
+        "integration_dv_decision", integration_dv_decision_node)
     orchestrator.add_node("validation_dv", validation_dv_node)
+    orchestrator.add_node("validation_dv_decision", validation_dv_decision_node)
     # Deterministic signoff scorecard: the single pre-END funnel for every
     # GENUINE terminal (validation_dv done, integration_dv terminal-fail,
     # pipeline_complete abort). It does NOT sit on the interrupt()-based
@@ -11103,11 +11321,27 @@ def build_pipeline_graph(checkpointer=None):
         {
             "validation_dv": "validation_dv",
             "integration_dv": "integration_dv",
+            "integration_dv_decision": "integration_dv_decision",
+            END: "final_report",
+        },
+    )
+    orchestrator.add_conditional_edges(
+        "integration_dv_decision", route_after_integration_dv_decision,
+        {
+            "integration_dv": "integration_dv",
             END: "final_report",
         },
     )
     orchestrator.add_conditional_edges(
         "validation_dv", route_after_validation_dv,
+        {
+            "validation_dv": "validation_dv",
+            "validation_dv_decision": "validation_dv_decision",
+            END: "final_report",
+        },
+    )
+    orchestrator.add_conditional_edges(
+        "validation_dv_decision", route_after_validation_dv_decision,
         {
             "validation_dv": "validation_dv",
             END: "final_report",

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -5213,6 +5213,14 @@ async def block_done_node(state: BlockState) -> dict:
     constr_path = block_dir / "constraints.json"
     constraints = _load_constraints_safe(constr_path)
 
+    # When this completion event happened. `completed_blocks` is append-only, so
+    # membership alone cannot tell a LEFTOVER interrupt (the graph moved past it
+    # and the block then finished) from a LIVE one (the block finished a pass
+    # ago and is parked again now). The daemon compares this against when the
+    # interrupt was raised; without it every pass-2 interrupt in a two-pass run
+    # was labelled stale on arrival and live_interrupt_count read 0.
+    completed_at = _time.time()
+
     if all_passed:
         result = {
             "name": block_name,
@@ -5223,6 +5231,7 @@ async def block_done_node(state: BlockState) -> dict:
             "constraints_learned": len(constraints),
             "step_log_paths": step_log_paths,
             "phase": phase,
+            "completed_at": completed_at,
         }
         log(f"  [{block_name}] PASSED (attempt {attempt})", GREEN)
     else:
@@ -5241,6 +5250,7 @@ async def block_done_node(state: BlockState) -> dict:
             "synth_success": synth_success,
             "step_log_paths": step_log_paths,
             "phase": phase,
+            "completed_at": completed_at,
         }
         reason = (
             "aborted" if is_abort

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -800,6 +800,10 @@ def _report_uarch_golden(block_name: str, ref: str, resolved: str) -> None:
             "kind": kind,
             "advisory": True,
             "unmodeled": detail,
+            # The explanation the report renders. It was built right above and
+            # then went nowhere the report reads, so every uarch_golden entry
+            # in the ledger carried a gate/kind pair and no account of itself.
+            "detail": detail,
             "first_divergence_block": block_name,
             "note": "",
         })

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -96,7 +96,7 @@ def preflight_check(phases: list[str] | None = None) -> dict:
         "yes",
         "on",
     }
-    # HOT-PATCH (chip-lead, codecv4-synthgated): honor CORESMITH_SYNTH_GENERIC in
+    # HOT-PATCH (chip-lead, synth-gated run): honor CORESMITH_SYNTH_GENERIC in
     # preflight. Generic (PDK-free) synth maps with abc -g and needs only yosys+
     # verilator -- NOT the sky130 Liberty/PDK. Preflight previously required the
     # PDK unconditionally whenever SKIP_SYNTH was unset, falsely blocking generic
@@ -752,7 +752,7 @@ def _report_uarch_golden(block_name: str, ref: str, resolved: str) -> None:
 
     Three cases, three different truths -- and the old code told none of them,
     because every reader of a golden returns "" on failure while the uArch
-    prompt appended the golden section unconditionally. Measured on the raster
+    prompt appended the golden section unconditionally. Measured on a
     validation run: all 8 uArch calls carried an empty golden block and nothing
     anywhere said so.
 
@@ -761,9 +761,9 @@ def _report_uarch_golden(block_name: str, ref: str, resolved: str) -> None:
         a transcription target that cannot be read; the spec author would have
         invented the math in its place. RED log + carried defect naming the ref.
       * no ref at all              -> this block legitimately has no reference
-        golden (6 of 8 raster blocks). Log it and carry it forward, because the
-        spec -- and every RTL lowering below it -- is then unconstrained by any
-        reference and the final report should say so.
+        golden (routinely most blocks of a design). Log it and carry it forward,
+        because the spec -- and every RTL lowering below it -- is then
+        unconstrained by any reference and the final report should say so.
 
     Neither empty case raises here: the hard failure belongs where a FLAG
     explicitly promised a golden (``CORESMITH_RTL_FROM_HW_GOLDEN`` in the RTL

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -1565,10 +1565,21 @@ async def _maybe_generate_block_golden(block: dict, callbacks: list = None) -> N
                     (PROJECT_ROOT / ".coresmith" / "blocks" / block_name
                      / "golden_feasibility_failed").write_text(
                         fr.get("reason", "degenerate golden"))
+            elif fr.get("verdict") == "pass":
+                _reach = (fr.get("checks", {})
+                          .get("slice_reachability", {}) or {})
+                log(f"  [BLOCK-MODEL] {block_name}: golden-feasibility PASS -- "
+                    f"the block's golden slice is REACHED by the reference "
+                    f"({_reach.get('reason') or 'slice exercised'})", GREEN)
             elif fr.get("ran"):
-                log(f"  [BLOCK-MODEL] {block_name}: golden-feasibility OK "
-                    f"({fr.get('checks', {}).get('slice_reachability', {}).get('verdict','')})",
-                    GREEN)
+                # NOT RUN, reported the way the gate-sim gate reports it: full
+                # reason, no green. The old line printed "OK (skipped)" in
+                # GREEN -- an OK whose own parenthetical said the discriminating
+                # check had not run. Every block of the first hands-off run got
+                # that line.
+                log(f"  [BLOCK-MODEL] {block_name}: golden-feasibility NOT RUN "
+                    f"-- {fr.get('not_run_reason') or 'no discriminating check concluded'}",
+                    YELLOW)
         except Exception as _fexc:  # noqa: BLE001 - probe is best-effort
             log(f"  [BLOCK-MODEL] {block_name}: feasibility probe skipped "
                 f"({_fexc})", YELLOW)

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -744,6 +744,62 @@ def rtl_reference_source(block: dict) -> tuple[str, bool]:
 
 
 # ---------------------------------------------------------------------------
+# µarch composition gate -- honest exit banner
+# ---------------------------------------------------------------------------
+
+def uarch_gate_banner(model_integration_result: dict | None) -> tuple[str, str]:
+    """``(banner_text, colour)`` for the µarch gate's exit banner.
+
+    CLEAN means nothing fired. Measured live: the gate detected a model-level
+    mismatch, logged it, DISMISSED it as advisory (the deterministic-BFM bypass,
+    which is a legitimate non-blocking decision) -- and four lines later the run
+    printed a green "µARCH GATE CLEAN". Two true statements were composed into a
+    false one, and the green line is the one a reader carries away.
+
+    This function does not change what the gate DOES -- the bypass stays
+    advisory, the run still proceeds -- only what it SAYS. Every outcome that is
+    not "nothing fired" gets a yellow banner naming the finding and stating
+    explicitly that it is non-blocking.
+    """
+    res = model_integration_result if isinstance(model_integration_result, dict) else {}
+    tail = " -> beginning RTL pass (pass 2)"
+
+    if res.get("advisory_bypass"):
+        n = len(res.get("violations") or [])
+        where = res.get("first_divergence_block") or ""
+        return (
+            "µARCH GATE NOT CLEAN: "
+            + (f"{n} model-level mismatch(es)" if n else "a model-level mismatch")
+            + " were DISMISSED as ADVISORY (non-blocking; the deterministic "
+            "integration DV on the real RTL is the authoritative check) and "
+            "carried forward"
+            + (f"; first-divergence block: {where}" if where else
+               "; first-divergence block: (unlocalized)")
+            + tail,
+            YELLOW,
+        )
+
+    if res and res.get("passed") is False:
+        return (
+            "µARCH GATE NOT CLEAN: the gate did not pass"
+            + (f" (action taken: {res.get('action_taken')})"
+               if res.get("action_taken") else "")
+            + tail,
+            YELLOW,
+        )
+
+    if res.get("derate_signed_off"):
+        return (
+            "µARCH GATE PASSED WITH A SIGNED-OFF DERATE (within budget, "
+            "recorded in the derate ledger)" + tail,
+            YELLOW,
+        )
+
+    # Nothing fired (or no record at all -- the gate never ran on this path).
+    return ("µARCH GATE CLEAN" + tail, CYAN)
+
+
+# ---------------------------------------------------------------------------
 # Microarchitecture Spec Generation
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/langgraph/ppa_check.py
+++ b/orchestrator/langgraph/ppa_check.py
@@ -837,6 +837,52 @@ def parse_sdc_period_ns(sdc_text: str) -> float | None:
     return min(vals) if vals else None
 
 
+def implausible_slack_ns() -> float:
+    """|WNS| above which a slack number is a SENTINEL, not a measurement.
+
+    OpenSTA answers ``worst_slack`` with its internal infinity when the design
+    it linked has no timing endpoints at all -- nothing to constrain, so nothing
+    to be late. That comes back as ``1.0000000433293989e+39``, and the block PPA
+    gate happily compared it to a budget and announced "within budget". Three
+    blocks of the first hands-off run passed their timing dimension on that
+    number, two of them the SRAM-bearing blocks whose timing is the whole
+    question.
+
+    No real pre-layout slack is anywhere near this: a 20 ns clock puts an honest
+    WNS in the tens of ns, and even a pathological unbuffered fan-out cone tops
+    out in the hundreds. A megasecond of slack is a tool sentinel.
+    Override with ``CORESMITH_PPA_MAX_PLAUSIBLE_WNS_NS``.
+    """
+    try:
+        return abs(float(os.environ.get(
+            "CORESMITH_PPA_MAX_PLAUSIBLE_WNS_NS", "1e6") or "1e6"))
+    except ValueError:
+        return 1e6
+
+
+def slack_is_implausible(wns_ns: float | None) -> bool:
+    """True when a slack value can only be a sentinel / uninitialised read."""
+    if wns_ns is None:
+        return False
+    try:
+        v = float(wns_ns)
+    except (TypeError, ValueError):
+        return False
+    return not (v == v) or abs(v) > implausible_slack_ns()  # NaN or huge
+
+
+def implausible_slack_detail(wns_ns: float, where: str = "") -> str:
+    """The reason string a sentinel slack travels with. States WHAT it saw."""
+    return (
+        f"implausible slack{f' from {where}' if where else ''}: "
+        f"{wns_ns:.6g} ns exceeds the plausibility bound "
+        f"{implausible_slack_ns():g} ns -- this is a tool SENTINEL (OpenSTA "
+        f"answers worst_slack with infinity when the linked design has no "
+        f"timing endpoints), not a measurement. Timing is NOT MEASURED for "
+        f"this block."
+    )
+
+
 def parse_sta_report(report_text: str) -> dict[str, float | None]:
     """Parse WNS/TNS (ns) from an OpenSTA ``report_wns``/``report_tns`` dump.
 
@@ -845,13 +891,19 @@ def parse_sta_report(report_text: str) -> dict[str, float | None]:
     legacy form, so on a modern OpenSTA (which prints the ``max`` corner token)
     the parse returned nothing and WNS/TNS silently came back ``None`` -- a
     dependency on the box's ``sta`` sed-wrapper that the engine must not rely on.
+
+    The number pattern accepts scientific notation deliberately. Without the
+    exponent the old pattern read ``wns max 1.0000000433293989e+39`` as the
+    MANTISSA, 1.0 -- a sentinel silently laundered into a plausible-looking
+    1 ns of slack, which is a worse outcome than either the sentinel or a parse
+    failure. :func:`slack_is_implausible` then rejects it honestly.
     """
     out: dict[str, float | None] = {"wns_ns": None, "tns_ns": None}
     for key, tag in (("wns_ns", "wns"), ("tns_ns", "tns")):
         # ``(?:\s+max)?`` optionally swallows the OpenSTA 3.x corner token so
         # both ``wns -3.42`` and ``wns max -3.42`` parse to the same number.
         m = re.search(
-            rf"\b{tag}\b(?:\s+max)?\s+(-?\d+(?:\.\d+)?)",
+            rf"\b{tag}\b(?:\s+max)?\s+(-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)",
             report_text or "", re.IGNORECASE,
         )
         if m:
@@ -1035,6 +1087,17 @@ def evaluate_ppa(
                     f"{area_budget_um2:,.0f} µm² by >{area_tolerance_pct:.0f}%"
                 )
 
+    # A sentinel slack is NOT a measurement, wherever it came from. This is the
+    # gate's own backstop: the measurement sites reject it too, but the gate is
+    # what declares "within budget", and it must never do so on a number no
+    # timing analysis produced. Demoted to the UNMEASURED branch below, which is
+    # the tri-state house convention -- pass / fail / not-measured + reason --
+    # so it can neither silently pass nor silently fail.
+    if wns_ns is not None and slack_is_implausible(wns_ns):
+        sta_error = implausible_slack_detail(float(wns_ns), "the PPA gate input")
+        logger.warning("PPA gate: %s", sta_error)
+        wns_ns = None
+
     if wns_ns is not None:
         # Grader alignment: the accelerator-chassis grader checks only cells/area/FF +
         # functional correctness and DEFERS timing to signoff (the golden
@@ -1083,19 +1146,27 @@ def evaluate_ppa(
         _timing_advisory = os.environ.get(
             "CORESMITH_PPA_TIMING_ADVISORY", "0").strip().lower() in (
             "1", "true", "yes", "on")
+        _implausible = sta_error.startswith("implausible slack")
         checks.append({
             "metric": "wns_ns", "actual": None, "passed": bool(_timing_advisory),
             "sta_error": sta_error, "unmeasured_timing": True,
+            "implausible_slack": _implausible,
             "advisory": bool(_timing_advisory),
         })
         if not _timing_advisory:
             ok = False
             reasons.append(
-                f"pre-layout STA produced no parseable timing ({sta_error}) -- "
-                f"refusing to declare the block within budget on an UNMEASURED "
-                f"timing dimension (fail-closed). Fix the netlist / re-run STA "
-                f"(retry), or set CORESMITH_PPA_TIMING_ADVISORY=1 to accept "
-                f"unmeasurable timing for this run."
+                (f"pre-layout STA returned a SENTINEL, not a measurement "
+                 f"({sta_error}) -- the design as linked has no timing "
+                 f"endpoints (all-blackbox / no registered path), so its "
+                 f"timing is UNMEASURED and cannot be declared within budget."
+                 if _implausible else
+                 f"pre-layout STA produced no parseable timing ({sta_error}) -- "
+                 f"refusing to declare the block within budget on an UNMEASURED "
+                 f"timing dimension (fail-closed).")
+                + " Fix the netlist / re-run STA (retry), or set "
+                  "CORESMITH_PPA_TIMING_ADVISORY=1 to accept unmeasurable "
+                  "timing for this run."
             )
 
     return PpaVerdict(ok=ok, checks=checks, reasons=reasons, unmeasured=unmeasured)
@@ -1482,6 +1553,12 @@ def run_pre_layout_sta(
             if tail:
                 reason += f"; output tail: {tail}"
             return _fail(reason)
+        if slack_is_implausible(parsed["wns_ns"]):
+            # A parsed sentinel is not a timing read. Route it down the same
+            # loud "STA produced no timing" path so the gate fails closed on an
+            # UNMEASURED dimension instead of comparing infinity to a budget.
+            return _fail(implausible_slack_detail(
+                float(parsed["wns_ns"]), f"report_wns on {top_module}"))
         return parsed
     except subprocess.TimeoutExpired:
         return _fail(f"OpenSTA timed out after {timeout_s}s")
@@ -1663,7 +1740,16 @@ def _measure_wns_from_rtl(sources: list[str], lib: str, base_wd: Path, tag: str,
         m = re.search(r"worst slack\s*(?:-?max)?\s*([-0-9.eE+]+)", out, re.IGNORECASE)
     if m is None:
         return None, "sta_parse_fail: " + out[-400:]
-    return float(m.group(1)), ""
+    val = float(m.group(1))
+    if slack_is_implausible(val):
+        # NOT a measurement. Returning it would let the caller max() it against
+        # a real number and win every comparison.
+        detail = implausible_slack_detail(
+            val, f"worst_slack -max on the {'buffered' if buffered else 'base'} "
+                 f"{top} netlist")
+        logger.warning("fan-out-aware STA for %s: %s", top, detail)
+        return None, detail
+    return val, ""
 
 
 def run_maxfanout_buffered_sta(

--- a/orchestrator/langgraph/tapeout_helpers.py
+++ b/orchestrator/langgraph/tapeout_helpers.py
@@ -1297,7 +1297,7 @@ def _run_magic_drc_on_gds(gds_path: str, output_dir: str, timeout: int = 600) ->
     when no measurement exists. This function used to return
     ``{"pass": False, "violation_count": -1}`` when Magic produced nothing at
     all, which every consumer read as "this layout HAS violations" -- see the
-    ``exp-raster-macro-20260727`` w32_d64 / w9_d512 macro reports, whose named
+    measured w32_d64 / w9_d512 macro reports from a validation run, whose named
     ``precheck_magic_drc.rpt`` was never written.
     """
     from orchestrator.langgraph.backend_helpers import (

--- a/orchestrator/mcp_server.py
+++ b/orchestrator/mcp_server.py
@@ -3003,6 +3003,27 @@ async def launch_backend(
     if not block_queue:
         return {"error": "No blocks found in block_specs.json or config.yaml"}
 
+    # Blocks retired by the pin map were deliberately never microarchitected,
+    # generated or synthesized (the chip top emits their routing itself) --
+    # they must not gate the backend launch nor enter the backend state.
+    from orchestrator.architecture.pin_map_retire import read_retired_blocks
+    _retired = {r.get("block") for r in read_retired_blocks(_project_root())
+                if isinstance(r, dict) and r.get("block")}
+    if _retired:
+        def _blk_name(b):
+            return b["name"] if isinstance(b, dict) else b
+        _before = len(block_queue)
+        block_queue = [b for b in block_queue if _blk_name(b) not in _retired]
+        frontend_blocks = [
+            b for b in frontend_blocks if _blk_name(b) not in _retired
+        ]
+        import logging
+        logging.getLogger(__name__).warning(
+            "backend gate: excluding %d pin-map-retired block(s) %s "
+            "(%d -> %d in queue)",
+            len(_retired), sorted(_retired), _before, len(block_queue),
+        )
+
     # Load architecture connections
     from orchestrator.langgraph.integration_helpers import load_architecture_connections
     architecture_connections, design_name = load_architecture_connections(_project_root())

--- a/orchestrator/tests/test_autonomy_gap_fixes.py
+++ b/orchestrator/tests/test_autonomy_gap_fixes.py
@@ -274,10 +274,18 @@ def test_the_discount_expires_the_moment_the_run_stops(daemon, monkeypatch):
     assert daemon._consumed_interrupt_ids == set()
 
 
-def test_suspected_stale_labelling_is_unchanged(daemon, monkeypatch):
+def test_suspected_stale_labelling_needs_the_completion_to_be_NEWER(
+        daemon, monkeypatch):
+    """A leftover is an interrupt the graph has moved PAST -- so the block's
+    completion must post-date it. Bare membership in the append-only
+    completed_blocks made every pass-2 interrupt of a two-pass run read stale
+    on arrival with live_interrupt_count=0."""
     monkeypatch.setattr(daemon._pipeline, "task", _FinishedTask())
+    monkeypatch.setattr(daemon, "_interrupt_first_seen", {"i1": 10.0},
+                        raising=False)
     snap = _Snap(
-        {"completed_blocks": [{"name": "blk", "success": True}],
+        {"completed_blocks": [{"name": "blk", "success": True,
+                               "completed_at": 1e9}],
          "block_queue": [{"name": "blk"}]},
         [_Task([_Intr("i1", {"type": "dv_failure", "block": "blk"})])],
     )
@@ -285,3 +293,10 @@ def test_suspected_stale_labelling_is_unchanged(daemon, monkeypatch):
     assert st["interrupts"][0]["stale_suspected"] is True
     assert st["pending_interrupt_count"] == 1      # surfaced, not hidden
     assert st["suspected_stale_interrupt_count"] == 1
+
+    # Same shape, but the interrupt was raised AFTER the block completed: LIVE.
+    monkeypatch.setattr(daemon, "_interrupt_first_seen", {"i1": 2e9},
+                        raising=False)
+    st2 = daemon._shape_state(snap)
+    assert st2["interrupts"][0]["stale_suspected"] is False
+    assert st2["live_interrupt_count"] == 1

--- a/orchestrator/tests/test_backend_graph.py
+++ b/orchestrator/tests/test_backend_graph.py
@@ -614,3 +614,147 @@ class TestSafeFormat:
         # ... and the rendered example is natural single-brace Verilog.
         assert "assign io_out = {31'b0, done, qspi_o, 2'b0};" in rendered
         assert "{4{oe}}, 2'b1};" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Synthesis self-recovery is never silent (run3-followups #3)
+# ---------------------------------------------------------------------------
+#
+# PRODUCTION CALL PATH: these drive ``flat_top_synthesis_node`` itself, with only
+# the LLM step faked. The bug was that a driver-internal retry left no trace, so
+# a test that exercised the collector alone would have proved nothing about the
+# artifact a later reader actually opens.
+
+class TestFlatSynthAttemptHistoryWiring:
+    def _state(self, tmp_path, **kw):
+        top = tmp_path / "rtl" / "integration" / "chip_top.v"
+        top.parent.mkdir(parents=True, exist_ok=True)
+        top.write_text("module chip_top(input wb_clk_i);\nendmodule\n")
+        state = {
+            "project_root": str(tmp_path),
+            "design_name": "chip_top",
+            "integration_top_path": str(top),
+            "block_rtl_paths": {},
+            "target_clock_mhz": 50.0,
+            "attempt": 1,
+            "current_block": {"name": "chip_top"},
+        }
+        state.update(kw)
+        return state
+
+    def _syn_dir(self, tmp_path):
+        d = tmp_path / "syn" / "output" / "chip_top"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    @pytest.mark.asyncio
+    async def test_success_on_attempt_2_retains_attempt_1(self, tmp_path, monkeypatch):
+        """THE defect, end to end: the driver succeeds on its second internal
+        attempt; attempt 1's reason lands in synth_result.json AND in state."""
+        from orchestrator.langgraph import backend_graph as bg
+
+        d = self._syn_dir(tmp_path)
+        net = d / "chip_top_netlist.v"
+        net.write_text("module chip_top(); endmodule\n")
+        (d / "synth_attempt1.log").write_text(
+            "ERROR: Module `cs_sram_1rw' referenced in module `chip_top' "
+            "is not part of the design.\n")
+
+        async def _fake_llm(**kwargs):
+            return {
+                "success": True,
+                "netlist_path": str(net),
+                "sdc_path": "",
+                "gate_count": 10,
+                "_llm_reply": "Synthesis succeeded on attempt 2.",
+            }
+
+        monkeypatch.setattr(bg, "_run_llm_eda_step", _fake_llm)
+        monkeypatch.setattr(bg, "_bind_macro_shells_for_backend",
+                            lambda _n: ([], ""))
+        monkeypatch.setattr(bg, "_run_chip_top_gate_sim",
+                            lambda _s, _n: (None, "not_run", "no TB"))
+
+        out = await bg.flat_top_synthesis_node(self._state(tmp_path))
+
+        hist = out["synth_attempt_history"]
+        assert [h["attempt"] for h in hist] == [1]
+        assert "cs_sram_1rw" in hist[0]["error_summary"]
+
+        import json as _json
+        artifact = _json.loads((d / "synth_result.json").read_text())
+        assert artifact["attempt_history"] == hist
+        assert artifact["attempt_failures"] == 1
+
+    @pytest.mark.asyncio
+    async def test_claimed_retry_with_no_evidence_is_recorded_as_a_gap(
+            self, tmp_path, monkeypatch):
+        from orchestrator.langgraph import backend_graph as bg
+
+        d = self._syn_dir(tmp_path)
+        net = d / "chip_top_netlist.v"
+        net.write_text("module chip_top(); endmodule\n")
+
+        async def _fake_llm(**kwargs):
+            return {"success": True, "netlist_path": str(net),
+                    "_llm_reply": "Synthesis succeeded on attempt 3."}
+
+        monkeypatch.setattr(bg, "_run_llm_eda_step", _fake_llm)
+        monkeypatch.setattr(bg, "_bind_macro_shells_for_backend",
+                            lambda _n: ([], ""))
+        monkeypatch.setattr(bg, "_run_chip_top_gate_sim",
+                            lambda _s, _n: (None, "not_run", ""))
+
+        out = await bg.flat_top_synthesis_node(self._state(tmp_path))
+        hist = out["synth_attempt_history"]
+        assert [h["attempt"] for h in hist] == [1, 2]
+        assert all(h["unrecorded"] for h in hist)
+
+    @pytest.mark.asyncio
+    async def test_a_failed_synthesis_carries_its_history_into_previous_error(
+            self, tmp_path, monkeypatch):
+        """diagnose reads previous_error. "attempt 3 failed" without the two
+        reasons before it is what made the same defect recur every run."""
+        from orchestrator.langgraph import backend_graph as bg
+
+        d = self._syn_dir(tmp_path)
+        (d / "run1.log").write_text("ERROR: cannot open liberty file\n")
+
+        async def _fake_llm(**kwargs):
+            return {"success": False, "error": "Flat synthesis failed",
+                    "_llm_reply": "gave up after attempt 2"}
+
+        monkeypatch.setattr(bg, "_run_llm_eda_step", _fake_llm)
+        out = await bg.flat_top_synthesis_node(self._state(tmp_path))
+        assert out["flat_netlist_path"] == ""
+        assert "Flat synthesis failed" in out["previous_error"]
+        assert "cannot open liberty file" in out["previous_error"]
+        # the FINAL attempt's reason is result["error"] (already in
+        # previous_error); the history retains the EARLIER attempt, which is
+        # exactly what used to vanish.
+        assert len(out["synth_attempt_history"]) == 1
+        assert out["synth_attempt_history"][0]["attempt"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_clean_first_attempt_is_byte_identical(
+            self, tmp_path, monkeypatch):
+        """No retry -> no history, no artifact mutation: the pre-fix shape."""
+        from orchestrator.langgraph import backend_graph as bg
+
+        d = self._syn_dir(tmp_path)
+        net = d / "chip_top_netlist.v"
+        net.write_text("module chip_top(); endmodule\n")
+
+        async def _fake_llm(**kwargs):
+            return {"success": True, "netlist_path": str(net),
+                    "_llm_reply": "Synthesis succeeded."}
+
+        monkeypatch.setattr(bg, "_run_llm_eda_step", _fake_llm)
+        monkeypatch.setattr(bg, "_bind_macro_shells_for_backend",
+                            lambda _n: ([], ""))
+        monkeypatch.setattr(bg, "_run_chip_top_gate_sim",
+                            lambda _s, _n: (None, "not_run", ""))
+
+        out = await bg.flat_top_synthesis_node(self._state(tmp_path))
+        assert out["synth_attempt_history"] == []
+        assert not (d / "synth_result.json").exists()

--- a/orchestrator/tests/test_backend_helpers.py
+++ b/orchestrator/tests/test_backend_helpers.py
@@ -838,3 +838,117 @@ class TestLvsIntegration:
         # Expected tap cell delta
         assert lvs["device_delta"] <= 2
         assert Path(lvs["report_path"]).exists()
+
+
+# ---------------------------------------------------------------------------
+# Synthesis attempt-history retention (run3-followups #3)
+# ---------------------------------------------------------------------------
+#
+# The flat-synth driver retries Yosys inside its own LLM step. A live run logged
+# "Synthesis succeeded on attempt 2" and attempt 1's failure reason was retained
+# NOWHERE -- not in attempt_history, not in previous_error, not in
+# synth_result.json. A driver that heals itself in silence teaches nobody: the
+# same script defect recurs every run and the only trace is a discarded
+# transcript.
+
+class TestSynthAttemptHistory:
+    def _collect(self, **kw):
+        from orchestrator.langgraph.backend_helpers import (
+            collect_synth_attempt_history,
+        )
+        kw.setdefault("now", "2026-07-31T00:00:00")
+        return collect_synth_attempt_history(kw.pop("result", {}), **kw)
+
+    def test_clean_first_attempt_records_nothing(self, tmp_path):
+        assert self._collect(
+            result={"success": True},
+            output_dir=str(tmp_path),
+            llm_reply="Synthesis succeeded.",
+        ) == []
+
+    def test_driver_reported_failures_are_retained_on_a_SUCCESS(self, tmp_path):
+        h = self._collect(
+            result={"success": True, "attempt_history": [
+                {"attempt": 1, "error_summary": "ERROR: Module `cs_sram_1rw' "
+                                                "is not part of the design"},
+            ]},
+            output_dir=str(tmp_path),
+            llm_reply="Synthesis succeeded on attempt 2.",
+        )
+        assert [e["attempt"] for e in h] == [1]
+        assert "cs_sram_1rw" in h[0]["error_summary"]
+        assert h[0]["source"] == "driver_reported"
+        assert h[0]["unrecorded"] is False
+
+    def test_yosys_logs_on_disk_are_harvested_without_the_driver(self, tmp_path):
+        """Deterministic evidence: the driver need not be honest about its own
+        retries for the failure reason to survive."""
+        (tmp_path / "synth_attempt1.log").write_text(
+            "1. Executing Verilog frontend\n"
+            "ERROR: syntax error, unexpected TOK_ID at line 12\n")
+        h = self._collect(result={"success": True}, output_dir=str(tmp_path),
+                          llm_reply="done")
+        assert len(h) == 1
+        assert h[0]["source"] == "yosys_log"
+        assert "syntax error" in h[0]["error_summary"]
+        assert "synth_attempt1.log" in h[0]["error_summary"]
+
+    def test_a_claimed_retry_with_no_evidence_is_recorded_as_NOT_RETAINED(
+            self, tmp_path):
+        """THE defect. The driver says it took two attempts and supplies nothing
+        about the first. The gap becomes a record instead of a silence."""
+        h = self._collect(result={"success": True}, output_dir=str(tmp_path),
+                          llm_reply="Synthesis succeeded on attempt 2.")
+        assert len(h) == 1
+        assert h[0]["attempt"] == 1
+        assert h[0]["unrecorded"] is True
+        assert "not retained" in h[0]["error_summary"]
+
+    def test_real_evidence_wins_over_the_not_retained_placeholder(self, tmp_path):
+        (tmp_path / "a.log").write_text("ERROR: cannot open liberty file\n")
+        h = self._collect(result={"success": True}, output_dir=str(tmp_path),
+                          llm_reply="succeeded on attempt 3")
+        assert [e["attempt"] for e in h] == [1, 2]
+        assert h[0]["unrecorded"] is False and "liberty" in h[0]["error_summary"]
+        assert h[1]["unrecorded"] is True
+
+    def test_node_level_prior_failure_is_folded_in(self, tmp_path):
+        h = self._collect(result={"success": True}, output_dir=str(tmp_path),
+                          prior_error="hierarchy -check failed on top",
+                          node_attempt=2, llm_reply="ok")
+        assert [e["source"] for e in h] == ["node_previous_error"]
+        assert h[0]["attempt"] == 1
+
+    def test_collector_never_raises_on_garbage(self, tmp_path):
+        assert self._collect(result={"attempt_history": "not-a-list"},
+                             output_dir="/nonexistent/dir",
+                             llm_reply=None) == []
+
+    def test_persist_merges_into_the_synth_result_artifact(self, tmp_path):
+        from orchestrator.langgraph.backend_helpers import (
+            persist_synth_attempt_history,
+        )
+        import json as _json
+        p = tmp_path / "synth_result.json"
+        p.write_text(_json.dumps({"success": True, "gate_count": 42}))
+        hist = [{"attempt": 1, "error_summary": "ERROR: boom",
+                 "source": "yosys_log", "timestamp": "t", "unrecorded": False}]
+        assert persist_synth_attempt_history(str(p), hist) is True
+        data = _json.loads(p.read_text())
+        assert data["gate_count"] == 42                 # existing keys survive
+        assert data["attempt_history"] == hist
+        assert data["attempt_failures"] == 1
+        assert data["attempt_history_unrecorded"] == 0
+
+    def test_describe_names_every_attempt(self):
+        from orchestrator.langgraph.backend_helpers import (
+            describe_synth_attempt_history,
+        )
+        assert describe_synth_attempt_history([]) == ""
+        txt = describe_synth_attempt_history([
+            {"attempt": 1, "error_summary": "boom", "source": "yosys_log",
+             "timestamp": "t", "unrecorded": False},
+            {"attempt": 2, "error_summary": "(not retained) ...",
+             "source": "unrecorded", "timestamp": "t", "unrecorded": True},
+        ])
+        assert "attempt 1" in txt and "attempt 2 [NOT RETAINED]" in txt

--- a/orchestrator/tests/test_carried_forward_defects.py
+++ b/orchestrator/tests/test_carried_forward_defects.py
@@ -109,3 +109,76 @@ def test_failure_signature_differs_on_structural_change():
     a = "UNSYNTHESIZABLE COMBINATIONAL CLOUD in foo"
     b = "WIDE FLAT PACKED STORAGE WITH DYNAMIC PART-SELECT in foo"
     assert _failure_signature(a) != _failure_signature(b)
+
+
+# ---- every entry explains itself -------------------------------------------
+#
+# The raster run's ledger held six uarch_golden entries. Each rendered as
+# "uarch_golden / no_reference_golden: 0 violation(s), first at <block>" and
+# nothing else -- the sentence explaining WHY that matters had been built and
+# then stored under a key no reporter read.
+
+def test_every_recorded_defect_carries_a_detail(tmp_path):
+    from orchestrator.langgraph.pipeline_graph import (
+        read_carried_forward_defects,
+        record_carried_forward_defect,
+    )
+    record_carried_forward_defect(str(tmp_path), {
+        "gate": "uarch_golden", "kind": "no_reference_golden",
+        "unmodeled": "block 'zbuffer_sram' has no reference golden model",
+        "first_divergence_block": "zbuffer_sram",
+    })
+    got = read_carried_forward_defects(str(tmp_path))[0]
+    assert got["detail"] == "block 'zbuffer_sram' has no reference golden model"
+
+
+def test_an_explicit_detail_is_never_overwritten(tmp_path):
+    from orchestrator.langgraph.pipeline_graph import (
+        read_carried_forward_defects,
+        record_carried_forward_defect,
+    )
+    record_carried_forward_defect(str(tmp_path), {
+        "gate": "g", "kind": "k", "unmodeled": "u", "detail": "the real story"})
+    assert read_carried_forward_defects(str(tmp_path))[0]["detail"] == (
+        "the real story")
+
+
+def test_note_is_the_fallback_when_there_is_no_unmodeled_text(tmp_path):
+    from orchestrator.langgraph.pipeline_graph import (
+        read_carried_forward_defects,
+        record_carried_forward_defect,
+    )
+    record_carried_forward_defect(str(tmp_path), {
+        "gate": "g", "kind": "k", "unmodeled": "", "note": "advisory bypass"})
+    assert read_carried_forward_defects(str(tmp_path))[0]["detail"] == (
+        "advisory bypass")
+
+
+def test_the_uarch_golden_recorder_persists_its_explanation(tmp_path,
+                                                            monkeypatch):
+    """Driven through the PRODUCTION recorder (_report_uarch_golden), which is
+    where the six raster entries came from."""
+    import json as _json
+
+    from orchestrator.langgraph import pipeline_helpers as ph
+    monkeypatch.setattr(ph, "PROJECT_ROOT", tmp_path)
+    ph._report_uarch_golden("zbuffer_sram", "", "")
+    entries = _json.loads(
+        (tmp_path / ".coresmith" / "carried_forward_defects.json").read_text())
+    assert entries[0]["detail"]
+    assert "no reference golden model" in entries[0]["detail"]
+
+
+def test_the_final_report_prints_the_explanation(tmp_path):
+    from orchestrator.langgraph import final_report as fr
+    (tmp_path / ".coresmith").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".coresmith" / "carried_forward_defects.json").write_text(
+        json.dumps([{
+            "gate": "uarch_golden", "kind": "no_reference_golden",
+            "first_divergence_block": "zbuffer_sram",
+            "detail": "block 'zbuffer_sram' has no reference golden model "
+                      "(python_source absent), so its uArch spec and RTL were "
+                      "never checked against one",
+        }]))
+    md = fr.render_markdown(fr.build_final_report({}, str(tmp_path)))
+    assert "no reference golden model" in md

--- a/orchestrator/tests/test_chip_model_anticheat.py
+++ b/orchestrator/tests/test_chip_model_anticheat.py
@@ -1,0 +1,261 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""``sim.run()`` is the Amaranth simulator, not a call to the oracle.
+
+Two consecutive runs lost their composition gate to this. The reference entry
+was named ``run``, the chip model ended (as every Amaranth driver does) with::
+
+    sim.add_testbench(bench)
+    sim.run()
+
+and the ANTI-CHEAT check matched attribute names blind::
+
+    ANTI-CHEAT: chip model calls 'run', matching the reference entry 'run'.
+    Never call the oracle from the chip model.
+
+The model was rejected, ``_chip_model.py`` was never written, and the
+composition gate -- the run's model-vs-golden check -- no-opped in silence.
+
+The relaxation is scoped: only a method call on a name this module BOUND to a
+value it constructed is spared, and only when the receiver is not itself
+oracle-shaped and the module does no dynamic importing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.langchain.agents.model_integration_generator import (
+    _chip_model_attempts,
+    _validate_chip_model_text,
+)
+
+_HEAD = (
+    "from amaranth import Elaboratable, Module\n"
+    "from amaranth.sim import Simulator\n"
+    "\n"
+    "class chip_model(Elaboratable):\n"
+    "    def elaborate(self, platform):\n"
+    "        return Module()\n"
+    "\n"
+)
+
+
+def _model(body: str) -> str:
+    return _HEAD + "def simulate(stimulus):\n" + body
+
+
+class TestTheFalsePositiveThatCostTwoRuns:
+
+    def test_the_amaranth_simulator_is_not_the_oracle(self):
+        src = _model(
+            "    sim = Simulator(chip_model())\n"
+            "    sim.add_testbench(lambda ctx: None)\n"
+            "    sim.run()\n"
+            "    return [], 0\n")
+        assert _validate_chip_model_text(src, "run") is None
+
+    def test_a_bare_call_to_the_entry_is_still_a_cheat(self):
+        src = _model("    return run(stimulus), 0\n")
+        assert "ANTI-CHEAT" in (_validate_chip_model_text(src, "run") or "")
+
+    def test_an_oracle_shaped_receiver_is_still_a_cheat(self):
+        """Even locally bound. ``golden = load(...)`` then ``golden.run()`` is
+        exactly the shape the check exists to stop."""
+        for recv in ("golden", "reference", "oracle", "ref", "_golden"):
+            src = _model(f"    {recv} = object()\n"
+                         f"    return {recv}.run(stimulus), 0\n")
+            assert "ANTI-CHEAT" in (_validate_chip_model_text(src, "run") or ""), recv
+
+    def test_an_unbound_receiver_is_still_a_cheat(self):
+        """``mod.run()`` where nothing in the module ever bound ``mod`` is a
+        module-level handle -- the way an oracle arrives."""
+        src = _model("    return mod.run(stimulus), 0\n")
+        assert "ANTI-CHEAT" in (_validate_chip_model_text(src, "run") or "")
+
+    def test_a_chained_receiver_is_still_a_cheat(self):
+        src = _model("    return pkg.mod.run(stimulus), 0\n")
+        assert "ANTI-CHEAT" in (_validate_chip_model_text(src, "run") or "")
+
+    def test_dynamic_import_restores_the_strict_rule(self):
+        """A module that can bind the oracle to a local at runtime does not get
+        the local-object exception."""
+        src = _model(
+            "    import importlib\n"
+            "    sim = importlib.import_module('x')\n"
+            "    sim.run()\n"
+            "    return [], 0\n")
+        assert "ANTI-CHEAT" in (_validate_chip_model_text(src, "run") or "")
+
+    @pytest.mark.parametrize("recv_binding", [
+        "    sim = Simulator(chip_model())\n",
+        "    for sim in sims:\n        pass\n",
+        "    with make() as sim:\n        pass\n",
+    ])
+    def test_every_local_binding_form_counts(self, recv_binding):
+        src = _model(recv_binding + "    sim.run()\n    return [], 0\n")
+        assert _validate_chip_model_text(src, "run") is None, recv_binding
+
+
+class TestTheOriginalChecksAreIntact:
+
+    def test_importing_the_golden_is_rejected(self):
+        src = "import design_golden\n" + _model("    return [], 0\n")
+        assert "ANTI-CHEAT" in (_validate_chip_model_text(src, "run") or "")
+
+    def test_from_importing_the_golden_is_rejected(self):
+        src = "from design_golden import run\n" + _model("    return [], 0\n")
+        assert "ANTI-CHEAT" in (_validate_chip_model_text(src, "run") or "")
+
+    def test_reimplementing_the_entry_is_rejected(self):
+        src = _model("    return [], 0\n") + "\ndef _run(stimulus):\n    return []\n"
+        assert "ANTI-CHEAT" in (_validate_chip_model_text(src, "run") or "")
+
+    def test_structural_requirements_still_apply(self):
+        assert "missing module-level def simulate" in (
+            _validate_chip_model_text(_HEAD, "run") or "")
+        assert "missing class chip_model" in (
+            _validate_chip_model_text("def simulate(s):\n    return [], 0\n",
+                                      "run") or "")
+
+    def test_no_entry_name_means_no_entry_check(self):
+        src = _model("    return run(stimulus), 0\n")
+        assert _validate_chip_model_text(src, "") is None
+
+
+class TestTheRetryBudget:
+
+    def test_default_is_two(self, monkeypatch):
+        monkeypatch.delenv("CORESMITH_CHIP_MODEL_ATTEMPTS", raising=False)
+        assert _chip_model_attempts() == 2
+
+    def test_single_shot_is_recoverable(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_CHIP_MODEL_ATTEMPTS", "1")
+        assert _chip_model_attempts() == 1
+
+    def test_garbage_falls_back(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_CHIP_MODEL_ATTEMPTS", "nonsense")
+        assert _chip_model_attempts() == 2
+
+
+class TestTheNoOpIsLoud:
+
+    @pytest.mark.asyncio
+    async def test_a_failed_chip_model_is_carried_forward(self, tmp_path,
+                                                          monkeypatch):
+        """The composition gate silently losing its input is the single most
+        expensive silent outcome in the flow, so it lands in the ledger the
+        final report and validation DV both read."""
+        from orchestrator.architecture import composition as _composition
+        from orchestrator.langgraph import pipeline_graph as pg
+
+        models = tmp_path / "arch" / _composition.BLOCK_MODELS_DIRNAME
+        models.mkdir(parents=True)
+        (models / "b.py").write_text("# a block model\n")
+        (tmp_path / "inputs").mkdir()
+        ref = tmp_path / "inputs" / "design_golden.py"
+        ref.write_text("def run(stimulus):\n    return []\n")
+
+        monkeypatch.setattr(_composition, "resolve_generator_reference",
+                            lambda pr: str(ref))
+
+        class _Boom:
+            def __init__(self, *a, **k):
+                pass
+
+            async def generate(self, **kw):
+                raise RuntimeError(
+                    "Integrated chip model at x is invalid: ANTI-CHEAT: chip "
+                    "model calls 'run'")
+
+        import orchestrator.langchain.agents.model_integration_generator as mig
+        monkeypatch.setattr(mig, "ModelIntegrationGenerator", _Boom)
+
+        await pg._maybe_generate_chip_model(str(tmp_path))
+
+        defects = pg.read_carried_forward_defects(str(tmp_path))
+        assert len(defects) == 1
+        d = defects[0]
+        assert d["gate"] == "model_integration"
+        assert d["kind"] == "chip_model_generation_failed"
+        assert "composition gate" in d["detail"]
+        assert "ANTI-CHEAT" in d["detail"]
+
+
+class TestTheRetryCarriesTheRejectionBack:
+    """The rules were in the prompt the first time. What was missing was the
+    validator's complaint, which localises the fault to one line."""
+
+    @staticmethod
+    def _agent(responses):
+        from orchestrator.langchain.agents.model_integration_generator import (
+            ModelIntegrationGenerator,
+        )
+        seen = []
+
+        class _LLM:
+            async def call(self, system, prompt, run_name=""):
+                seen.append(prompt)
+                return responses[min(len(seen) - 1, len(responses) - 1)]
+
+        # Bypass __init__: constructing ClaudeLLM needs the CLI on PATH, which
+        # has nothing to do with what this asserts.
+        agent = object.__new__(ModelIntegrationGenerator)
+        agent.llm = _LLM()
+        return agent, seen
+
+    @staticmethod
+    def _fenced(body):
+        return "```python\n" + _model(body) + "```\n"
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_model_is_regenerated_with_the_reason(self,
+                                                                   tmp_path):
+        agent, seen = self._agent([
+            self._fenced("    return run(stimulus), 0\n"),      # cheats
+            self._fenced("    sim = Simulator(chip_model())\n"
+                         "    sim.run()\n    return [], 0\n"),  # clean
+        ])
+        models = tmp_path / "models"
+        models.mkdir()
+        (models / "b.py").write_text("# block model\n")
+        out = models / "_chip_model.py"
+        res = await agent.generate(
+            project_root=str(tmp_path), block_models_dir=str(models),
+            block_diagram={}, interface_contracts={},
+            reference_impl_source="", reference_entry_name="run",
+            output_path=str(out))
+        assert res["path"] == str(out)
+        assert len(seen) == 2
+        assert "YOUR PREVIOUS ATTEMPT WAS REJECTED" in seen[1]
+        assert "ANTI-CHEAT" in seen[1]
+        assert "sim.run()" in out.read_text()
+
+    @pytest.mark.asyncio
+    async def test_a_clean_first_attempt_costs_nothing_extra(self, tmp_path):
+        agent, seen = self._agent([
+            self._fenced("    sim = Simulator(chip_model())\n"
+                         "    sim.run()\n    return [], 0\n"),
+        ])
+        models = tmp_path / "models"
+        models.mkdir()
+        await agent.generate(
+            project_root=str(tmp_path), block_models_dir=str(models),
+            block_diagram={}, interface_contracts={},
+            reference_impl_source="", reference_entry_name="run",
+            output_path=str(models / "_chip_model.py"))
+        assert len(seen) == 1
+
+    @pytest.mark.asyncio
+    async def test_two_bad_attempts_still_raise(self, tmp_path):
+        agent, seen = self._agent([self._fenced("    return run(stimulus), 0\n")])
+        models = tmp_path / "models"
+        models.mkdir()
+        with pytest.raises(RuntimeError, match="ANTI-CHEAT"):
+            await agent.generate(
+                project_root=str(tmp_path), block_models_dir=str(models),
+                block_diagram={}, interface_contracts={},
+                reference_impl_source="", reference_entry_name="run",
+                output_path=str(models / "_chip_model.py"))
+        assert len(seen) == 2

--- a/orchestrator/tests/test_composition_gate_wiring.py
+++ b/orchestrator/tests/test_composition_gate_wiring.py
@@ -346,3 +346,83 @@ class TestUarchGateAdvisoryBypass:
         assert mir.get("passed") is not True
         assert mir.get("first_divergence_block") == "raster"
         assert route_after_uarch_gate(result) == "begin_rtl_pass"
+
+
+# ---------------------------------------------------------------------------
+# The gate's EXIT BANNER must state the actual outcome (run3-followups #4a)
+# ---------------------------------------------------------------------------
+#
+# Measured live: the gate detected a model-level mismatch, logged it, and
+# DISMISSED it as advisory -- a legitimate non-blocking decision. Four lines
+# later the run printed a green "µARCH GATE CLEAN". Two true statements composed
+# into a false one, and the green line is the one a reader carries away.
+#
+# ``uarch_gate_banner`` does not change what the gate DOES (the bypass stays
+# advisory and the run still proceeds) -- only what it SAYS.
+
+class TestUarchGateBanner:
+    def _banner(self, result):
+        from orchestrator.langgraph.pipeline_helpers import uarch_gate_banner
+        return uarch_gate_banner(result)
+
+    def test_clean_only_when_nothing_fired(self):
+        from orchestrator.langgraph.pipeline_helpers import CYAN
+        for res in (None, {}, {"passed": True}):
+            text, colour = self._banner(res)
+            assert text.startswith("µARCH GATE CLEAN"), res
+            assert colour == CYAN
+            assert "beginning RTL pass" in text
+
+    def test_an_advisory_dismissal_is_NOT_reported_as_clean(self):
+        """THE defect. A dismissed mismatch must never print CLEAN."""
+        from orchestrator.langgraph.pipeline_helpers import YELLOW
+        text, colour = self._banner({
+            "passed": False,
+            "advisory_bypass": True,
+            "first_divergence_block": "stage_b",
+            "violations": [{"expected": "0102", "observed": "0000"}],
+        })
+        assert "GATE CLEAN" not in text        # the green claim, gone
+        assert "NOT CLEAN" in text
+        assert colour == YELLOW
+        # it names the finding, says it was non-blocking, and still says the
+        # run proceeds -- all three, because all three are true
+        assert "1 model-level mismatch(es)" in text
+        assert "ADVISORY" in text and "non-blocking" in text
+        assert "stage_b" in text
+        assert "beginning RTL pass" in text
+
+    def test_an_advisory_dismissal_without_localization_says_so(self):
+        text, _ = self._banner({"passed": False, "advisory_bypass": True,
+                                "violations": []})
+        assert "NOT CLEAN" in text
+        assert "(unlocalized)" in text
+
+    def test_a_signed_off_derate_is_not_plain_clean_either(self):
+        from orchestrator.langgraph.pipeline_helpers import YELLOW
+        text, colour = self._banner({"passed": True, "derate_signed_off": True})
+        assert "DERATE" in text and colour == YELLOW
+        assert "GATE CLEAN" not in text
+
+    def test_a_non_advisory_failure_is_also_never_clean(self):
+        text, _ = self._banner({"passed": False, "action_taken": "retry"})
+        assert "NOT CLEAN" in text and "retry" in text
+
+    @pytest.mark.asyncio
+    async def test_the_advisory_bypass_result_the_NODE_produces_is_not_clean(
+            self, tmp_path, monkeypatch):
+        """PRODUCTION SHAPE: feed the banner the dict the real advisory-bypass
+        branch returns, not a hand-written one -- the shapes cannot drift."""
+        monkeypatch.setenv("CORESMITH_DETERMINISTIC_BFM", "1")
+        calls = _install_failing_gate(monkeypatch)
+        result = await pipeline_graph.uarch_integration_gate_node(
+            {"project_root": str(tmp_path)}
+        )
+        mir = result["model_integration_result"]
+        assert mir.get("advisory_bypass") is True
+        assert calls["interrupt"] == 0
+        # ...and the run proceeds to the RTL pass, which is exactly where the
+        # green banner used to be printed.
+        assert route_after_uarch_gate(result) == "begin_rtl_pass"
+        text, _ = self._banner(mir)
+        assert "NOT CLEAN" in text and "ADVISORY" in text

--- a/orchestrator/tests/test_contract_conformance.py
+++ b/orchestrator/tests/test_contract_conformance.py
@@ -355,3 +355,218 @@ class TestDeterministicPortRepair:
         f = _rtl(tmp_path, "ap", ["ch_dat"])          # nothing repairable
         out = repair_block_ports(root, "ap", f, apply=True)
         assert out["conforms"] is False
+
+
+# ---------------------------------------------------------------------------
+# The stage, and its wiring into the per-block RTL flow
+# ---------------------------------------------------------------------------
+
+class TestTheStage:
+    """``run_conformance_stage`` is what the block flow calls: check, repair
+    what is provable, re-check, and carry the testbench along."""
+
+    def test_a_deviation_is_repaired_and_the_channel_reported(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import (
+            run_conformance_stage,
+        )
+        root = _project(tmp_path, [
+            _edge("ap", "s", "host_write", sideband=["write_enable"])])
+        f = _rtl(tmp_path, "ap", ["host_write_enable"])
+        rec = run_conformance_stage(root, "ap", f)
+        assert rec["ran"] and rec["ok"]
+        assert rec["renames"] == {"host_write_enable": "host_write_write_enable"}
+        assert rec["rename_channels"]["host_write_enable"] == "host_write"
+        assert rec["before_missing"] == 1 and rec["after_missing"] == 0
+        assert "host_write_write_enable" in f.read_text()
+
+    def test_no_contract_edge_means_not_run_not_pass(self, tmp_path):
+        """A block no edge names has no evidence either way. The stage must
+        say so instead of manufacturing a green verdict."""
+        from orchestrator.langgraph.contract_conformance import (
+            run_conformance_stage,
+        )
+        root = _project(tmp_path, [_edge("x", "y", "ch", fields=["data"])])
+        rec = run_conformance_stage(root, "ap", _rtl(tmp_path, "ap", ["clk"]))
+        assert rec["ran"] is False and rec["checked_edges"] == 0
+        assert "no interface contract edge" in rec["reason"]
+
+    def test_an_unrepairable_deviation_fails_with_the_exact_name(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import (
+            run_conformance_stage,
+        )
+        root = _project(tmp_path, [
+            _edge("ap", "s", "ch", fields=["data"], sideband=["valid"])])
+        rec = run_conformance_stage(root, "ap", _rtl(tmp_path, "ap", ["ch_dat"]))
+        assert rec["ran"] and rec["ok"] is False
+        assert "ch_data" in rec["feedback"] and "ch_valid" in rec["feedback"]
+        assert rec["deviations"]
+
+    def test_testbench_dut_references_follow_the_rename(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import (
+            run_conformance_stage,
+        )
+        root = _project(tmp_path, [
+            _edge("ap", "s", "host_write", sideband=["write_enable"])])
+        f = _rtl(tmp_path, "ap", ["host_write_enable"])
+        tb = tmp_path / "test_ap.py"
+        tb.write_text("async def t(dut):\n"
+                      "    dut.host_write_enable.value = 1\n"
+                      "    return int(dut.host_write_enable.value)\n")
+        rec = run_conformance_stage(root, "ap", f, tb_path=str(tb))
+        assert "dut.host_write_write_enable" in tb.read_text()
+        assert "dut.host_write_enable" not in tb.read_text()
+        assert rec["tb"]["changed"] and not rec["tb"]["needs_regen"]
+        assert Path(str(tb) + ".pre_portrepair").exists()
+
+    def test_a_name_string_reference_asks_for_regeneration(self, tmp_path):
+        """Generated testbenches really do drive ``getattr(dut, field)`` over a
+        tuple of port-name strings -- and key their MODEL stimulus with the same
+        strings. Rewriting those blind would corrupt the model side, so the
+        stage asks for a regeneration instead of guessing."""
+        from orchestrator.langgraph.contract_conformance import (
+            run_conformance_stage,
+        )
+        root = _project(tmp_path, [
+            _edge("ap", "s", "host_write", sideband=["write_enable"])])
+        f = _rtl(tmp_path, "ap", ["host_write_enable"])
+        tb = tmp_path / "test_ap.py"
+        tb.write_text('FIELDS = ("host_write_enable",)\n'
+                      'def t(dut):\n'
+                      '    for k in FIELDS:\n'
+                      '        getattr(dut, k).value = 0\n')
+        rec = run_conformance_stage(root, "ap", f, tb_path=str(tb))
+        assert rec["tb"]["needs_regen"] is True
+        assert rec["tb"]["residual"] == ["host_write_enable"]
+
+    def test_an_unreadable_rtl_is_not_a_verdict(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import (
+            run_conformance_stage,
+        )
+        root = _project(tmp_path, [
+            _edge("ap", "s", "ch", fields=["data"])])
+        rec = run_conformance_stage(root, "ap", tmp_path / "absent.v")
+        assert rec["ran"] is False and rec["ok"] is True and rec["reason"]
+
+
+class TestWiredIntoTheBlockFlow:
+    """The check existed and had tests; nothing CALLED it. These assert the
+    PRODUCTION node -- ``generate_testbench_node`` -- runs it."""
+
+    @staticmethod
+    def _state(tmp_path, rtl, tb):
+        return {
+            "current_block": {"name": "ap", "testbench": str(
+                Path(tb).relative_to(tmp_path))},
+            "project_root": str(tmp_path),
+            "attempt": 1,
+            "rtl_path": str(rtl),
+            "tb_path": str(tb),
+            "force_regen_tb": False,
+            "preserve_testbench": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_the_node_repairs_before_it_simulates(self, tmp_path):
+        from unittest.mock import patch
+
+        from orchestrator.langgraph.pipeline_graph import generate_testbench_node
+        root = _project(tmp_path, [
+            _edge("ap", "s", "host_write", sideband=["write_enable"])])
+        rtl = _rtl(tmp_path, "ap", ["host_write_enable"])
+        tb = tmp_path / "tb" / "test_ap.py"
+        tb.parent.mkdir(parents=True)
+        tb.write_text("def t(dut):\n    dut.host_write_enable.value = 1\n")
+        seen = {}
+
+        def _sim(block, rtl_path, tb_path, attempt):
+            # The sim that runs is the one AFTER the repair -- that is the
+            # whole reason the stage sits here and not after the testbench.
+            seen["rtl"] = Path(rtl_path).read_text()
+            seen["tb"] = Path(tb_path).read_text()
+            return {"passed": True, "log": "ok", "returncode": 0,
+                    "tests_passed": 1, "tests_total": 1}
+
+        with patch("orchestrator.langgraph.pipeline_graph.run_simulation", _sim):
+            out = await generate_testbench_node(
+                self._state(tmp_path, rtl, tb))
+        assert out["sim_passed"] is True
+        assert out["conformance_renames"] == {
+            "host_write_enable": "host_write_write_enable"}
+        assert "host_write_write_enable" in seen["rtl"]
+        assert "dut.host_write_write_enable" in seen["tb"]
+        rec = json.loads((root / ".coresmith" / "blocks" / "ap"
+                          / "contract_conformance.json").read_text())
+        assert rec["renames"] and rec["ok"]
+
+    @pytest.mark.asyncio
+    async def test_a_deviating_block_never_reaches_sim(self, tmp_path):
+        from unittest.mock import patch
+
+        from orchestrator.langgraph.pipeline_graph import generate_testbench_node
+        root = _project(tmp_path, [
+            _edge("ap", "s", "ch", fields=["data"], sideband=["valid"])])
+        rtl = _rtl(tmp_path, "ap", ["ch_dat"])
+        tb = tmp_path / "tb" / "test_ap.py"
+        tb.parent.mkdir(parents=True)
+        tb.write_text("# tb\n")
+        calls = []
+
+        with patch("orchestrator.langgraph.pipeline_graph.run_simulation",
+                   lambda *a, **k: calls.append(a) or {"passed": True}):
+            out = await generate_testbench_node(
+                self._state(tmp_path, rtl, tb))
+        assert out["sim_passed"] is False and not calls
+        prev = (root / ".coresmith" / "blocks" / "ap"
+                / "previous_error.txt").read_text()
+        assert "CONTRACT-CONFORMANCE" in prev and "ch_data" in prev
+
+    @pytest.mark.asyncio
+    async def test_the_env_gate_turns_it_off(self, tmp_path, monkeypatch):
+        from unittest.mock import patch
+
+        from orchestrator.langgraph.pipeline_graph import generate_testbench_node
+        monkeypatch.setenv("CORESMITH_CONTRACT_CONFORMANCE_GATE", "0")
+        root = _project(tmp_path, [
+            _edge("ap", "s", "host_write", sideband=["write_enable"])])
+        rtl = _rtl(tmp_path, "ap", ["host_write_enable"])
+        tb = tmp_path / "tb" / "test_ap.py"
+        tb.parent.mkdir(parents=True)
+        tb.write_text("# tb\n")
+        with patch("orchestrator.langgraph.pipeline_graph.run_simulation",
+                   lambda *a, **k: {"passed": True, "log": "", "returncode": 0}):
+            out = await generate_testbench_node(
+                self._state(tmp_path, rtl, tb))
+        assert out["sim_passed"] is True
+        assert "host_write_enable" in rtl.read_text()
+        assert "host_write_write_enable" not in rtl.read_text()
+        assert not (root / ".coresmith" / "blocks" / "ap"
+                    / "contract_conformance.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_the_second_failure_parks_instead_of_looping(self, tmp_path):
+        from unittest.mock import patch
+
+        from orchestrator.langgraph.pipeline_graph import generate_testbench_node
+        root = _project(tmp_path, [
+            _edge("ap", "s", "ch", fields=["data"], sideband=["valid"])])
+        rtl = _rtl(tmp_path, "ap", ["ch_dat"])
+        tb = tmp_path / "tb" / "test_ap.py"
+        tb.parent.mkdir(parents=True)
+        tb.write_text("# tb\n")
+        parked = []
+
+        with patch("orchestrator.langgraph.pipeline_graph.run_simulation",
+                   lambda *a, **k: {"passed": True}), \
+             patch("orchestrator.langgraph.pipeline_graph.interrupt",
+                   lambda payload: parked.append(payload) or {}):
+            await generate_testbench_node(self._state(tmp_path, rtl, tb))
+            assert not parked          # first failure: retry, do not park
+            await generate_testbench_node(self._state(tmp_path, rtl, tb))
+
+        assert len(parked) == 1
+        assert parked[0]["type"] == "contract_conformance_unrepairable"
+        assert "ch_data" in parked[0]["expected_ports"]
+        # the counter resets after a park, so a later genuine change gets a
+        # fresh pair of tries rather than parking on every entry
+        assert not (root / ".coresmith" / "blocks" / "ap"
+                    / "_conformance_failures.txt").exists()

--- a/orchestrator/tests/test_daemon_state_counters.py
+++ b/orchestrator/tests/test_daemon_state_counters.py
@@ -12,6 +12,7 @@ event count for forensics.
 """
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 from orchestrator.daemon.server import _shape_state
@@ -61,10 +62,10 @@ def test_single_pass_run_unchanged():
     assert out["remaining_count"] == 1
 
 
-def _snap_with_interrupt(completed, queue, block_name):
+def _snap_with_interrupt(completed, queue, block_name, iid="i0"):
     """Snapshot with one PARKED interrupt for ``block_name``."""
-    intr = SimpleNamespace(id="i0", value={"type": "ask_human",
-                                           "block_name": block_name})
+    intr = SimpleNamespace(id=iid, value={"type": "ask_human",
+                                          "block_name": block_name})
     task = SimpleNamespace(interrupts=[intr])
     snap = _snap(completed, queue)
     return SimpleNamespace(values=snap.values, next=snap.next, tasks=[task])
@@ -89,9 +90,6 @@ def test_live_interrupt_for_a_previously_completed_block_is_not_hidden():
     out = _shape_state(snap)
     assert out["pending_interrupt_count"] == 1, "live interrupt was hidden"
     assert len(out["interrupts"]) == 1
-    assert out["interrupts"][0]["stale_suspected"] is True
-    assert out["suspected_stale_interrupt_count"] == 1
-    assert out["live_interrupt_count"] == 0
 
 
 def test_interrupt_for_an_uncompleted_block_is_not_flagged_stale():
@@ -105,3 +103,88 @@ def test_interrupt_for_an_uncompleted_block_is_not_flagged_stale():
     assert out["interrupts"][0]["stale_suspected"] is False
     assert out["live_interrupt_count"] == 1
     assert out["suspected_stale_interrupt_count"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Staleness is keyed to WHEN THE INTERRUPT WAS RAISED, not to bare membership
+# in the append-only completed_blocks (and not to time since the last resume).
+# --------------------------------------------------------------------------- #
+
+def test_a_just_raised_interrupt_on_a_completed_block_reads_LIVE(monkeypatch):
+    """THE BUG: in a two-pass run every block completes pass 1, so every pass-2
+    interrupt was born ``stale_suspected: true`` / ``live_interrupt_count: 0``
+    -- and an automated consumer concludes there is nothing to act on. Observed
+    on a parked hands-off raster run whose ``contract_conformance_unrepairable``
+    interrupt was entirely live."""
+    import orchestrator.daemon.server as srv
+
+    monkeypatch.setattr(srv, "_interrupt_first_seen", {}, raising=False)
+    snap = _snap_with_interrupt(
+        completed=[{"name": "blk_a", "success": True, "completed_at": 1000.0}],
+        queue=["blk_a", "blk_b"],
+        block_name="blk_a",
+        iid="fresh",
+    )
+    out = _shape_state(snap)          # first sight => raised now >> 1000.0
+    row = out["interrupts"][0]
+    assert row["stale_suspected"] is False
+    assert row["stale_basis"] == "raised_after_block_completed"
+    assert out["live_interrupt_count"] == 1
+    assert out["suspected_stale_interrupt_count"] == 0
+
+
+def test_an_interrupt_the_graph_moved_PAST_is_still_flagged_stale(monkeypatch):
+    """The leftover the label exists for: the interrupt was raised, answered,
+    and the block completed AFTERWARDS -- so the checkpoint's copy is stale."""
+    import orchestrator.daemon.server as srv
+
+    monkeypatch.setattr(srv, "_interrupt_first_seen", {"old": 10.0},
+                        raising=False)
+    snap = _snap_with_interrupt(
+        completed=[{"name": "blk_a", "success": True,
+                    "completed_at": time.time()}],
+        queue=["blk_a", "blk_b"],
+        block_name="blk_a",
+        iid="old",
+    )
+    out = _shape_state(snap)
+    row = out["interrupts"][0]
+    assert row["stale_suspected"] is True
+    assert row["stale_basis"] == "raised_before_block_completed"
+    assert out["suspected_stale_interrupt_count"] == 1
+    assert out["pending_interrupt_count"] == 1     # surfaced, never hidden
+
+
+def test_an_unstamped_completion_is_no_evidence_and_reads_LIVE(monkeypatch):
+    """Checkpoints written before ``completed_at`` existed carry no completion
+    time. Absence of evidence is not evidence of absence -- this file's whole
+    thesis -- so the interrupt is reported LIVE, with the basis stated."""
+    import orchestrator.daemon.server as srv
+
+    monkeypatch.setattr(srv, "_interrupt_first_seen", {"legacy": 10.0},
+                        raising=False)
+    snap = _snap_with_interrupt(
+        completed=[{"name": "blk_a", "success": True}],   # no completed_at
+        queue=["blk_a", "blk_b"],
+        block_name="blk_a",
+        iid="legacy",
+    )
+    out = _shape_state(snap)
+    row = out["interrupts"][0]
+    assert row["stale_suspected"] is False
+    assert row["stale_basis"] == "completion_unstamped"
+    assert out["live_interrupt_count"] == 1
+
+
+def test_first_seen_is_remembered_across_polls_and_pruned_when_gone(monkeypatch):
+    """The raise time must not drift forward on every poll (that is what made
+    the age unusable), and an id that stops being pending is forgotten."""
+    import orchestrator.daemon.server as srv
+
+    monkeypatch.setattr(srv, "_interrupt_first_seen", {}, raising=False)
+    srv._note_interrupts_seen({"a"}, now=100.0)
+    srv._note_interrupts_seen({"a"}, now=500.0)
+    assert srv._interrupt_raised_ts("a") == 100.0
+    srv._note_interrupts_seen({"b"}, now=900.0)
+    assert "a" not in srv._interrupt_first_seen
+    assert srv._interrupt_raised_ts("b") == 900.0

--- a/orchestrator/tests/test_engine_provenance.py
+++ b/orchestrator/tests/test_engine_provenance.py
@@ -56,3 +56,59 @@ def test_final_report_includes_engine_sha(tmp_path):
     assert report["engine_sha_changed_mid_run"] is True
     md = fr.render_markdown(report)
     assert "abc123abc123" in md and "CHANGED MID-RUN" in md
+
+
+# ---------------------------------------------------------------------------
+# Engine source carries no benchmark-exercise vocabulary (run3-followups #5)
+# ---------------------------------------------------------------------------
+#
+# Standing repo rule: engine source must be exercise-agnostic. Naming a specific
+# benchmark exercise (or a specific reference design's internals) in a comment
+# looks harmless and is not: it leaks the evaluation set into the engine, and it
+# teaches every later reader -- human and model -- that this file is allowed to
+# know which exercise it is running.
+#
+# Protocol-generic identifiers are FINE and deliberately not matched here: the
+# QSPI contract fields in ``bfm_lib`` describe a bus protocol, not an exercise,
+# and ``rasterise``/``TRIANGLES`` in the layout renderer are graphics primitives.
+# The guard is scoped to the files this sweep cleaned, so it pins the fix rather
+# than asserting a repo-wide invariant that other work would have to keep true.
+
+_EXERCISE_WORDS = ("raster", "triangle", "h264", "h.264", "cavlc")
+
+_SCRUBBED_FILES = (
+    "orchestrator/langgraph/bfm_lib/maxgeo.py",
+    "orchestrator/langgraph/bfm_lib/stimulus.py",
+    "orchestrator/langgraph/drc_verdict.py",
+    "orchestrator/langgraph/macro_prebind.py",
+    "orchestrator/langgraph/tapeout_helpers.py",
+    "orchestrator/langgraph/integration_helpers.py",
+    "orchestrator/langchain/agents/contract_audit_agent.py",
+    "orchestrator/langchain/agents/uarch_spec_generator.py",
+    "orchestrator/architecture/model_integration.py",
+)
+
+
+def _engine_root():
+    from pathlib import Path
+
+    import orchestrator
+    return Path(orchestrator.__file__).resolve().parent.parent
+
+
+def test_scrubbed_engine_files_name_no_benchmark_exercise():
+    root = _engine_root()
+    offenders = []
+    for rel in _SCRUBBED_FILES:
+        p = root / rel
+        assert p.exists(), rel
+        for i, line in enumerate(
+                p.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            low = line.lower()
+            for word in _EXERCISE_WORDS:
+                if word in low:
+                    offenders.append(f"{rel}:{i}: {line.strip()[:100]}")
+    assert not offenders, (
+        "benchmark-exercise vocabulary in engine source:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/orchestrator/tests/test_full_model_dv.py
+++ b/orchestrator/tests/test_full_model_dv.py
@@ -172,3 +172,147 @@ def simulate(stimulus):
         violations = model_integration.run_model_integration_gate(str(root))
         assert violations
         assert "BYTE-SHIFT DETECTED" in str(violations[0].get("suggested_fix", ""))
+
+
+# ---------------------------------------------------------------------------
+# Timeout localization (run3-followups #4b)
+# ---------------------------------------------------------------------------
+#
+# When the composed model runs unbounded there is no divergence offset and no
+# traceback, so the failure reported "First-divergence block: (unlocalized)" and
+# the router broadcast a re-spec to EVERY block. A stall has one first cause, and
+# this is the failure mode where saying WHERE matters most.
+#
+# The probe is static (ast over the composition + a standalone import of each
+# block model), so it costs nothing and works on a run that is already hung.
+
+HANGING_CHIP = '''\
+def simulate(stimulus):
+    while True:
+        pass
+'''
+
+# A composition where one block's ports are wired to signals nothing else in the
+# whole chip model touches -- an output no one consumes / an input no one drives.
+DANGLING_CHIP = '''\
+from amaranth import Module, Signal
+
+from producer import producer
+from orphan import orphan
+
+
+class chip_model:
+    def elaborate(self, platform):
+        m = Module()
+        shared = Signal(8)
+        shared_valid = Signal()
+        never_read_a = Signal(8)
+        never_read_b = Signal()
+        m.submodules.p = producer(shared, shared_valid)
+        m.submodules.o = orphan(never_read_a, never_read_b)
+        m.d.comb += shared.eq(shared_valid)
+        return m
+
+
+def simulate(stimulus):
+    while True:
+        pass
+'''
+
+BROKEN_BLOCK = "import a_module_that_does_not_exist_anywhere\n"
+
+
+def _good_block(name: str) -> str:
+    """A block model that imports cleanly and exposes its own name."""
+    return f"class {name}:\n    def __init__(self, *args):\n        pass\n"
+
+
+def _stall_project(tmp_path: Path, chip: str, blocks: dict) -> Path:
+    d = tmp_path / "arch" / "block_models"
+    for stem, text in blocks.items():
+        _write(d / f"{stem}.py", text if text else _good_block(stem))
+    _write(d / "_chip_model.py", chip)
+    _write(tmp_path / "inputs" / "toy_golden.py", REFERENCE_IMPL)
+    return tmp_path
+
+
+class TestStallLocalization:
+    def test_probe_names_a_block_that_does_not_even_import(self, tmp_path):
+        root = _stall_project(tmp_path, HANGING_CHIP, {
+            "producer": "", "orphan": BROKEN_BLOCK})
+        rep = model_integration.probe_composition_stall(
+            str(root), root / "arch" / "block_models")
+        assert set(rep["blocks"]) == {"producer", "orphan"}
+        assert "orphan" in rep["import_failures"]
+        assert "producer" not in rep["import_failures"]
+        assert rep["candidates"] == ["orphan"]
+        assert "DOES NOT IMPORT" in rep["summary"]
+
+    def test_probe_names_a_block_whose_ports_are_wired_to_nothing(self, tmp_path):
+        root = _stall_project(tmp_path, DANGLING_CHIP, {
+            "producer": "", "orphan": ""})
+        rep = model_integration.probe_composition_stall(
+            str(root), root / "arch" / "block_models")
+        assert rep["dangling"].get("orphan") == ["never_read_a", "never_read_b"]
+        assert "producer" not in rep["dangling"]     # its signals ARE consumed
+        assert rep["candidates"] == ["orphan"]
+        assert "read NOWHERE else" in rep["summary"]
+
+    def test_probe_reports_nothing_when_the_composition_is_well_formed(
+            self, tmp_path):
+        chip = DANGLING_CHIP.replace(
+            "m.submodules.o = orphan(never_read_a, never_read_b)",
+            "m.submodules.o = orphan(shared, shared_valid)")
+        root = _stall_project(tmp_path, chip, {
+            "producer": "", "orphan": ""})
+        rep = model_integration.probe_composition_stall(
+            str(root), root / "arch" / "block_models")
+        assert rep["candidates"] == []
+        assert rep["summary"] == ""
+
+    def test_probe_never_raises_on_a_missing_or_unparseable_dir(self, tmp_path):
+        rep = model_integration.probe_composition_stall(
+            str(tmp_path), tmp_path / "nope")
+        assert rep["candidates"] == [] and rep["blocks"] == []
+
+    def test_timeout_violation_says_WHERE(self, tmp_path, monkeypatch):
+        """PRODUCTION PATH: the real gate, a real (fast) timeout, and the
+        violation the router consumes now NAMES the block instead of reporting
+        '(unlocalized)'."""
+        _env(monkeypatch)
+        monkeypatch.setenv("CORESMITH_GATE_SIM_TIMEOUT", "1")
+        root = _stall_project(tmp_path, DANGLING_CHIP, {
+            "producer": "", "orphan": ""})
+        violations = model_integration.run_model_integration_gate(str(root))
+        assert violations, "a hanging simulate() must be a violation"
+        v = violations[0]
+        assert v["criterion"] == "simulate_timeout"
+        assert v["first_divergence_block"] == "orphan"
+        assert "LOCALIZED to block 'orphan'" in v["observed"]
+        assert "read NOWHERE else" in v["suggested_fix"]
+        assert v["stall_localization"]["candidates"] == ["orphan"]
+
+    def test_localization_can_be_switched_off(self, tmp_path, monkeypatch):
+        """Env-gate convention: 0 restores the pre-fix '(unlocalized)' report,
+        so both branches are covered."""
+        _env(monkeypatch)
+        monkeypatch.setenv("CORESMITH_GATE_SIM_TIMEOUT", "1")
+        monkeypatch.setenv("CORESMITH_GATE_STALL_LOCALIZE", "0")
+        root = _stall_project(tmp_path, DANGLING_CHIP, {
+            "producer": "", "orphan": ""})
+        violations = model_integration.run_model_integration_gate(str(root))
+        assert violations
+        v = violations[0]
+        assert v["first_divergence_block"] == ""
+        assert "NOT localized" in v["observed"]
+        assert v["stall_localization"] == {}
+
+    def test_ambiguous_evidence_does_not_invent_a_single_block(self, tmp_path):
+        """Two candidate blocks -> the probe reports both and names NEITHER as
+        the first-divergence block. A false-precise pointer misdirects a re-spec,
+        which is why the broadcast default exists."""
+        root = _stall_project(tmp_path, DANGLING_CHIP, {
+            "producer": BROKEN_BLOCK, "orphan": BROKEN_BLOCK})
+        rep = model_integration.probe_composition_stall(
+            str(root), root / "arch" / "block_models")
+        assert len(rep["candidates"]) == 2

--- a/orchestrator/tests/test_golden_feasibility_verdict.py
+++ b/orchestrator/tests/test_golden_feasibility_verdict.py
@@ -1,0 +1,134 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""A probe that ran no discriminating check has not PASSED anything.
+
+Every block of the first hands-off run logged, in green::
+
+    [BLOCK-MODEL] <block>: golden-feasibility OK (skipped)
+
+-- an OK whose own parenthetical said the only check capable of returning the
+other answer had not run. The stored artifact said the same thing:
+``passed: true`` next to ``slice_reachability: {verdict: "skipped"}``.
+
+What the probe CHECKS is unchanged here. What it CLAIMS is not.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orchestrator.architecture.model_integration import (
+    _golden_feasibility_verdict,
+    _persist_golden_feasibility,
+    check_golden_feasibility,
+)
+
+#: Verbatim from exp-raster-auto-20260731 (.coresmith/blocks/zbuffer_sram/
+#: golden_feasibility.json) -- the shape 8 of 8 blocks produced.
+OBSERVED = {
+    "block": "zbuffer_sram", "ran": True, "passed": True, "skipped": False,
+    "reason": "",
+    "checks": {
+        "model_valid": True,
+        "golden_resolvable": True,
+        "slice_reachability": {
+            "verdict": "skipped",
+            "reason": "no confident slice (needs Phase-2 generalized mapping)",
+            "calls": {},
+        },
+    },
+}
+
+
+class TestTheStoredVerdict:
+
+    def test_the_observed_artifact_is_not_run_not_pass(self):
+        r = _golden_feasibility_verdict(json.loads(json.dumps(OBSERVED)))
+        assert r["verdict"] == "not_run"
+        assert r["discriminating"] is False
+        # actionable, in the [GATE-SIM] NOT RUN house style: it names the check
+        # that did not conclude AND why
+        assert "slice reachability" in r["not_run_reason"]
+        assert "no confident slice" in r["not_run_reason"]
+        # `passed` keeps its meaning -- the advisory gate's semantics are
+        # untouched; only the claim got honest.
+        assert r["passed"] is True
+
+    def test_a_reachable_slice_is_a_real_pass(self):
+        d = json.loads(json.dumps(OBSERVED))
+        d["checks"]["slice_reachability"] = {
+            "verdict": "reachable", "reason": "2 slice fn(s) produced output",
+            "calls": {"f": {"n": 3, "produced": True}},
+        }
+        r = _golden_feasibility_verdict(d)
+        assert r["verdict"] == "pass" and r["discriminating"] is True
+        assert "not_run_reason" not in r
+
+    def test_a_failure_is_still_a_failure(self):
+        d = json.loads(json.dumps(OBSERVED))
+        d["passed"] = False
+        d["reason"] = "model invalid: import failed"
+        assert _golden_feasibility_verdict(d)["verdict"] == "fail"
+
+    def test_a_probe_that_never_ran_is_not_run(self):
+        d = {"block": "b", "ran": False, "passed": True, "skipped": True,
+             "reason": "block goldens disabled", "checks": {}}
+        r = _golden_feasibility_verdict(d)
+        assert r["verdict"] == "not_run" and r["discriminating"] is False
+
+    def test_the_verdict_is_stamped_on_the_persisted_artifact(self, tmp_path):
+        """Every return path in check_golden_feasibility goes through the
+        persister, so stamping there is what makes the on-disk artifact
+        honest for all of them."""
+        _persist_golden_feasibility(str(tmp_path), "zbuffer_sram",
+                                    json.loads(json.dumps(OBSERVED)))
+        on_disk = json.loads(
+            (tmp_path / ".coresmith" / "blocks" / "zbuffer_sram"
+             / "golden_feasibility.json").read_text())
+        assert on_disk["verdict"] == "not_run"
+        assert on_disk["discriminating"] is False
+        assert on_disk["not_run_reason"]
+
+
+class TestTheProductionEntryPoint:
+
+    def test_disabled_block_goldens_report_not_run(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CORESMITH_BLOCK_GOLDENS", "0")
+        res = check_golden_feasibility(str(tmp_path), "b")
+        assert res["ran"] is False and res["verdict"] == "not_run"
+
+    def test_a_missing_model_is_a_failure_not_a_not_run(self, tmp_path,
+                                                        monkeypatch):
+        monkeypatch.setenv("CORESMITH_BLOCK_GOLDENS", "1")
+        res = check_golden_feasibility(str(tmp_path), "b")
+        assert res["ran"] is True and res["passed"] is False
+        assert res["verdict"] == "fail"
+
+    def test_a_valid_model_with_no_reachable_slice_is_not_run(self, tmp_path,
+                                                              monkeypatch):
+        """The observed case, driven through the real entry point: the model
+        imports and exposes its Elaboratable, and nothing exercised its math."""
+        monkeypatch.setenv("CORESMITH_BLOCK_GOLDENS", "1")
+        from orchestrator.architecture import composition as _composition
+        mdir = Path(tmp_path) / "arch" / _composition.BLOCK_MODELS_DIRNAME
+        mdir.mkdir(parents=True)
+        (mdir / "b.py").write_text(
+            "from amaranth import Elaboratable, Module, Signal\n"
+            "\n"
+            "class b(Elaboratable):\n"
+            "    def __init__(self, wb_clk_i, out):\n"
+            "        self.wb_clk_i = wb_clk_i\n"
+            "        self.out = out\n"
+            "\n"
+            "    def elaborate(self, platform):\n"
+            "        m = Module()\n"
+            "        m.d.sync += self.out.eq(Signal(4))\n"
+            "        return m\n"
+        )
+        res = check_golden_feasibility(str(tmp_path), "b")
+        assert res["ran"] is True and res["passed"] is True
+        assert res["verdict"] == "not_run", res
+        assert res["discriminating"] is False
+        assert res["not_run_reason"]

--- a/orchestrator/tests/test_maxgeo_conformance.py
+++ b/orchestrator/tests/test_maxgeo_conformance.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 
 import pytest
 
@@ -286,4 +287,316 @@ def test_a_bus_only_design_gets_a_clean_pass_not_an_advisory(tmp_path):
     involved."""
     pr = _project(tmp_path, BUS_DIMS)
     tb, res = _conformance_tb(tmp_path, BUS_DIMS)
-    assert pipeline_graph._maxgeo_gate_verdict(pr, tb, res) is None
+    v = pipeline_graph._maxgeo_gate_verdict(pr, tb, res)
+    # run3-followups: full coverage is an explicit PASS verdict, not None.
+    assert v is not None and v.get("verdict") == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Generator-side MAX-CONFIGURATION functional case (run3-followups #1)
+# ---------------------------------------------------------------------------
+#
+# The deterministic codegen baked exactly ONE host-flow case -- the FIRST
+# acceptance case, which is the small canonical KAT. It therefore proved nothing
+# about any declared maximum, and the operator had to hand-add a max-geometry
+# functional test to the generated artifact. These tests pin the generator-side
+# fix, and they run it through the PRODUCTION writer
+# (``write_deterministic_integration_tb``), not through a test-shaped call.
+
+# A generic two-parameter design: one small canonical case and one larger one.
+# Names are placeholders on purpose -- the selection rule is over MAGNITUDES.
+_GEN_GOLDEN = '''
+def run(stimulus):
+    n = int(stimulus["unit_count"])
+    data = bytes(stimulus["data"])
+    # two output bytes per input byte -> OUT extent differs from IN extent
+    return bytes(v for b in data for v in (((b + n) & 0xFF), ((b ^ n) & 0xFF)))
+'''
+
+_GEN_ACCEPT = '''
+def _case(n):
+    return {"unit_count": n, "cfg0": n, "data": bytes((i * 7) & 0xFF for i in range(16 * n))}
+
+cases = [
+    ("canonical_smoke", _case(1)),
+    ("mid", _case(4)),
+    ("max_config", _case(8)),
+    ("mid2", _case(2)),
+]
+'''
+
+# What such a design declares. ``unit_count`` is the only compute-lane dim a
+# stimulus scalar names AND drives at its maximum.
+_GEN_DIMS = {
+    "unit_count": 8,
+    "internal_store_depth": 128,
+    "qspi_address": 16777215,
+    "in_write_length": 128,
+    "out_read_length": 256,
+}
+
+
+def _generic_run(tmp_path, *, dims: dict | None = None) -> str:
+    root = tmp_path / "run"
+    (root / ".coresmith").mkdir(parents=True, exist_ok=True)
+    (root / "inputs").mkdir(parents=True, exist_ok=True)
+    (root / "inputs" / "design_golden.py").write_text(_GEN_GOLDEN, encoding="utf-8")
+    (root / "inputs" / "acceptance_stimulus.py").write_text(
+        _GEN_ACCEPT, encoding="utf-8")
+    (root / ".coresmith" / "ers_spec.json").write_text(json.dumps({"ers": {
+        "parameters": [
+            {"name": n, "role": "dimension", "max": v}
+            for n, v in (dims if dims is not None else _GEN_DIMS).items()
+        ]
+    }}), encoding="utf-8")
+    return str(root)
+
+
+def _write_integration_tb(pr: str) -> tuple[str, dict]:
+    """The PRODUCTION path: plan -> writer -> artifact on disk."""
+    from orchestrator.langgraph.bfm_lib import (
+        build_plan_from_run,
+        declared_dimensional_maxima,
+        write_deterministic_integration_tb,
+    )
+    c = QSPIContract()
+    plan = build_plan_from_run(pr, c)
+    assert plan is not None, "the generic run must yield a host-flow plan"
+    out = str(Path(pr) / "tb" / "integration" / "test_chip_top.py")
+    res = write_deterministic_integration_tb(
+        pr, "chip_top", c, plan, out, include_conformance=True,
+        declared_dims=declared_dimensional_maxima(pr),
+    )
+    return out, res
+
+
+def test_max_config_case_is_selected_by_magnitude_not_by_order(tmp_path):
+    """Generic selection: the case maximizing (IN payload bytes, cfg0) wins --
+    it is neither first nor last in the declared list."""
+    from orchestrator.langgraph.bfm_lib import (
+        load_acceptance_cases,
+        select_max_geometry_case,
+    )
+    pr = _generic_run(tmp_path)
+    cases = load_acceptance_cases(pr)
+    assert [n for n, _ in cases] == ["canonical_smoke", "mid", "max_config", "mid2"]
+    assert select_max_geometry_case(cases)[0] == "max_config"
+
+
+def test_writer_emits_a_second_baked_max_geometry_test(tmp_path):
+    """The production writer emits a SECOND host-flow test for the max case,
+    with its golden baked at GENERATION time (bytes in the file, no runtime
+    import of the reference)."""
+    pr = _generic_run(tmp_path)
+    tb, res = _write_integration_tb(pr)
+    src = Path(tb).read_text(encoding="utf-8")
+    compile(src, "<integration_tb>", "exec")          # must parse
+
+    assert res["case_name"] == "canonical_smoke"       # primary is unchanged
+    assert res["maxgeo_case"]["name"] == "max_config"
+    assert res["maxgeo_case"]["emitted_test"] is True
+    assert res["test_count"] == 3                      # host-flow + max + conformance
+
+    assert "async def deterministic_qspi_dv_max_geometry(dut):" in src
+    assert "MAXGEO_EXPECTED = bytes.fromhex(" in src   # baked, not imported
+    assert "import acceptance_stimulus" not in src
+    assert "MAXGEO_IN_WRITES" in src
+
+
+def test_max_geometry_case_marker_is_emitted_and_is_not_a_coverage_claim(tmp_path):
+    """``# MAXGEO_CASE`` records WHICH case and at what magnitudes -- and the
+    underscore form must not be readable as a coverage claim for dims literally
+    named cfg0 / in_bytes / out_bytes."""
+    pr = _generic_run(tmp_path)
+    tb, _res = _write_integration_tb(pr)
+    src = Path(tb).read_text(encoding="utf-8")
+    assert "# MAXGEO_CASE: name=max_config cfg0=8 in_bytes=128 out_bytes=256" in src
+    read = _gate_reads(src)
+    for k in ("cfg0", "in_bytes", "out_bytes", "name"):
+        assert k not in read, k
+
+
+def test_functional_dims_are_claimed_only_with_driven_evidence(tmp_path):
+    """A declared dim joins ``# MAXGEO`` only when a stimulus scalar NAMES it and
+    carries its declared maximum. Everything else stays confessed -- a big case
+    is not evidence for a dimension it does not drive."""
+    pr = _generic_run(tmp_path)
+    tb, res = _write_integration_tb(pr)
+    src = Path(tb).read_text(encoding="utf-8")
+    read = _gate_reads(src)
+
+    assert res["maxgeo_functional"] == {"unit_count": 8}
+    assert read["unit_count"] == 8                     # driven: cfg0/unit_count=8
+    # declared, NOT driven by any scalar of the chosen case -> still confessed
+    assert "internal_store_depth" not in read
+    assert "internal_store_depth=128" in src
+    assert "# MAXGEO_NOT_COVERED: " in src
+
+
+def test_no_larger_case_means_no_second_test(tmp_path):
+    """When the FIRST case already is the largest, a second identical test would
+    prove nothing: no extra test is emitted, but the marker still records that
+    the primary IS the max-geometry case."""
+    root = tmp_path / "run"
+    (root / ".coresmith").mkdir(parents=True, exist_ok=True)
+    (root / "inputs").mkdir(parents=True, exist_ok=True)
+    (root / "inputs" / "design_golden.py").write_text(_GEN_GOLDEN, encoding="utf-8")
+    (root / "inputs" / "acceptance_stimulus.py").write_text(
+        _GEN_ACCEPT.replace('("canonical_smoke", _case(1))', '("biggest", _case(8))')
+        .replace('("max_config", _case(8))', '("small", _case(1))'),
+        encoding="utf-8")
+    (root / ".coresmith" / "ers_spec.json").write_text(json.dumps({"ers": {
+        "parameters": [{"name": n, "role": "dimension", "max": v}
+                       for n, v in _GEN_DIMS.items()]}}), encoding="utf-8")
+    tb, res = _write_integration_tb(str(root))
+    src = Path(tb).read_text(encoding="utf-8")
+    assert res["maxgeo_case"]["is_primary"] is True
+    assert res["maxgeo_case"]["emitted_test"] is False
+    assert res["test_count"] == 2
+    assert "deterministic_qspi_dv_max_geometry" not in src
+    assert "# MAXGEO_CASE: name=biggest" in src
+
+
+def test_a_run_without_acceptance_cases_is_byte_identical(tmp_path):
+    """No acceptance module -> no max case -> the emitted TB is exactly what it
+    was before any of this existed."""
+    from orchestrator.langgraph.bfm_lib import (
+        StimulusPlan,
+        render_integration_tb,
+        write_deterministic_integration_tb,
+    )
+    c = QSPIContract()
+    plan = StimulusPlan(cfg=[(c.cfg0_addr, 1, 4)],
+                        writes=[(c.in_addr, bytes(range(16)))],
+                        out_addr=c.out_addr, out_len=16,
+                        expected=bytes(range(16)), case_name="unit")
+    out = str(tmp_path / "tb" / "test_chip_top.py")
+    res = write_deterministic_integration_tb(
+        str(tmp_path), "chip_top", c, plan, out)
+    assert res["maxgeo_case"] is None
+    assert res["test_count"] == 1
+    assert Path(out).read_text(encoding="utf-8") == render_integration_tb(
+        c, "chip_top", plan)
+
+
+def test_the_generated_max_geometry_tb_satisfies_the_gate(tmp_path):
+    """End-to-end through the PRODUCTION gate: the artifact the writer produces
+    is one the MAX-GEOMETRY gate accepts (pass or advisory), not a hard fail."""
+    pr = _generic_run(tmp_path)
+    tb, res = _write_integration_tb(pr)
+    v = pipeline_graph._maxgeo_gate_verdict(pr, tb, res)
+    assert v is None or v.get("verdict") == "pass" or v.get("advisory") is True, v
+
+
+# ---------------------------------------------------------------------------
+# Dimension-registry alignment (run3-followups #2)
+# ---------------------------------------------------------------------------
+#
+# On the live run three numbers disagreed: the gate ENFORCED 9 dims, the TB
+# CONFESSED 13, the declared table had 18. Nothing lied -- they were three
+# derivations. One derivation now, three views of it.
+
+def test_registry_matches_the_gate_declared_dimension_derivation(tmp_path):
+    """``declared_dimensional_maxima`` IS what the gate derives today, so the
+    call-site swap is a no-op on behaviour. Both the typed ``parameters`` block
+    and the legacy generic harvest are exercised."""
+    from orchestrator.langgraph.bfm_lib import declared_dimensional_maxima
+    cs = tmp_path / ".coresmith"
+    cs.mkdir(parents=True, exist_ok=True)
+    (cs / "ers_spec.json").write_text(json.dumps({"ers": {
+        "parameters": [
+            {"name": "unit_count", "role": "dimension", "max": 8},
+            {"name": "opcode_select", "role": "mode", "max": 255},
+        ],
+        # harvested generically (no parameters entry) -- must still appear
+        "constraints": [{"name": "scraped_depth", "max": 512}],
+    }}), encoding="utf-8")
+    assert declared_dimensional_maxima(str(tmp_path)) == \
+        pipeline_graph._declared_dimensions(str(tmp_path))
+
+
+def test_registry_is_empty_for_a_legacy_prose_spec(tmp_path):
+    from orchestrator.langgraph.bfm_lib import declared_dimensional_maxima
+    assert declared_dimensional_maxima(str(tmp_path)) == {}
+
+
+def test_demand_partitions_the_declared_table_and_exposes_value_collisions():
+    """The 18/13/9 reconciliation, on the exact shape that produced it: five bus
+    dims are PROVEN, four compute-lane dims merely COLLIDE in value with a bus
+    marker (the old gate counted those as covered), nine are MISSING. 5+4+9=18,
+    and the confession (value_only|missing) is 13."""
+    from orchestrator.langgraph.bfm_lib import maxgeo_demand
+    d = maxgeo_demand(RASTER_DIMS, BUS_DIMS)
+    assert set(d.proven) == set(BUS_DIMS)
+    assert len(d.proven) + len(d.value_only) + len(d.missing) == len(RASTER_DIMS)
+    # 4096 and 255 are bus marker values AND compute-lane maxima
+    assert d.value_only == {
+        "framebuffer_depth": 4096, "triangle_color": 255,
+        "triangle_depth": 255, "zbuffer_depth": 4096,
+    }
+    assert len(d.missing) == 9
+    assert len(d.unproven) == 13
+    # today's gate demands exactly `missing` -- swapping in maxgeo_demand is
+    # semantics-preserving for the demand, and ADDS the weak-evidence set
+    marker_values = set(BUS_DIMS.values())
+    assert d.missing == {
+        n: v for n, v in RASTER_DIMS.items() if v not in marker_values
+    }
+
+
+def test_demand_requires_name_and_value_together():
+    from orchestrator.langgraph.bfm_lib import maxgeo_demand
+    d = maxgeo_demand({"a": 64}, {"a": 32})     # right name, wrong value
+    assert d.proven == {} and d.missing == {"a": 64}
+    d2 = maxgeo_demand({"a": 64}, {"a": 64})
+    assert d2.proven == {"a": 64} and not d2.unproven
+
+
+def test_the_confession_and_the_classification_are_one_computation(tmp_path):
+    """The generator's ``MAXGEO_NOT_COVERED`` line and the shared bus/compute
+    classification cannot drift: the confession IS the classification's
+    ``uncovered``, minus exactly the dims a functional case drove."""
+    from orchestrator.langgraph.bfm_lib import (
+        bus_maxgeo_coverage,
+        declared_dimensional_maxima,
+    )
+    pr = _generic_run(tmp_path)
+    tb, res = _write_integration_tb(pr)
+    src = Path(tb).read_text(encoding="utf-8")
+    dims = declared_dimensional_maxima(pr)
+    cov = bus_maxgeo_coverage(QSPIContract(), dims)
+    confessed = {}
+    for line in src.splitlines():
+        if line.startswith("# MAXGEO_NOT_COVERED:"):
+            for n, v in _PAIR_RE.findall(line.split(":", 1)[1]):
+                confessed[n] = int(v)
+    assert confessed == {
+        n: v for n, v in cov.uncovered.items()
+        if n not in res["maxgeo_functional"]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Token matching -- never claim an axis you did not drive
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("dim,key,ok", [
+    ("unit_count", "unit_count", True),        # exact
+    ("frame_width", "width", True),            # key tokens subset of dim tokens
+    ("width", "frame_width", True),            # and the other direction
+    ("frame_width", "burst_width", False),     # shared token, different axis
+    ("num_triangles", "triangle_depth", False),
+    ("", "unit_count", False),
+])
+def test_token_match_rule(dim, key, ok):
+    from orchestrator.langgraph.bfm_lib import token_match
+    assert token_match(dim, key) is ok
+
+
+def test_functional_dims_need_the_value_too():
+    from orchestrator.langgraph.bfm_lib import functional_maxgeo_dims
+    dims = {"unit_count": 8, "frame_width": 64}
+    assert functional_maxgeo_dims({"unit_count": 8}, dims) == {"unit_count": 8}
+    # right name, BELOW the maximum -> not driven at max -> not claimed
+    assert functional_maxgeo_dims({"unit_count": 4}, dims) == {}
+    # right value, unrelated name -> a coincidence, not evidence
+    assert functional_maxgeo_dims({"unrelated_thing": 8}, dims) == {}

--- a/orchestrator/tests/test_param_schema.py
+++ b/orchestrator/tests/test_param_schema.py
@@ -305,7 +305,9 @@ class TestMaxgeoEndToEndFromSchema:
         tb = _write_tb(
             tmp_path / "tb" / "t.py",
             "import cocotb\n# MAXGEO: frame_width=640 frame_height=352\n")
-        assert pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb) is None
+        # run3-followups: full coverage is an explicit PASS verdict, not None.
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        assert v is not None and v.get("verdict") == "pass"
 
     def test_aes_nonvideo_schema_end_to_end(self, tmp_path):
         # NON-video two-domain proof: the deterministic gate fires identically
@@ -316,7 +318,8 @@ class TestMaxgeoEndToEndFromSchema:
         tb_ok = _write_tb(
             tmp_path / "tb" / "g.py",
             "import cocotb\n# MAXGEO: max_message_blocks=1024\n")
-        assert pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb_ok) is None
+        v_ok = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb_ok)
+        assert v_ok is not None and v_ok.get("verdict") == "pass"
 
     def test_legacy_prose_ers_still_noops(self, tmp_path):
         _write_ers(tmp_path, _LEGACY_PROSE)

--- a/orchestrator/tests/test_pin_map_retire.py
+++ b/orchestrator/tests/test_pin_map_retire.py
@@ -1,0 +1,308 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""A pin map retires the pad-adapter block BEFORE it is ever generated.
+
+Calibrated against the raster run that died on this block twice. Its PRD
+declares a structured ``pin_map``; its architecture declares an eighth block
+carrying the locked Caravel boundary; its interface contract says that block
+translates six signals -- and the pin map routes all six (five mapped signals
+plus one output-enable). The generator produced a full chip top instead of a
+leaf adapter 6 times out of 6, and the conformance gate correctly refused the
+shape and parked the run. The block is the defect, not the RTL: a pin map
+replaces it, so the flow must not ask for it.
+
+Everything here is name-free on purpose. The adapter is identified by the
+LOCKED BOUNDARY it carries (io_in/io_out/io_oeb) or by an ``rtl_target`` whose
+module is the Caravel top -- the same two pieces of evidence
+``detect_wrapper_block`` and ``check_block``'s ``locked_boundary`` already use.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orchestrator.architecture import pin_map_retire as pmr
+from orchestrator.architecture.pin_map import parse_pin_map
+
+PIN_MAP = {
+    "bus_width": 38,
+    "entries": [
+        {"signal": "qspi_csn", "dir": "in", "msb": 0, "lsb": 0},
+        {"signal": "qspi_sck", "dir": "in", "msb": 1, "lsb": 1},
+        {"signal": "qspi_io_in", "dir": "in", "msb": 5, "lsb": 2},
+        {"signal": "qspi_io_out", "dir": "out", "msb": 5, "lsb": 2,
+         "oe": "qspi_drive_en"},
+        {"signal": "irq_level", "dir": "out", "msb": 6, "lsb": 6},
+    ],
+}
+
+PAD = "pad_boundary_block"        # deliberately NOT user_project_wrapper*
+CORE = "protocol_engine"
+
+BLOCK_QUEUE = [
+    {"name": PAD, "tier": 1, "rtl_target": "rtl/user_project_wrapper.v"},
+    {"name": CORE, "tier": 2, "rtl_target": "rtl/protocol_engine.v"},
+]
+
+BLOCK_DIAGRAM = {
+    "blocks": [
+        {
+            "name": PAD, "tier": 1,
+            "rtl_target": "rtl/user_project_wrapper.v",
+            "interfaces": {
+                "caravel_harness": {"wb_clk_i": 1, "wb_rst_i": 1,
+                                    "io_in": 38, "io_out": 38, "io_oeb": 38},
+                "qspi_async_pins": {"qspi_csn": 1, "qspi_sck": 1,
+                                    "qspi_io_in": 4},
+                "qspi_drive": {"qspi_io_out": 4, "qspi_drive_en": 1},
+                "irq_level": {"width": 1},
+            },
+        },
+        {"name": CORE, "tier": 2, "rtl_target": "rtl/protocol_engine.v"},
+    ],
+}
+
+CONTRACTS = {
+    "contracts": [
+        {"edge_id": "e1", "producer_block": PAD, "producer_port":
+            "qspi_async_pins", "consumer_block": CORE,
+         "consumer_port": "qspi_async_pins",
+         "fields": [{"name": "qspi_csn"}, {"name": "qspi_sck"},
+                    {"name": "qspi_io_in"}], "sideband_signals": []},
+        {"edge_id": "e2", "producer_block": CORE, "producer_port": "qspi_drive",
+         "consumer_block": PAD, "consumer_port": "qspi_drive",
+         "fields": [{"name": "qspi_io_out"}, {"name": "qspi_drive_en"}],
+         "sideband_signals": []},
+        {"edge_id": "e3", "producer_block": CORE, "producer_port": "irq_level",
+         "consumer_block": PAD, "consumer_port": "irq_level",
+         "fields": [{"name": "irq_level"}], "sideband_signals": []},
+    ]
+}
+
+
+def _seed(tmp_path, *, pin_map=PIN_MAP, contracts=CONTRACTS,
+          diagram=BLOCK_DIAGRAM):
+    cs = tmp_path / ".coresmith"
+    cs.mkdir(parents=True, exist_ok=True)
+    prd = {"prd": {"summary": "x"}}
+    if pin_map is not None:
+        prd["prd"]["pin_map"] = pin_map
+    (cs / "prd_spec.json").write_text(json.dumps(prd))
+    if contracts is not None:
+        (cs / "interface_contracts.json").write_text(json.dumps(contracts))
+    if diagram is not None:
+        (cs / "block_diagram.json").write_text(json.dumps(diagram))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _default_on(monkeypatch):
+    monkeypatch.delenv("CORESMITH_PINMAP_RETIRES_ADAPTER", raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# Identification is structural, never by name
+# --------------------------------------------------------------------------- #
+
+class TestTheAdapterIsFoundByEvidence:
+    def test_the_locked_boundary_in_the_architecture_entry_identifies_it(
+            self, tmp_path):
+        _seed(tmp_path)
+        # rtl_target stripped, so the ONLY evidence left is the interfaces map.
+        queue = [{"name": PAD, "tier": 1}, {"name": CORE, "tier": 2}]
+        assert pmr.pad_adapter_blocks(tmp_path, queue) == [PAD]
+
+    def test_an_rtl_target_naming_the_caravel_top_identifies_it(self, tmp_path):
+        # No block_diagram at all: rtl_target is the remaining evidence, which
+        # is exactly the contract-locked-module-name case.
+        _seed(tmp_path, diagram=None)
+        assert pmr.pad_adapter_blocks(tmp_path, BLOCK_QUEUE) == [PAD]
+
+    def test_a_design_with_no_pad_boundary_has_no_adapter(self, tmp_path):
+        _seed(tmp_path, diagram={"blocks": [{"name": CORE, "tier": 1}]})
+        assert pmr.pad_adapter_blocks(
+            tmp_path, [{"name": CORE, "tier": 1}]) == []
+
+    def test_the_block_NAME_is_never_the_evidence(self, tmp_path):
+        """A block called ``user_project_wrapper_io`` with no locked boundary
+        and no Caravel rtl_target is NOT the adapter."""
+        _seed(tmp_path, diagram={"blocks": [
+            {"name": "user_project_wrapper_io", "tier": 1,
+             "interfaces": {"data": {"tdata": 8}}}]})
+        assert pmr.pad_adapter_blocks(
+            tmp_path,
+            [{"name": "user_project_wrapper_io", "tier": 1}]) == []
+
+
+# --------------------------------------------------------------------------- #
+# Coverage decides
+# --------------------------------------------------------------------------- #
+
+class TestCoverageDecides:
+    def test_full_coverage_retires_the_block(self, tmp_path):
+        _seed(tmp_path)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        assert plan.retire is True and plan.park is False
+        assert plan.block == PAD
+        assert plan.reason == pmr.RETIRE_REASON
+        assert sorted(plan.covered) == [
+            "irq_level", "qspi_csn", "qspi_drive_en", "qspi_io_in",
+            "qspi_io_out", "qspi_sck"]
+        assert plan.uncovered == []
+
+    def test_an_output_enable_counts_as_coverage(self, tmp_path):
+        """``qspi_drive_en`` is not a mapped SIGNAL -- it is the ``oe`` of one.
+        The top inverts it into io_oeb, so it is routed, so it is covered."""
+        _seed(tmp_path)
+        pm = parse_pin_map(PIN_MAP)
+        assert "qspi_drive_en" in pmr.pin_map_signal_names(pm)
+
+    def test_partial_coverage_PARKS_and_never_retires(self, tmp_path):
+        """A boundary where the top routes some pads and a block routes the
+        rest is a contradiction -- both would drive the same bus."""
+        partial = {"bus_width": 38, "entries": [
+            e for e in PIN_MAP["entries"] if e["signal"] != "irq_level"]}
+        _seed(tmp_path, pin_map=partial)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        assert plan.retire is False
+        assert plan.park is True
+        assert plan.uncovered == ["irq_level"]
+        assert "irq_level" in plan.message
+        assert "contradiction" in plan.message
+        # and the queue is untouched
+        assert len(pmr.apply_retirement(BLOCK_QUEUE, plan)) == 2
+
+    def test_zero_coverage_neither_retires_nor_parks(self, tmp_path):
+        """This pin map is not about this block; refusing the run would be a
+        new failure mode with no evidence behind it."""
+        other = {"bus_width": 38, "entries": [
+            {"signal": "uart_rx", "dir": "in", "msb": 0, "lsb": 0}]}
+        _seed(tmp_path, pin_map=other)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        assert plan.retire is False and plan.park is False
+        assert "covers NONE" in plan.reason
+
+    def test_no_contract_edge_means_no_retirement(self, tmp_path):
+        _seed(tmp_path, contracts={"contracts": []})
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        assert plan.retire is False and plan.park is False
+        assert "no interface-contract edge" in plan.reason
+
+    def test_an_invalid_pin_map_retires_nothing(self, tmp_path):
+        bad = {"bus_width": 38, "entries": [
+            {"signal": "a", "dir": "in", "msb": 0, "lsb": 0},
+            {"signal": "b", "dir": "in", "msb": 0, "lsb": 0}]}   # bit 0 twice
+        _seed(tmp_path, pin_map=bad)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        assert plan.retire is False and plan.park is False
+        assert "INVALID" in plan.reason
+
+
+# --------------------------------------------------------------------------- #
+# Non-pin-map designs are untouched
+# --------------------------------------------------------------------------- #
+
+class TestDesignsWithoutAPinMapAreUntouched:
+    def test_no_pin_map_no_plan(self, tmp_path):
+        _seed(tmp_path, pin_map=None)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        assert plan.retire is False and plan.park is False
+        assert plan.block == ""
+        assert pmr.apply_retirement(BLOCK_QUEUE, plan) == BLOCK_QUEUE
+
+    def test_a_bare_project_root_is_not_an_error(self, tmp_path):
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        assert plan.retire is False and plan.park is False
+
+
+# --------------------------------------------------------------------------- #
+# Opt-out
+# --------------------------------------------------------------------------- #
+
+class TestTheOptOut:
+    def test_env_zero_restores_todays_behaviour(self, tmp_path, monkeypatch):
+        _seed(tmp_path)
+        monkeypatch.setenv("CORESMITH_PINMAP_RETIRES_ADAPTER", "0")
+        assert pmr.retirement_enabled() is False
+        from orchestrator.harness.blocks import load_block_queue
+        (tmp_path / ".coresmith" / "block_specs.json").write_text(
+            json.dumps(BLOCK_QUEUE))
+        names = [b["name"] for b in load_block_queue(tmp_path)]
+        assert names == [PAD, CORE]
+
+    def test_default_on(self, tmp_path):
+        assert pmr.retirement_enabled() is True
+
+    def test_the_harness_queue_agrees_with_the_pipeline(self, tmp_path):
+        """Sibling lists, `coresmith verify` and the MCP views must not report
+        a block the pipeline is not running."""
+        _seed(tmp_path)
+        (tmp_path / ".coresmith" / "block_specs.json").write_text(
+            json.dumps(BLOCK_QUEUE))
+        from orchestrator.harness.blocks import block_names, load_block_queue
+        assert [b["name"] for b in load_block_queue(tmp_path)] == [CORE]
+        assert block_names(tmp_path) == [CORE]
+
+
+# --------------------------------------------------------------------------- #
+# Artifacts
+# --------------------------------------------------------------------------- #
+
+class TestTheReasonSurvivesTheRun:
+    def test_a_record_lands_in_the_block_dir_and_the_carried_artifact(
+            self, tmp_path):
+        _seed(tmp_path)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        rec = pmr.record_retirement(tmp_path, plan)
+        assert rec["block"] == PAD and rec["reason"] == pmr.RETIRE_REASON
+        assert rec["skipped"] is True
+        note = (tmp_path / ".coresmith" / "blocks" / PAD
+                / pmr.BLOCK_NOTE_NAME).read_text()
+        assert "RETIRED" in note and "irq_level" in note
+        assert "CORESMITH_PINMAP_RETIRES_ADAPTER=0" in note
+        rows = pmr.read_retired_blocks(tmp_path)
+        assert [r["block"] for r in rows] == [PAD]
+
+    def test_recording_twice_does_not_duplicate(self, tmp_path):
+        _seed(tmp_path)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        pmr.record_retirement(tmp_path, plan)
+        pmr.record_retirement(tmp_path, plan)
+        assert len(pmr.read_retired_blocks(tmp_path)) == 1
+
+    def test_the_final_report_explains_the_short_block_count(self, tmp_path):
+        from orchestrator.langgraph.final_report import (
+            build_final_report,
+            render_markdown,
+        )
+        _seed(tmp_path)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        rec = pmr.record_retirement(tmp_path, plan)
+        state = {"block_queue": [{"name": CORE}], "retired_blocks": [rec],
+                 "target_clock_mhz": 50.0}
+        report = build_final_report(state, str(tmp_path))
+        assert report["signoff"]["retired_block_count"] == 1
+        assert report["retired_blocks"][0]["block"] == PAD
+        md = render_markdown(report)
+        assert "Retired blocks" in md and PAD in md
+
+
+# --------------------------------------------------------------------------- #
+# apply_retirement
+# --------------------------------------------------------------------------- #
+
+class TestApplyRetirement:
+    def test_it_removes_exactly_the_retired_block(self, tmp_path):
+        _seed(tmp_path)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        out = pmr.apply_retirement(BLOCK_QUEUE, plan)
+        assert [b["name"] for b in out] == [CORE]
+
+    def test_it_is_idempotent(self, tmp_path):
+        _seed(tmp_path)
+        plan = pmr.plan_retirement(tmp_path, BLOCK_QUEUE)
+        once = pmr.apply_retirement(BLOCK_QUEUE, plan)
+        assert pmr.apply_retirement(once, plan) == once

--- a/orchestrator/tests/test_pin_map_retire_dispatch.py
+++ b/orchestrator/tests/test_pin_map_retire_dispatch.py
@@ -1,0 +1,303 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The retirement happens on the PRODUCTION dispatch path, not in a helper.
+
+``init_tier_node`` is the graph's START node and every re-entry point, and
+``fan_out_tier`` is the conditional edge that leaves it -- so a block dropped
+from the queue there is never ``Send()``-ed, never microarchitected, never
+generated and never gated. These tests drive those two functions, plus the two
+completeness gates that size ``expected`` off ``block_queue``, so the whole
+chain is exercised the way the daemon runs it.
+
+Seeded from the raster run that parked twice on this block.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from orchestrator.langgraph import pipeline_graph
+from orchestrator.tests.test_pin_map_retire import (
+    BLOCK_DIAGRAM,
+    BLOCK_QUEUE,
+    CONTRACTS,
+    CORE,
+    PAD,
+    PIN_MAP,
+)
+
+
+def _seed(tmp_path, pin_map=PIN_MAP):
+    cs = tmp_path / ".coresmith"
+    cs.mkdir(parents=True, exist_ok=True)
+    prd = {"prd": {"summary": "x"}}
+    if pin_map is not None:
+        prd["prd"]["pin_map"] = pin_map
+    (cs / "prd_spec.json").write_text(json.dumps(prd))
+    (cs / "interface_contracts.json").write_text(json.dumps(CONTRACTS))
+    (cs / "block_diagram.json").write_text(json.dumps(BLOCK_DIAGRAM))
+    return tmp_path
+
+
+def _state(tmp_path, queue=None):
+    return {
+        "project_root": str(tmp_path),
+        "target_clock_mhz": 50.0,
+        "max_attempts": 3,
+        "block_queue": list(queue if queue is not None else BLOCK_QUEUE),
+        "tier_list": [],
+        "current_tier_index": 0,
+        "completed_blocks": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _default_on(monkeypatch):
+    monkeypatch.delenv("CORESMITH_PINMAP_RETIRES_ADAPTER", raising=False)
+
+
+class TestInitTierRetiresBeforeAnyFanOut:
+    @pytest.mark.asyncio
+    async def test_the_queue_shrinks_and_the_reason_is_published(self, tmp_path):
+        _seed(tmp_path)
+        out = await pipeline_graph.init_tier_node(_state(tmp_path))
+        assert [b["name"] for b in out["block_queue"]] == [CORE]
+        assert out["retired_blocks"][0]["block"] == PAD
+        assert out["retired_blocks"][0]["reason"] == "retired_by_pin_map"
+        # tier_list is computed from the REDUCED queue, so the adapter's tier
+        # disappears with it rather than fanning out an empty tier.
+        assert out["tier_list"] == [2]
+
+    @pytest.mark.asyncio
+    async def test_fan_out_never_sends_the_retired_block(self, tmp_path):
+        _seed(tmp_path)
+        st = _state(tmp_path)
+        out = await pipeline_graph.init_tier_node(st)
+        st.update(out)                       # what LangGraph merges before the edge
+        sends = pipeline_graph.fan_out_tier(st)
+        assert [s.arg["current_block"]["name"] for s in sends] == [CORE]
+
+    @pytest.mark.asyncio
+    async def test_a_design_without_a_pin_map_is_untouched(self, tmp_path):
+        _seed(tmp_path, pin_map=None)
+        out = await pipeline_graph.init_tier_node(_state(tmp_path))
+        assert "block_queue" not in out      # nothing rewritten
+        assert "retired_blocks" not in out
+        assert out["tier_list"] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_the_opt_out_restores_todays_behaviour(
+            self, tmp_path, monkeypatch):
+        _seed(tmp_path)
+        monkeypatch.setenv("CORESMITH_PINMAP_RETIRES_ADAPTER", "0")
+        out = await pipeline_graph.init_tier_node(_state(tmp_path))
+        assert "block_queue" not in out
+        assert "retired_blocks" not in out
+        assert out["tier_list"] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_re_entry_is_idempotent(self, tmp_path):
+        """Every tier advance re-enters init_tier. The second pass must not
+        re-log, re-record or re-shrink anything."""
+        _seed(tmp_path)
+        st = _state(tmp_path)
+        st.update(await pipeline_graph.init_tier_node(st))
+        again = await pipeline_graph.init_tier_node(st)
+        assert [b["name"] for b in again.get("block_queue", st["block_queue"])] \
+            == [CORE]
+        from orchestrator.architecture import pin_map_retire as pmr
+        assert len(pmr.read_retired_blocks(tmp_path)) == 1
+
+
+class TestPartialCoverageParks:
+    @pytest.mark.asyncio
+    async def test_it_raises_an_interrupt_with_the_uncovered_signals(
+            self, tmp_path, monkeypatch):
+        partial = {"bus_width": 38, "entries": [
+            e for e in PIN_MAP["entries"] if e["signal"] != "irq_level"]}
+        _seed(tmp_path, pin_map=partial)
+        seen = {}
+
+        def _fake_interrupt(payload):
+            seen.update(payload)
+            return {"action": "keep_block"}
+
+        monkeypatch.setattr(pipeline_graph, "interrupt", _fake_interrupt)
+        out = await pipeline_graph.init_tier_node(_state(tmp_path))
+        assert seen["type"] == "pin_map_partial_coverage"
+        assert seen["block"] == PAD
+        assert seen["uncovered_signals"] == ["irq_level"]
+        assert "retry" in seen["supported_actions"]
+        # keep_block => the queue is NOT reduced (today's behaviour).
+        assert "block_queue" not in out
+
+    @pytest.mark.asyncio
+    async def test_override_retires_anyway_and_says_so(
+            self, tmp_path, monkeypatch):
+        partial = {"bus_width": 38, "entries": [
+            e for e in PIN_MAP["entries"] if e["signal"] != "irq_level"]}
+        _seed(tmp_path, pin_map=partial)
+        monkeypatch.setattr(pipeline_graph, "interrupt",
+                            lambda _p: {"action": "override"})
+        out = await pipeline_graph.init_tier_node(_state(tmp_path))
+        assert [b["name"] for b in out["block_queue"]] == [CORE]
+        assert "override" in out["retired_blocks"][0]["explanation"]
+
+    @pytest.mark.asyncio
+    async def test_retry_replans_and_retires_once_the_map_is_fixed(
+            self, tmp_path, monkeypatch):
+        partial = {"bus_width": 38, "entries": [
+            e for e in PIN_MAP["entries"] if e["signal"] != "irq_level"]}
+        _seed(tmp_path, pin_map=partial)
+
+        def _fix_then_retry(_payload):
+            # the operator amends prd.pin_map, then resumes `retry`
+            _seed(tmp_path, pin_map=PIN_MAP)
+            return {"action": "retry"}
+
+        monkeypatch.setattr(pipeline_graph, "interrupt", _fix_then_retry)
+        out = await pipeline_graph.init_tier_node(_state(tmp_path))
+        assert [b["name"] for b in out["block_queue"]] == [CORE]
+
+    @pytest.mark.asyncio
+    async def test_an_unresolving_driver_is_bounded_not_infinite(
+            self, tmp_path, monkeypatch):
+        """In production each re-park SUSPENDS the graph, so this bounds an
+        outer agent that keeps sending `retry` without fixing anything (and
+        stops a plain-return interrupt double from spinning)."""
+        partial = {"bus_width": 38, "entries": [
+            e for e in PIN_MAP["entries"] if e["signal"] != "irq_level"]}
+        _seed(tmp_path, pin_map=partial)
+        monkeypatch.setattr(pipeline_graph, "interrupt",
+                            lambda _p: {"action": "retry"})
+        with pytest.raises(RuntimeError, match="partially covers"):
+            await pipeline_graph.init_tier_node(_state(tmp_path))
+
+
+class TestTheCompletenessGatesAgree:
+    """`expected` on both gates is sized off ``block_queue``, so a retired
+    block is not missing -- it is not expected."""
+
+    @pytest.mark.asyncio
+    async def test_pipeline_complete_passes_with_the_reduced_queue(
+            self, tmp_path, monkeypatch):
+        _seed(tmp_path)
+        st = _state(tmp_path)
+        st.update(await pipeline_graph.init_tier_node(st))
+        st["completed_blocks"] = [
+            {"name": CORE, "success": True, "attempts": 1, "phase": "rtl"}]
+        st["pipeline_phase"] = "rtl"
+
+        def _boom(_payload):
+            raise AssertionError("pipeline_incomplete fired on a retired block")
+
+        monkeypatch.setattr(pipeline_graph, "interrupt", _boom)
+        out = await pipeline_graph.pipeline_complete_node(st)
+        assert out["frontend_complete"] is True
+
+    def test_missing_from_ignores_a_skipped_block(self):
+        """The other half: ``_eligible_blocks`` already excludes skipped
+        blocks, so a block marked skipped is never reported unresolved."""
+        from orchestrator.langgraph.integration_helpers import missing_from
+        completed = [{"name": CORE}, {"name": PAD, "skipped": True}]
+        assert missing_from({CORE: "/x.v"}, completed) == []
+
+
+# --------------------------------------------------------------------------- #
+# Assembly when the adapter NEVER EXISTED
+# --------------------------------------------------------------------------- #
+
+_ENGINE_V = """\
+module protocol_engine (
+  input  wire wb_clk_i,
+  input  wire wb_rst_i,
+  input  wire qspi_csn,
+  input  wire qspi_sck,
+  input  wire [3:0] qspi_io_in,
+  output wire [3:0] qspi_io_out,
+  output wire qspi_drive_en,
+  output wire irq_level
+);
+  assign qspi_io_out  = qspi_io_in;
+  assign qspi_drive_en = ~qspi_csn;
+  assign irq_level     = qspi_sck;
+endmodule
+"""
+
+
+class TestTheAssemblerNeedsNoAdapterPresent:
+    """The existing ``dropped_adapter`` path drops a block that EXISTS. After a
+    retirement the block never existed, ``detect_wrapper_block`` returns None
+    and the pin map is the sole enable condition -- that combination must still
+    assemble a boundary-routed top."""
+
+    def _assemble(self, tmp_path):
+        from orchestrator.architecture.pin_map import parse_pin_map
+        from orchestrator.langgraph.integration_helpers import (
+            detect_wrapper_block,
+            generate_caravel_wrapper_top,
+            parse_verilog_ports,
+        )
+        p = tmp_path / "protocol_engine.v"
+        p.write_text(_ENGINE_V)
+        modules = {CORE: parse_verilog_ports(str(p))}
+        assert detect_wrapper_block(modules) is None   # the enable condition
+        # The contract edges STILL name the retired block on one end.
+        edges = [
+            {"producer_block": PAD, "consumer_block": CORE,
+             "producer_port": "qspi_async_pins",
+             "consumer_port": "qspi_async_pins",
+             "fields": [{"name": "qspi_csn"}, {"name": "qspi_sck"},
+                        {"name": "qspi_io_in"}],
+             "sideband_signals": [], "edge_id": "e1"},
+            {"producer_block": CORE, "consumer_block": PAD,
+             "producer_port": "qspi_drive", "consumer_port": "qspi_drive",
+             "fields": [{"name": "qspi_io_out"}, {"name": "qspi_drive_en"}],
+             "sideband_signals": [], "edge_id": "e2"},
+        ]
+        return generate_caravel_wrapper_top(
+            modules, edges, {CORE: str(p)}, str(tmp_path / "out"),
+            None, parse_pin_map(PIN_MAP))
+
+    def test_it_assembles_with_no_wrapper_block_and_no_hazards(self, tmp_path):
+        asm = self._assemble(tmp_path)
+        assert asm["wiring_errors"] == [], asm["wiring_errors"]
+        assert asm["module_name"] == "user_project_wrapper"
+        assert asm["block_count"] == 1
+        assert asm["instantiated"] == [CORE]
+        # Nothing was dropped -- there was nothing there to drop.
+        assert asm["dropped_adapter"] == ""
+
+    def test_edges_naming_the_retired_block_are_not_hazards(self, tmp_path):
+        """Assembly used to drop these edges explicitly with the adapter. When
+        the adapter never existed they must simply not resolve to anything --
+        and specifically must NOT be reported as unresolvable NAMED edges."""
+        asm = self._assemble(tmp_path)
+        assert not any(PAD in e for e in asm["wiring_errors"])
+
+    def test_the_boundary_is_routed_by_the_top(self, tmp_path):
+        v = self._assemble(tmp_path)["verilog"]
+        assert "wire qspi_csn = io_in[0];" in v
+        assert "wire [3:0] qspi_io_in = io_in[5:2];" in v
+        assert "assign io_out[5:2] = qspi_io_out;" in v
+        assert "assign io_oeb[5:2] = {4{~qspi_drive_en}};" in v
+        assert "assign io_out[6] = irq_level;" in v
+        # and the surviving block's ports bind to those pin-map signals
+        assert ".qspi_csn(qspi_csn)" in v
+        assert ".qspi_io_out(qspi_io_out)" in v
+        assert ".irq_level(irq_level)" in v
+
+    def test_the_missing_instantiation_postcondition_is_satisfied(
+            self, tmp_path):
+        """integration_check's postcondition: every block in ``modules`` is
+        instantiated, minus a deliberately dropped adapter. A retired block is
+        not in ``modules`` at all, so it cannot be reported missing."""
+        asm = self._assemble(tmp_path)
+        dropped = asm.get("dropped_adapter") or ""
+        modules_seen = {CORE}
+        missing = [b for b in modules_seen
+                   if b != dropped and f"u_{b} (" not in asm["verilog"]]
+        assert missing == []

--- a/orchestrator/tests/test_pipeline_graph.py
+++ b/orchestrator/tests/test_pipeline_graph.py
@@ -38,15 +38,19 @@ from orchestrator.langgraph.pipeline_graph import (
     build_block_subgraph,
     build_pipeline_graph,
     init_block_node,
+    integration_dv_decision_node,
     integration_dv_node,
     pipeline_complete_node,
     route_after_human,
     route_after_integration_dv,
+    route_after_integration_dv_decision,
     route_after_integration_review,
     route_after_uarch_review,
     route_after_validation_dv,
+    route_after_validation_dv_decision,
     route_decision,
     route_next_tier,
+    validation_dv_decision_node,
     validation_dv_node,
 )
 
@@ -216,6 +220,7 @@ class TestGraphConstruction:
             "init_tier", "process_block", "integration_review",
             "advance_tier", "pipeline_complete",
             "integration_check", "integration_dv", "validation_dv",
+            "integration_dv_decision", "validation_dv_decision",
         ]
         for name in expected:
             assert name in node_names, f"Missing orchestrator node: {name}"
@@ -298,15 +303,32 @@ class TestGraphConstruction:
             },
         })
 
+        # run3-followups two-phase flow: the DV node itself NEVER calls
+        # interrupt() (the one-cycle-late defect) -- it parks with the
+        # payload in state; the dedicated decision node consumes the
+        # response.
         dv_result = result["integration_dv_result"]
         assert dv_result["passed"] is False
         assert dv_result["phase"] == "tb_generation"
-        assert dv_result["action_taken"] == "fix_tb"
+        assert dv_result["pending_decision"] is True
         assert result["pipeline_done"] is False
-        assert route_after_integration_dv(result) == "integration_dv"
-        assert interrupts
-        assert interrupts[0]["phase"] == "tb_generation"
-        assert interrupts[0]["contract_audit"]["category"] == "INTEGRATION_TB_BUG"
+        assert not interrupts, "DV node must not call interrupt() directly"
+        payload = dv_result["interrupt_payload"]
+        assert payload["phase"] == "tb_generation"
+        assert payload["contract_audit"]["category"] == "INTEGRATION_TB_BUG"
+        assert route_after_integration_dv(result) == "integration_dv_decision"
+
+        decision = await integration_dv_decision_node({
+            "project_root": str(tmp_path),
+            "integration_dv_result": dv_result,
+        })
+        assert interrupts and interrupts[0] is payload
+        d_result = decision["integration_dv_result"]
+        assert d_result["action_taken"] == "fix_tb"
+        assert d_result["pending_decision"] is False
+        assert d_result["fix_applied"] == "repair generator"
+        assert route_after_integration_dv_decision(decision) == "integration_dv"
+        assert route_after_integration_dv(decision) == "integration_dv"
 
     @pytest.mark.asyncio
     async def test_integration_testbench_generator_accepts_written_file(self, tmp_path):
@@ -396,14 +418,27 @@ class TestGraphConstruction:
             },
         })
 
+        # run3-followups two-phase flow (see the integration variant).
         dv_result = result["validation_dv_result"]
         assert dv_result["passed"] is False
         assert dv_result["phase"] == "tb_generation"
-        assert dv_result["action_taken"] == "fix_tb"
-        assert route_after_validation_dv(result) == "validation_dv"
-        assert interrupts
-        assert interrupts[0]["phase"] == "tb_generation"
-        assert interrupts[0]["contract_audit"]["category"] == "VALIDATION_TB_BUG"
+        assert dv_result["pending_decision"] is True
+        assert not interrupts, "DV node must not call interrupt() directly"
+        payload = dv_result["interrupt_payload"]
+        assert payload["phase"] == "tb_generation"
+        assert payload["contract_audit"]["category"] == "VALIDATION_TB_BUG"
+        assert route_after_validation_dv(result) == "validation_dv_decision"
+
+        decision = await validation_dv_decision_node({
+            "project_root": str(tmp_path),
+            "validation_dv_result": dv_result,
+        })
+        assert interrupts and interrupts[0] is payload
+        d_result = decision["validation_dv_result"]
+        assert d_result["action_taken"] == "fix_tb"
+        assert d_result["pending_decision"] is False
+        assert route_after_validation_dv_decision(decision) == "validation_dv"
+        assert route_after_validation_dv(decision) == "validation_dv"
 
     def test_block_subgraph_has_expected_nodes(self):
         subgraph = build_block_subgraph().compile()
@@ -2129,6 +2164,9 @@ _SINGLE_PASS_NODES = {
     "init_tier", "process_block", "integration_review", "advance_tier",
     "pipeline_complete", "integration_check", "model_integration",
     "integration_dv", "validation_dv",
+    # run3-followups: dedicated interrupt-decision nodes (resume responses are
+    # consumed immediately, not one regeneration cycle late).
+    "integration_dv_decision", "validation_dv_decision",
     # Deterministic signoff-scorecard node: the pre-END funnel for the genuine
     # terminals (validation_dv done / integration_dv terminal-fail /
     # pipeline_complete abort). Shared by both topologies.

--- a/orchestrator/tests/test_ppa_check.py
+++ b/orchestrator/tests/test_ppa_check.py
@@ -693,3 +693,97 @@ some stderr noise
         # the last === marker is STDERR with no cells; candidates must fall
         # back to the real table section
         assert count_ff_bits_from_stat(self._REAL_FORMAT) > 0
+
+
+class TestSentinelSlackIsNotAMeasurement:
+    """The first hands-off run's PPA gate accepted ``WNS +1e39 ns`` on three
+    blocks (both SRAM-bearing ones among them) and printed "within budget".
+
+    ``worst_slack -max`` answers with OpenSTA's infinity when the linked design
+    has no timing endpoints at all. That is the tool saying "there was nothing
+    to measure", and the gate read it as an enormous margin.
+    """
+
+    OBSERVED = 1.0000000433293989e+39      # verbatim, exp-raster-auto-20260731
+
+    def test_the_observed_value_is_recognised(self):
+        from orchestrator.langgraph.ppa_check import slack_is_implausible
+        assert slack_is_implausible(self.OBSERVED) is True
+        assert slack_is_implausible(-self.OBSERVED) is True
+        assert slack_is_implausible(float("nan")) is True
+        # every plausible pre-layout number stays a measurement
+        for ok in (0.0, 19.44, -17.75, -7.31, 999.0):
+            assert slack_is_implausible(ok) is False
+        assert slack_is_implausible(None) is False
+
+    def test_the_bound_is_configurable(self, monkeypatch):
+        from orchestrator.langgraph.ppa_check import slack_is_implausible
+        monkeypatch.setenv("CORESMITH_PPA_MAX_PLAUSIBLE_WNS_NS", "10")
+        assert slack_is_implausible(11.0) is True
+        assert slack_is_implausible(9.0) is False
+
+    def test_the_exponent_is_not_truncated_to_its_mantissa(self):
+        """The old number pattern read `1.0000000433293989e+39` as 1.0 -- a
+        sentinel laundered into a plausible 1 ns of slack, which is worse than
+        either the sentinel or a parse failure."""
+        out = parse_sta_report(f"wns max {self.OBSERVED!r}\ntns max 0.0\n")
+        assert out["wns_ns"] == pytest.approx(self.OBSERVED)
+
+    def test_the_gate_calls_it_unmeasured_not_within_budget(self):
+        v = evaluate_ppa(actual_ff=100, ff_budget=1200,
+                         wns_ns=self.OBSERVED, period_ns=20.0)
+        assert v.ok is False
+        wns = [c for c in v.checks if c["metric"] == "wns_ns"][0]
+        assert wns["actual"] is None            # NOT recorded as +1e39
+        assert wns["unmeasured_timing"] is True
+        assert wns["implausible_slack"] is True
+        reason = " ".join(v.reasons)
+        assert "SENTINEL" in reason and "1e+39" in reason.replace("E", "e")
+
+    def test_the_operator_opt_out_still_applies(self, monkeypatch):
+        """It must not silently FAIL either: the documented advisory opt-out
+        is the one way past an unmeasurable timing dimension, and it records
+        the demotion rather than inventing a number."""
+        monkeypatch.setenv("CORESMITH_PPA_TIMING_ADVISORY", "1")
+        v = evaluate_ppa(actual_ff=100, ff_budget=1200,
+                         wns_ns=self.OBSERVED, period_ns=20.0)
+        assert v.ok is True
+        wns = [c for c in v.checks if c["metric"] == "wns_ns"][0]
+        assert wns["unmeasured_timing"] is True and wns["advisory"] is True
+
+    def test_a_real_negative_slack_still_fails_on_its_merits(self):
+        v = evaluate_ppa(actual_ff=100, ff_budget=1200,
+                         wns_ns=-7.31, period_ns=20.0)
+        wns = [c for c in v.checks if c["metric"] == "wns_ns"][0]
+        assert wns["actual"] == pytest.approx(-7.31)
+        assert not wns.get("unmeasured_timing")
+
+    def test_the_maxfanout_measurement_refuses_to_return_it(self, tmp_path,
+                                                            monkeypatch):
+        """The measurement site rejects it too, so the sentinel never reaches
+        the max(base, buffered) comparison it would win by construction."""
+        import subprocess
+
+        from orchestrator.langgraph import ppa_check as pc
+
+        lib = tmp_path / "x.lib"
+        lib.write_text("library(x){}\n")
+        src = tmp_path / "b.v"
+        src.write_text("module b(input clk); endmodule\n")
+
+        def _fake_run(cmd, *a, **k):
+            if "yosys" in str(cmd[0]):
+                # the script's write_verilog target is the last token of the
+                # netlist path the caller composed
+                Path(str(cmd[-1])).parent.joinpath("netlist.v").write_text(
+                    "module b(); endmodule\n")
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            return subprocess.CompletedProcess(
+                cmd, 0, f"CORESMITH_WNS {self.OBSERVED!r}\n", "")
+
+        monkeypatch.setattr(pc.subprocess, "run", _fake_run)
+        wns, detail = pc._measure_wns_from_rtl(
+            [str(src)], str(lib), tmp_path, "base", False, 20.0, "b", "clk",
+            "/usr/bin/yosys", "/usr/bin/sta", 30)
+        assert wns is None
+        assert "implausible slack" in detail and "SENTINEL" in detail

--- a/orchestrator/tests/test_rung3_fixes2.py
+++ b/orchestrator/tests/test_rung3_fixes2.py
@@ -153,7 +153,12 @@ class TestMaxgeoGateVerdict:
             tmp_path / "tb" / "t.py",
             "import cocotb\n# MAXGEO: frame_width=640 frame_height=352\n",
         )
-        assert pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb) is None
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        # run3-followups: an evaluated PASS is a verdict the caller LOGS,
+        # not a silent None (None now means only "gate disabled or no
+        # declared dims").
+        assert v is not None and v.get("verdict") == "pass"
+        assert v["marker_pairs"] == {"frame_width": 640, "frame_height": 352}
 
     def test_partial_marker_is_rejected(self, tmp_path):
         _write_ers(tmp_path, _VIDEO_DIMS_DOC)
@@ -201,7 +206,8 @@ class TestMaxgeoGateGenericNonVideo:
             "import cocotb\n"
             "# MAXGEO: cmd_fifo=512 max_burst_len=256 addr_range=1024\n",
         )
-        assert pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb) is None
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        assert v is not None and v.get("verdict") == "pass"
 
     def test_nonvideo_partial_marker_rejected(self, tmp_path):
         _write_ers(tmp_path, _NONVIDEO_DIMS_DOC)
@@ -268,10 +274,10 @@ class TestMaxgeoNodeWiring:
         self, tmp_path, monkeypatch
     ):
         _write_ers(tmp_path, _VIDEO_DIMS_DOC)
-        captured = {}
+        interrupts = []
 
         def fake_interrupt(payload):
-            captured.update(payload)
+            interrupts.append(payload)
             return {"action": "abort"}
         monkeypatch.setattr(pipeline_graph, "interrupt", fake_interrupt)
 
@@ -279,10 +285,15 @@ class TestMaxgeoNodeWiring:
             monkeypatch, tmp_path, tb_body="import cocotb\n# no marker\n")
         result = await pipeline_graph.integration_dv_node(state)
 
+        # run3-followups two-phase flow: the node parks with the payload in
+        # state; the decision node consumes the response.
         dv = result["integration_dv_result"]
         assert dv["passed"] is False
-        assert captured.get("type") == "integration_dv_failure"
-        assert "MAX-GEOMETRY" in captured.get("sim_log", "")
+        assert dv["pending_decision"] is True
+        assert not interrupts, "DV node must not call interrupt() directly"
+        payload = dv["interrupt_payload"]
+        assert payload.get("type") == "integration_dv_failure"
+        assert "MAX-GEOMETRY" in payload.get("sim_log", "")
 
     @pytest.mark.asyncio
     async def test_integration_dv_passes_when_marker_present(
@@ -348,3 +359,48 @@ class TestMaxgeoEquivNvectors:
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+class TestMaxgeoFunctionalMaxCase:
+    """run3-followups: a functional MAXIMUM-CONFIGURATION case (# MAXGEO_CASE,
+    emitted by the deterministic codegen) downgrades remaining per-dimension
+    gaps to a LOUD advisory -- the max config + full payload extents exercise
+    the 2^n wrap class end-to-end -- but ONLY when the case's extents attain
+    declared maxima. Otherwise the gate stays hard."""
+
+    def test_case_parser(self, tmp_path):
+        tb = _write_tb(
+            tmp_path / "tb" / "t.py",
+            "import cocotb\n"
+            "# MAXGEO_CASE: name=big_case cfg0=256 in_bytes=512 out_bytes=1024\n",
+        )
+        case = pipeline_graph._tb_maxgeo_case(tb)
+        assert case == {"name": "big_case", "cfg0": 256,
+                        "in_bytes": 512, "out_bytes": 1024}
+
+    def test_attaining_case_downgrades_to_advisory(self, tmp_path):
+        _write_ers(tmp_path, _NONVIDEO_DIMS_DOC)
+        tb = _write_tb(
+            tmp_path / "tb" / "t.py",
+            "import cocotb\n"
+            "# MAXGEO: addr_range=1024\n"
+            "# MAXGEO_CASE: name=big cfg0=256 in_bytes=512 out_bytes=1024\n",
+        )
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        assert v is not None and v.get("advisory") is True
+        assert v.get("scope") == "functional-max-case"
+        assert v["uncovered_dims"] == {"cmd_fifo": 512, "max_burst_len": 256}
+        assert "functional_max_case" in v
+
+    def test_non_attaining_case_stays_hard(self, tmp_path):
+        _write_ers(tmp_path, _NONVIDEO_DIMS_DOC)
+        tb = _write_tb(
+            tmp_path / "tb" / "t.py",
+            "import cocotb\n"
+            "# MAXGEO: addr_range=1024\n"
+            "# MAXGEO_CASE: name=small cfg0=7 in_bytes=512 out_bytes=1024\n",
+        )
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        assert v is not None and not v.get("advisory")
+        assert v.get("verdict") != "pass"
+        assert "uncovered_dims" in v


### PR DESCRIPTION
## What

**Stacked on #A (feat/autonomous-gatesim) — retarget to main after it merges.**

Wires the contract conformance check+repair into the per-block flow (it existed but was never called on the production path), so regenerated RTL port-name deviations are caught and repaired deterministically before the testbench is built. Plus gate-honesty fixes found on the hands-off runs:

- PPA gate: `+1e39 ns` WNS is a sentinel, not a measurement — now tri-state UNMEASURED with a plausibility bound (it was laundered twice: OpenSTA infinity AND a no-exponent regex parsing it as 1.0).
- Golden-feasibility probe: a probe whose only discriminating sub-check is skipped no longer prints a green "OK".
- Composition anti-cheat: `sim.run()` (the Amaranth simulator) no longer matches a reference entry named `run` — receiver-aware check + one retry.
- Carried-forward defects keep their explanation (`detail` was `None` in the final report).
- No benchmark exercise names in engine source.

## Evidence

Hands-off attempt #2: wiring hazards 10→0 with zero LLM fallback; conformance TB importable on the production path for the first time. Attempt #3 inherited all of this and reached the full gate-sim verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBWgL9qExhCeRdRMAXv7yX
