### PR TITLE
DV honesty follow-ups: immediate resume consumption, always-on MAXGEO, generator max-geometry case

### DIFF
--- a/orchestrator/architecture/model_integration.py
+++ b/orchestrator/architecture/model_integration.py
@@ -1290,8 +1290,9 @@ def _classify_gap(project_root: str, expected: Any, observed: Any) -> str:
     composed correctly and ONE downstream block emitted wrong/short content. That
     is ``block_math`` (route to a single-block re-spec, not a whole-chip re-fan).
     Only a divergence at/near offset 0 (no shared framing) is a true ``contract``
-    width/framing mismatch. Keystone fix: the length-only heuristic sent the Opus
-    codec's entropy coding bug (byte-32 residual) down the contract path and re-fanned all
+    width/framing mismatch. Keystone fix: the length-only heuristic sent a
+    measured single-block content defect (a divergence starting at byte 32, well
+    past the shared framing prefix) down the contract path and re-fanned all
     8 blocks twice (>55% of that run's token budget).
     """
     if _prefix_classify_enabled() and _is_byteseq(expected) and _is_byteseq(observed):
@@ -1489,6 +1490,189 @@ def _attach_stall_autopsy(project_root: str, violations: list[dict]) -> list[dic
         except Exception:  # noqa: BLE001
             pass
     return violations
+
+
+# ---------------------------------------------------------------------------
+# Per-block localization fallback for a composition TIMEOUT
+# ---------------------------------------------------------------------------
+#
+# When the composed model runs unbounded, there is no divergence offset to trace
+# and no traceback to read, so the failure reported "First-divergence block:
+# (unlocalized)" -> broadcast re-spec of every block. A timeout is exactly the
+# case where saying WHERE matters most (a stall has ONE first cause), and it was
+# the case that said the least.
+#
+# The stall autopsy above is the dynamic answer, but it only exists when an edge
+# monitor wrote the file. This is the deterministic fallback that always runs: a
+# per-block probe over the composition itself. Nothing here simulates anything --
+# it reads what the composition wired and what each block model can even be
+# imported to be -- so it is fast, safe on a hung run, and unit-testable.
+
+def stall_localization_enabled() -> bool:
+    """True (default) -> a composition timeout is localized by the block probe.
+
+    ``CORESMITH_GATE_STALL_LOCALIZE=0`` restores the pre-fix behaviour (report
+    ``(unlocalized)`` and broadcast). Both branches are tested.
+    """
+    return os.environ.get(
+        "CORESMITH_GATE_STALL_LOCALIZE", "1"
+    ).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _instance_ports(chip_model_src: str) -> dict[str, list[str]]:
+    """``{block_name: [signal identifiers wired into it]}`` from the composition.
+
+    Parses ``m.submodules.<inst> = <BlockClass>(<name>, kw=<name>, ...)`` out of
+    ``_chip_model.py`` with the ast module -- no regex guessing at Python syntax.
+    Blocks are keyed by the CLASS name (which is the block-model module name, the
+    identifier every other localization path uses). ``{}`` on any parse failure.
+    """
+    import ast as _ast
+
+    out: dict[str, list[str]] = {}
+    try:
+        tree = _ast.parse(chip_model_src)
+    except SyntaxError:
+        return out
+    for node in _ast.walk(tree):
+        if not isinstance(node, _ast.Assign) or not isinstance(node.value, _ast.Call):
+            continue
+        call = node.value
+        cls = ""
+        if isinstance(call.func, _ast.Name):
+            cls = call.func.id
+        elif isinstance(call.func, _ast.Attribute):
+            cls = call.func.attr
+        if not cls:
+            continue
+        # only ``m.submodules.<x> = ...`` / ``m.submodules += ...`` targets
+        targets_submodule = False
+        for tgt in node.targets:
+            src = _ast.dump(tgt)
+            if "submodules" in src:
+                targets_submodule = True
+        if not targets_submodule:
+            continue
+        names: list[str] = []
+        for arg in list(call.args) + [kw.value for kw in call.keywords]:
+            if isinstance(arg, _ast.Name):
+                names.append(arg.id)
+        if names:
+            out.setdefault(cls, []).extend(names)
+    return out
+
+
+def _identifier_counts(chip_model_src: str) -> dict[str, int]:
+    """How many times each identifier is READ in the composition source.
+
+    LOAD contexts only: a signal's own ``x = Signal(8)`` declaration is not a
+    use of it, and counting it would hide the very thing we are looking for (a
+    signal whose ONLY use is the one block instantiation it is passed to).
+    """
+    import ast as _ast
+
+    counts: dict[str, int] = {}
+    try:
+        tree = _ast.parse(chip_model_src)
+    except SyntaxError:
+        return counts
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Name) and isinstance(node.ctx, _ast.Load):
+            counts[node.id] = counts.get(node.id, 0) + 1
+    return counts
+
+
+def probe_composition_stall(project_root: str, models_dir) -> dict:
+    """Per-block probe for a composition that never returned. NEVER raises.
+
+    Two deterministic checks, both of which name a BLOCK:
+
+      * ``import_failures`` -- the block model does not even import standalone.
+        A composition that hangs around an unimportable block is localized.
+      * ``dangling`` -- signals wired into exactly ONE block instance and read
+        nowhere else in the composition. A block output nothing consumes never
+        moves a downstream handshake, and a block input nothing drives is stuck
+        at its reset value: both are stall causes with a name attached.
+
+    Returns ``{"blocks": [...], "import_failures": {...}, "dangling": {...},
+    "candidates": [...], "summary": str}``. ``candidates`` is the ordered list of
+    blocks the evidence points at; empty means the probe found nothing and the
+    caller must keep saying ``(unlocalized)`` rather than guess.
+    """
+    report: dict = {
+        "blocks": [], "import_failures": {}, "dangling": {},
+        "candidates": [], "summary": "",
+    }
+    try:
+        d = Path(models_dir)
+        if not d.is_dir():
+            return report
+        blocks = sorted(
+            p.stem for p in d.glob("*.py")
+            if not p.name.startswith("__") and p.stem != "_chip_model"
+        )
+        report["blocks"] = blocks
+
+        for name in blocks:
+            try:
+                _import_module_from_path(d / f"{name}.py", f"_cs_probe_{name}")
+            except Exception as exc:  # noqa: BLE001 - that IS the finding
+                report["import_failures"][name] = f"{type(exc).__name__}: {exc}"
+
+        chip = d / "_chip_model.py"
+        if chip.exists():
+            try:
+                src = chip.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                src = ""
+            if src:
+                ports = _instance_ports(src)
+                counts = _identifier_counts(src)
+                for cls, names in sorted(ports.items()):
+                    if cls not in blocks:
+                        continue
+                    # A signal referenced ONCE in the whole composition is
+                    # referenced only by this instantiation: nothing on the other
+                    # side of it.
+                    lonely = sorted({n for n in names if counts.get(n, 0) <= 1})
+                    if lonely:
+                        report["dangling"][cls] = lonely
+
+        candidates = list(report["import_failures"]) + [
+            b for b in report["dangling"] if b not in report["import_failures"]
+        ]
+        report["candidates"] = candidates
+        report["summary"] = _format_stall_localization(report)
+    except Exception:  # noqa: BLE001 - a diagnostic must not replace the failure
+        return report
+    return report
+
+
+def _format_stall_localization(report: dict) -> str:
+    """Human/LLM-readable rendering of :func:`probe_composition_stall`."""
+    lines: list[str] = []
+    imports = report.get("import_failures") or {}
+    dangling = report.get("dangling") or {}
+    if not imports and not dangling:
+        return ""
+    lines.append(
+        "PER-BLOCK STALL PROBE (the composed sim never returned, so there is no "
+        "divergence offset and no traceback -- this is what the composition "
+        "itself says):"
+    )
+    for name, err in sorted(imports.items()):
+        lines.append(
+            f"  block {name}: its block model DOES NOT IMPORT standalone -- {err}"
+        )
+    for name, ports in sorted(dangling.items()):
+        lines.append(
+            f"  block {name}: {len(ports)} signal(s) wired into this instance and "
+            f"read NOWHERE else in _chip_model.py -- an output nothing consumes "
+            f"never advances a downstream handshake, and an input nothing drives "
+            f"holds at its reset value: {', '.join(ports[:12])}"
+            + (" ..." if len(ports) > 12 else "")
+        )
+    return "\n".join(lines)
 
 
 _SIGNATURE_ERROR_MARKERS = (
@@ -1814,23 +1998,41 @@ def _run_full_model_dv(
                 _state.write_text(_json.dumps({"timeouts": _prior + 1}))
             except Exception:  # noqa: BLE001
                 pass
+            # Same localization fallback as the default-tier timeout: a stall
+            # that cannot say WHERE broadcasts a re-spec to every block.
+            _fmdv_probe: dict = {}
+            _fmdv_block = _first_divergence_block(project_root)
+            if stall_localization_enabled():
+                _fmdv_probe = probe_composition_stall(project_root, models_dir)
+                _c = _fmdv_probe.get("candidates") or []
+                if len(_c) == 1 and not _fmdv_block:
+                    _fmdv_block = _c[0]
+            _fmdv_where = (
+                _fmdv_block,
+                (f" LOCALIZED to block {_fmdv_block!r}." if _fmdv_block
+                 else " NOT localized to a single block (the probe found no "
+                      "single-block evidence)."),
+            )
             violations.append(_attach_stall_autopsy(project_root, [{
                 "type": "model_integration_failure",
                 "criterion": "full_model_dv_timeout",
                 "stimulus_tier": "acceptance",
                 "acceptance_case": str(name),
-                "first_divergence_block": _first_divergence_block(project_root),
+                "first_divergence_block": _fmdv_where[0],
                 "expected": expected,
                 "observed": f"full-model-dv simulate() did not return within "
-                            f"{budget:.0f}s on acceptance case {name!r}",
+                            f"{budget:.0f}s on acceptance case {name!r}."
+                            + _fmdv_where[1],
                 "gap_class": "contract",
+                "stall_localization": _fmdv_probe,
                 "suggested_fix": (
                     "The composed model cannot process the mission-scale "
                     "acceptance stimulus within the Full Model DV budget. "
                     "Next attempt auto-extends (x1.5, cap "
                     f"{_cap:.0f}s); use CORESMITH_SIM_PYTHON=pypy3 to JIT the "
                     "Amaranth sim if not already."
-                ),
+                ) + (("\n\n" + str(_fmdv_probe.get("summary") or ""))
+                     if _fmdv_probe.get("summary") else ""),
             }])[0])
             break
         if sim_exc is not None:
@@ -2306,15 +2508,35 @@ def _run_gate_inner(
         simulate, chip_model_path, models_dir, stimulus, sim_timeout
     )
     if timed_out:
+        # LOCALIZE. "(unlocalized)" on a timeout broadcasts a re-spec to every
+        # block, and a stall has ONE first cause. The per-block probe reads what
+        # the composition wired and what each block model imports to; when it
+        # points at exactly ONE block that block is NAMED, and the evidence is
+        # attached either way.
+        _probe: dict = {}
+        _fdb_timeout = _first_divergence_block(project_root)
+        if stall_localization_enabled():
+            _probe = probe_composition_stall(project_root, models_dir)
+            _cands = _probe.get("candidates") or []
+            if len(_cands) == 1 and not _fdb_timeout:
+                _fdb_timeout = _cands[0]
+        _probe_txt = str(_probe.get("summary") or "")
+        _where = (
+            f" LOCALIZED to block {_fdb_timeout!r}." if _fdb_timeout
+            else " NOT localized to a single block (the probe found no "
+                 "single-block evidence)."
+        )
         return _attach_stall_autopsy(project_root, [
             {
                 "type": "model_integration_failure",
-                "first_divergence_block": _first_divergence_block(project_root),
+                "first_divergence_block": _fdb_timeout,
                 "expected": expected,
                 "observed": f"simulate() did not return within {sim_timeout:.0f}s "
-                            "(no output frame-end / runaway emission / deadlock)",
+                            "(no output frame-end / runaway emission / deadlock)."
+                            + _where,
                 "criterion": "simulate_timeout",
                 "gap_class": "contract",
+                "stall_localization": _probe,
                 "suggested_fix": (
                     "The integrated chip model's simulate() ran unbounded. Usually "
                     "the pipeline never asserts the output frame-end (m_axis_tlast) "
@@ -2322,7 +2544,7 @@ def _run_gate_inner(
                     "emission to the frame, and that simulate() has a hard cycle cap "
                     "(see prompt). Raise CORESMITH_GATE_SIM_TIMEOUT for a legitimately "
                     "long sim."
-                ),
+                ) + (("\n\n" + _probe_txt) if _probe_txt else ""),
             }
         ])
     if sim_exc is not None:
@@ -2475,7 +2697,8 @@ def _run_gate_inner(
             # Legacy escape hatch (opt-in): the OLD, too-weak Tier-B check that
             # accepted any NON-DEGENERATE output WITHOUT comparing it to the
             # reference. This let a composition streaming a handful of garbage
-            # bytes pass (e.g. the codec that emitted ~0.5% of the reference
+            # bytes pass (e.g. a measured composition that emitted ~0.5% of the
+            # reference
             # bytes yet "passed"). Kept only for designs with genuinely no usable
             # oracle comparison.
             if _is_degenerate(observed_norm):

--- a/orchestrator/daemon/server.py
+++ b/orchestrator/daemon/server.py
@@ -90,7 +90,7 @@ _STALL_POLL_S = float(os.environ.get("CORESMITH_INTERRUPT_STALL_POLL_S", "300"))
 #   * ``_shape_state`` labelled an interrupt "stale_suspected" purely because
 #     its block appears in the append-only ``completed_blocks``. In a two-pass
 #     run EVERY block completes pass 1, so EVERY pass-2 interrupt is born
-#     stale: the parked raster run reported ``stale_suspected: true`` and
+#     stale: a parked graded run reported ``stale_suspected: true`` and
 #     ``live_interrupt_count: 0`` on a freshly raised, entirely live
 #     ``contract_conformance_unrepairable`` -- and an automated consumer
 #     reading ``live_interrupt_count == 0`` concludes there is nothing to act

--- a/orchestrator/langchain/agents/contract_audit_agent.py
+++ b/orchestrator/langchain/agents/contract_audit_agent.py
@@ -40,8 +40,8 @@ class ContractAuditAgent:
         The output path is stage-derived and therefore STABLE across failures,
         so a file left by a PREVIOUS audit is already sitting there when this
         call begins -- and the "did the agent write the result?" check was a
-        bare ``out.exists()``, which that stale file satisfies. Observed on the
-        raster run: a 0.99-confidence TESTBENCH_BUG audit for an already-fixed
+        bare ``out.exists()``, which that stale file satisfies. Observed on a
+        validation run: a 0.99-confidence TESTBENCH_BUG audit for an already-fixed
         crash was adopted verbatim as the verdict on a new and completely
         different failure.
 

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -449,7 +449,7 @@ class UarchSpecGenerator:
             # used to append the section unconditionally, so a block whose
             # python_source resolved to "" got `--- Python Golden Model ---`
             # followed by an empty code fence -- indistinguishable, to the spec
-            # author, from a golden that says nothing. Measured on the raster
+            # author, from a golden that says nothing. Measured on a
             # validation run: all 8 uArch calls carried an empty golden block,
             # silently. Say what actually happened instead.
             if python_source.strip():

--- a/orchestrator/langchain/prompts/backend_synth_llm.md
+++ b/orchestrator/langchain/prompts/backend_synth_llm.md
@@ -62,9 +62,14 @@ All outputs go in: `{output_dir}/`
    - Writes netlist: `write_verilog -noattr {output_dir}/{design_name}_netlist.v`
    - Generates stats: `stat -liberty $lib`
 
-2. Run `yosys -s <script_path>` via Bash
+2. Run `yosys -s <script_path>` via Bash, TEEING the output to a log file in
+   `{output_dir}/` (e.g. `yosys -s <script> 2>&1 | tee {output_dir}/synth_attempt1.log`).
+   Use a NEW numbered log per attempt -- never overwrite a failed attempt's log.
 
-3. If Yosys fails, read the error, fix the script, and retry (up to 3 times)
+3. If Yosys fails, read the error, fix the script, and retry (up to 3 times).
+   RECORD every failed attempt: its number and the error that ended it. A retry
+   whose reason is not written down teaches nobody, and the same script defect
+   recurs on the next run.
 
 4. Generate the SDC file with:
    ```
@@ -87,9 +92,18 @@ All outputs go in: `{output_dir}/`
   "gate_count": 150,
   "area_um2": 12345.6,
   "cell_count": 42,
-  "report_path": "{output_dir}/{design_name}_report.txt"
+  "report_path": "{output_dir}/{design_name}_report.txt",
+  "attempt_history": [
+    {{"attempt": 1, "error_summary": "ERROR: Module `cs_sram_1rw' referenced in module `top' is not part of the design"}}
+  ]
 }}
 ```
+
+`attempt_history` is REQUIRED whenever you retried, **including when a later
+attempt succeeded** -- one entry per FAILED attempt, with the error that ended
+it. Omit the key (or use `[]`) only when the FIRST attempt succeeded. Reporting
+"succeeded on attempt 2" in prose while leaving attempt 1's reason out of the
+JSON is the exact silence this field exists to end.
 
 If synthesis fails after all retries:
 ```json
@@ -97,7 +111,11 @@ If synthesis fails after all retries:
   "success": false,
   "error": "description of the failure",
   "gate_count": 0,
-  "area_um2": 0
+  "area_um2": 0,
+  "attempt_history": [
+    {{"attempt": 1, "error_summary": "..."}},
+    {{"attempt": 2, "error_summary": "..."}}
+  ]
 }}
 ```
 

--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -116,6 +116,10 @@ class BackendState(TypedDict):
     chip_gate_sim_status: str
     chip_gate_sim_reason: str
     flat_sdc_path: str                   # syn/output/<design>/<design>.sdc
+    # Per-attempt synthesis failure reasons retained even when a LATER attempt
+    # succeeded ([{attempt, error_summary, source, timestamp, unrecorded}]).
+    # Empty when nothing failed. Also merged into synth_result.json.
+    synth_attempt_history: list[dict]
     synth_gate_count: int
     synth_area_um2: float
     macro_bindings: list                 # Part C: [{name,lef,gds,lib,...}] bound shells
@@ -239,6 +243,7 @@ async def _run_llm_eda_step(
     context: dict,
     result_json_path: str,
     timeout: int = 1200,
+    capture_reply: bool = False,
 ) -> dict:
     """Run an EDA step entirely within the inner Claude LLM.
 
@@ -252,6 +257,12 @@ async def _run_llm_eda_step(
         context: Dict of template variables to fill into the prompt.
         result_json_path: Path where the LLM must write the result JSON.
         timeout: Max seconds for the LLM call.
+        capture_reply: Attach the step's own summary text under ``_llm_reply``.
+            Default OFF so every other EDA step's result dict is byte-identical
+            (these dicts land in graph state and the final report). The
+            synthesis driver opts in because a step that RETRIED internally says
+            so only in that text -- the transcript is otherwise discarded, which
+            is how "succeeded on attempt 2" left no record of attempt 1.
 
     Returns:
         Parsed result dict from the JSON file, or a failure dict.
@@ -269,23 +280,33 @@ async def _run_llm_eda_step(
 
     llm = ClaudeLLM(model=DEFAULT_MODEL, timeout=timeout)
 
+    reply = ""
     try:
-        await llm.call(
+        reply = await llm.call(
             system=system_prompt,
             prompt=user_message,
             run_name=step_name,
-        )
+        ) or ""
     except Exception as e:
         return {"success": False, "error": f"LLM call failed: {e}"}
 
     result_path = Path(result_json_path)
     if result_path.exists():
         try:
-            return json.loads(result_path.read_text(encoding="utf-8"))
+            parsed = json.loads(result_path.read_text(encoding="utf-8"))
+            if capture_reply and isinstance(parsed, dict):
+                parsed.setdefault("_llm_reply", str(reply)[:4000])
+            return parsed
         except (json.JSONDecodeError, OSError):
             pass
 
-    return {"success": False, "error": f"LLM did not write result JSON to {result_json_path}"}
+    failed = {
+        "success": False,
+        "error": f"LLM did not write result JSON to {result_json_path}",
+    }
+    if capture_reply:
+        failed["_llm_reply"] = str(reply)[:4000]
+    return failed
 
 
 def _block_name(state: BackendState) -> str:
@@ -855,16 +876,43 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
                 "sram_wrapper_lib": _sram_wrapper_lib or "(already in inputs)",
             },
             result_json_path=result_json_path,
+            # the driver retries Yosys internally -- its own summary is the only
+            # place that says so (see collect_synth_attempt_history)
+            capture_reply=True,
         )
 
         span.set_attribute("success", result.get("success", False))
         if result.get("success"):
             span.set_attribute("gate_count", result.get("gate_count", 0))
 
+    # SELF-RECOVERY MUST NOT BE SILENT. The driver retries Yosys internally; a
+    # live run logged "Synthesis succeeded on attempt 2" and attempt 1's reason
+    # survived nowhere -- not in attempt_history, not in previous_error, not in
+    # synth_result.json. Retain every attempt's failure reason (driver-reported,
+    # harvested from the Yosys logs on disk, and the node's own prior failure),
+    # and record EXPLICITLY when the driver claims a retry we cannot account for.
+    from orchestrator.langgraph.backend_helpers import (
+        collect_synth_attempt_history,
+        describe_synth_attempt_history,
+        persist_synth_attempt_history,
+    )
+    _synth_history = collect_synth_attempt_history(
+        result,
+        output_dir=output_dir,
+        llm_reply=str(result.get("_llm_reply", "")),
+        prior_error=str(state.get("previous_error", "")),
+        node_attempt=int(state.get("attempt", 1) or 1),
+    )
+    if _synth_history:
+        persist_synth_attempt_history(result_json_path, _synth_history)
+        log("  [FLAT-SYNTH] " + describe_synth_attempt_history(_synth_history),
+            YELLOW)
+
     write_graph_event(pr, "Flat Top Synthesis", "graph_node_exit", {
         "design_name": design_name,
         "success": result.get("success", False),
         "gate_count": result.get("gate_count", 0),
+        "synth_attempt_failures": len(_synth_history),
         "graph": "backend",
     })
 
@@ -885,6 +933,7 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
             })
             return {
                 "phase": "synth",
+                "synth_attempt_history": _synth_history,
                 "previous_error": _bind_err,
                 "flat_netlist_path": "",
                 "flat_sdc_path": "",
@@ -892,6 +941,7 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
         _gs_ok, _gs_status, _gs_reason = _run_chip_top_gate_sim(state, _netlist)
         return {
             "phase": "synth",
+            "synth_attempt_history": _synth_history,
             "flat_netlist_path": _netlist,
             "flat_sdc_path": result.get("sdc_path", ""),
             "synth_gate_count": result.get("gate_count", 0),
@@ -906,9 +956,15 @@ async def flat_top_synthesis_node(state: BackendState) -> dict:
                 f"chip_top gate-sim FAIL: {_gs_reason}"} if _gs_ok is False else {}),
         }
     else:
+        # A FAILED synthesis carries its per-attempt history into previous_error
+        # too: diagnose reads that string, and "attempt 3 failed" without the two
+        # reasons before it is what made the same script defect recur every run.
+        _err = result.get("error", "Flat synthesis failed")
+        _hist_txt = describe_synth_attempt_history(_synth_history)
         return {
             "phase": "synth",
-            "previous_error": result.get("error", "Flat synthesis failed"),
+            "synth_attempt_history": _synth_history,
+            "previous_error": (f"{_err}\n\n{_hist_txt}" if _hist_txt else _err),
             "flat_netlist_path": "",
             "flat_sdc_path": "",
         }

--- a/orchestrator/langgraph/backend_helpers.py
+++ b/orchestrator/langgraph/backend_helpers.py
@@ -155,6 +155,227 @@ def render_layout_image(
 
 
 # ---------------------------------------------------------------------------
+# Synthesis attempt history (self-recovery must never be silent)
+# ---------------------------------------------------------------------------
+#
+# The flat-synth driver runs Yosys inside an LLM step that retries on its own.
+# On a live run it reported "Synthesis succeeded on attempt 2" -- and attempt 1's
+# failure reason was retained NOWHERE: not in ``attempt_history``, not in
+# ``previous_error``, not in ``synth_result.json``. A driver that heals itself in
+# silence teaches nobody: the same script defect recurs every run, and the only
+# trace is a sentence in a chat transcript that is discarded.
+#
+# Everything below is a PURE function of (result dict, on-disk logs, reply text)
+# so it can be unit-tested without an LLM, and it NEVER raises: retaining history
+# is diagnostics, and diagnostics must not be able to fail a synthesis that
+# succeeded.
+
+#: Yosys prints hard failures as ``ERROR: ...``; Verilog front-end syntax errors
+#: come through as ``... syntax error ...``. Both are attempt-ending.
+_SYNTH_ERROR_RE = re.compile(
+    r"^(?:\s*)(ERROR:.*|.*\bsyntax error\b.*)$", re.MULTILINE | re.IGNORECASE
+)
+#: "succeeded on attempt 3", "attempt 2 succeeded", "on the 2nd attempt", ...
+_ATTEMPT_CLAIM_RE = re.compile(r"attempt\s*#?\s*(\d+)", re.IGNORECASE)
+_SYNTH_LOG_GLOBS = ("*.log", "*.txt", "*.out")
+_MAX_SUMMARY_CHARS = 800
+
+
+def _clip(text: str, limit: int = _MAX_SUMMARY_CHARS) -> str:
+    t = " ".join(str(text or "").split())
+    return t if len(t) <= limit else t[: limit - 3] + "..."
+
+
+def _first_error_line(text: str) -> str:
+    m = _SYNTH_ERROR_RE.search(str(text or ""))
+    return _clip(m.group(1)) if m else ""
+
+
+def collect_synth_attempt_history(
+    result: dict | None,
+    *,
+    output_dir: str = "",
+    llm_reply: str = "",
+    prior_error: str = "",
+    node_attempt: int = 1,
+    now: str = "",
+) -> list[dict]:
+    """Per-attempt failure records for ONE synthesis-driver invocation.
+
+    Merges every source of attempt evidence that exists, de-duplicated and
+    ordered by attempt number. Each record is
+    ``{attempt, error_summary, source, timestamp}``.
+
+      * ``result["attempt_history"]`` / ``["attempts"]`` -- what the driver
+        itself recorded (the prompt now asks for it explicitly).
+      * on-disk logs under ``output_dir`` -- any log carrying a Yosys ``ERROR:``
+        line. Deterministic evidence that does not depend on the driver being
+        honest about its own retries.
+      * ``prior_error`` -- the failure this NODE-level attempt is retrying, which
+        otherwise only survives until the next node overwrites it.
+      * ``llm_reply`` -- the driver's own summary. When it claims success on
+        attempt N and fewer than N-1 failures were recovered above, the missing
+        attempts are recorded EXPLICITLY as ``not retained``. That entry is the
+        point: a gap we can see beats a gap we cannot.
+
+    Returns ``[]`` when nothing failed and nothing claims anything did.
+    """
+    try:
+        return _collect_synth_attempt_history(
+            result or {}, output_dir, llm_reply, prior_error, node_attempt, now)
+    except Exception:  # noqa: BLE001 - diagnostics never fail a synthesis
+        return []
+
+
+def _collect_synth_attempt_history(
+    result: dict, output_dir: str, llm_reply: str, prior_error: str,
+    node_attempt: int, now: str,
+) -> list[dict]:
+    import time as _time
+
+    stamp = now or _time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    by_attempt: dict[int, dict] = {}
+
+    def _record(attempt: int, summary: str, source: str, timestamp: str = "") -> None:
+        summary = _clip(summary)
+        if not summary:
+            return
+        n = max(1, int(attempt))
+        prev = by_attempt.get(n)
+        # First writer wins per attempt, EXCEPT that a real error summary always
+        # displaces a "not retained" placeholder.
+        if prev is not None and not prev.get("unrecorded"):
+            return
+        by_attempt[n] = {
+            "attempt": n,
+            "error_summary": summary,
+            "source": source,
+            "timestamp": timestamp or stamp,
+            "unrecorded": source == "unrecorded",
+        }
+
+    # 1. What the driver recorded about itself.
+    declared = result.get("attempt_history")
+    if not isinstance(declared, list):
+        declared = result.get("attempts")
+    if isinstance(declared, list):
+        for i, entry in enumerate(declared):
+            if isinstance(entry, dict):
+                n = entry.get("attempt", entry.get("n", i + 1))
+                summary = (
+                    entry.get("error_summary") or entry.get("error")
+                    or entry.get("reason") or entry.get("summary") or ""
+                )
+                try:
+                    n = int(n)
+                except (TypeError, ValueError):
+                    n = i + 1
+                _record(n, summary, "driver_reported",
+                        str(entry.get("timestamp", "")))
+            elif isinstance(entry, str):
+                _record(i + 1, entry, "driver_reported")
+
+    # 2. Deterministic on-disk evidence.
+    log_hits: list[tuple[float, str, str]] = []
+    if output_dir:
+        d = Path(output_dir)
+        if d.is_dir():
+            seen: set[str] = set()
+            for pattern in _SYNTH_LOG_GLOBS:
+                for p in sorted(d.glob(pattern)):
+                    if str(p) in seen or not p.is_file():
+                        continue
+                    seen.add(str(p))
+                    try:
+                        line = _first_error_line(
+                            p.read_text(encoding="utf-8", errors="replace"))
+                    except OSError:
+                        continue
+                    if line:
+                        log_hits.append((p.stat().st_mtime, p.name, line))
+    log_hits.sort()
+    for i, (mtime, name, line) in enumerate(log_hits):
+        import time as _t
+        _record(i + 1, f"{line}  [{name}]", "yosys_log",
+                _t.strftime("%Y-%m-%dT%H:%M:%S", _t.localtime(mtime)))
+
+    # 3. The node-level failure this invocation is retrying.
+    if prior_error and str(prior_error).strip().lower() not in ("", "none"):
+        _record(max(1, int(node_attempt) - 1), prior_error, "node_previous_error")
+
+    # 4. The driver's own claim about how many attempts it took.
+    claimed = 0
+    for m in _ATTEMPT_CLAIM_RE.finditer(str(llm_reply or "")):
+        try:
+            claimed = max(claimed, int(m.group(1)))
+        except ValueError:
+            continue
+    if claimed > 1:
+        for n in range(1, claimed):
+            if n not in by_attempt:
+                _record(
+                    n,
+                    f"(not retained) the synthesis driver reported reaching "
+                    f"attempt {claimed}, so attempt {n} failed, but no error "
+                    f"text for it was written to the result JSON or to any log "
+                    f"under the output dir",
+                    "unrecorded",
+                )
+
+    return [by_attempt[k] for k in sorted(by_attempt)]
+
+
+def persist_synth_attempt_history(
+    result_json_path: str, history: list[dict]
+) -> bool:
+    """Merge ``history`` into the synthesis result artifact. True when written.
+
+    The artifact is the thing a later reader (diagnose, the final report, a
+    human) actually opens, so the record has to live THERE and not only in
+    graph state that dies with the process. Never raises.
+    """
+    if not result_json_path or not history:
+        return False
+    try:
+        import json as _json
+
+        p = Path(result_json_path)
+        data: dict = {}
+        if p.exists():
+            try:
+                loaded = _json.loads(p.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    data = loaded
+            except (OSError, ValueError):
+                data = {}
+        data["attempt_history"] = history
+        data["attempt_failures"] = len(history)
+        data["attempt_history_unrecorded"] = sum(
+            1 for h in history if h.get("unrecorded"))
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_json.dumps(data, indent=2), encoding="utf-8")
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def describe_synth_attempt_history(history: list[dict]) -> str:
+    """One-line-per-attempt human summary ('' when nothing failed)."""
+    if not history:
+        return ""
+    lines = [
+        f"{len(history)} failed synthesis attempt(s) BEFORE the reported outcome:"
+    ]
+    for h in history:
+        tag = " [NOT RETAINED]" if h.get("unrecorded") else ""
+        lines.append(
+            f"  attempt {h.get('attempt')}{tag} ({h.get('source')}, "
+            f"{h.get('timestamp')}): {h.get('error_summary')}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Flat Top-Level Synthesis (Yosys)
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/langgraph/bfm_lib/__init__.py
+++ b/orchestrator/langgraph/bfm_lib/__init__.py
@@ -55,6 +55,8 @@ from .codegen import (
     render_conformance_test_fn,
     render_contract_literal,
     render_integration_tb,
+    render_maxgeo_case_marker,
+    render_maxgeo_functional_test_fn,
     render_maxgeo_markers,
     render_maxgeo_probe_block,
     render_rom_bfm_module,
@@ -62,14 +64,29 @@ from .codegen import (
 )
 from .maxgeo import (
     BusMaxgeoCoverage,
+    MaxgeoDemand,
     bus_maxgeo_coverage,
     classify_dim_role,
+    declared_dimensional_maxima,
+    functional_maxgeo_dims,
     max_burst_bytes,
+    maxgeo_demand,
+    schema_dimensional_maxima,
+    token_match,
 )
 from .qspi_contract import QSPIContract
 from .qspi_master_bfm import QSPIMasterBFM
 from .qspi_rom_bfm import QSPIRomContract, QSPIRomResponderBFM
-from .stimulus import StimulusPlan, build_plan_from_run
+from .stimulus import (
+    MaxGeoCase,
+    StimulusPlan,
+    build_max_geometry_case,
+    build_plan_from_run,
+    load_acceptance_cases,
+    map_stimulus,
+    select_max_geometry_case,
+    stimulus_scalars,
+)
 
 __all__ = [
     "STATUS_BOUNDARY_OFF_TOP",
@@ -78,6 +95,8 @@ __all__ = [
     "STATUS_QSPI_TOP",
     "BusMaxgeoCoverage",
     "BusVerdict",
+    "MaxGeoCase",
+    "MaxgeoDemand",
     "PinBoundary",
     "QSPIContract",
     "QSPIMasterBFM",
@@ -86,28 +105,40 @@ __all__ = [
     "StimulusPlan",
     "arch_indicates_qspi_slave",
     "boundary_gate_enabled",
+    "build_max_geometry_case",
     "build_plan_from_run",
     "bus_maxgeo_coverage",
     "classify_bus_verdict",
     "classify_chip_bus",
     "classify_dim_role",
     "conformance_enabled",
+    "declared_dimensional_maxima",
     "describe_unmodeled_roles",
     "detect_bus_roles",
     "detect_dut_mastered_buses",
     "deterministic_bfm_enabled",
     "find_pin_boundary",
+    "functional_maxgeo_dims",
+    "load_acceptance_cases",
+    "map_stimulus",
     "max_burst_bytes",
+    "maxgeo_demand",
     "plan_deterministic_dv",
     "render_bfm_module",
     "render_conformance_tb",
     "render_conformance_test_fn",
     "render_contract_literal",
     "render_integration_tb",
+    "render_maxgeo_case_marker",
+    "render_maxgeo_functional_test_fn",
     "render_maxgeo_markers",
     "render_maxgeo_probe_block",
     "render_rom_bfm_module",
     "render_rom_contract_literal",
+    "schema_dimensional_maxima",
+    "select_max_geometry_case",
+    "stimulus_scalars",
+    "token_match",
     "write_deterministic_integration_tb",
     "write_qspi_conformance_tb",
 ]
@@ -231,18 +262,43 @@ def write_deterministic_integration_tb(
 
     ``declared_dims`` is the design's dimensional maxima; the bus-drivable subset
     is driven at maximum extent and advertised with a ``# MAXGEO`` marker.
+
+    The MAX-CONFIGURATION acceptance case is selected + baked here too (see
+    :func:`stimulus.build_max_geometry_case`): the primary plan is whichever case
+    the run declared FIRST -- the small canonical KAT -- so on its own it proves
+    nothing about the declared maxima. When a larger case exists it becomes a
+    second host-flow test in the same module, and the dims it drives at their
+    declared maximum are subtracted from the confession (and only those).
     """
+    maxgeo_case = None
+    schema_dims: dict = {}
+    try:
+        maxgeo_case = build_max_geometry_case(
+            project_root, contract, plan.case_name)
+    except Exception:  # noqa: BLE001 - a max case we cannot bake is simply absent
+        maxgeo_case = None
+    try:
+        schema_dims = schema_dimensional_maxima(project_root)
+    except Exception:  # noqa: BLE001
+        schema_dims = {}
     tb_src = render_integration_tb(
         contract, design_name, plan, include_conformance=include_conformance,
-        declared_dims=declared_dims,
+        declared_dims=declared_dims, maxgeo_case=maxgeo_case,
+        schema_dims=schema_dims,
+    )
+    functional = (
+        functional_maxgeo_dims(
+            maxgeo_case.scalars, schema_dims or declared_dims)
+        if maxgeo_case is not None else {}
     )
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(tb_src, encoding="utf-8")
+    extra_test = 1 if (maxgeo_case is not None and not maxgeo_case.is_primary) else 0
     return {
         "tb_path": str(out),
         "testbench_path": str(out),
-        "test_count": 2 if include_conformance else 1,
+        "test_count": (2 if include_conformance else 1) + extra_test,
         "deterministic_bfm": True,
         "qspi_conformance": bool(include_conformance),
         "contract_fingerprint": contract.fingerprint(),
@@ -250,6 +306,21 @@ def write_deterministic_integration_tb(
         # testbench was CAPABLE of driving instead of trusting what it claimed.
         "contract": contract.to_dict(),
         "case_name": plan.case_name,
+        # The MAX-CONFIGURATION case, so the gate reads the generator's record
+        # rather than re-deriving it (and can tell "no larger case exists" from
+        # "the generator skipped it").
+        "maxgeo_case": (
+            {
+                "name": maxgeo_case.plan.case_name,
+                "cfg0": maxgeo_case.cfg0,
+                "in_bytes": maxgeo_case.in_bytes,
+                "out_bytes": maxgeo_case.out_bytes,
+                "is_primary": maxgeo_case.is_primary,
+                "emitted_test": bool(extra_test),
+            }
+            if maxgeo_case is not None else None
+        ),
+        "maxgeo_functional": functional,
     }
 
 

--- a/orchestrator/langgraph/bfm_lib/codegen.py
+++ b/orchestrator/langgraph/bfm_lib/codegen.py
@@ -20,13 +20,15 @@ from __future__ import annotations
 
 import inspect
 
+import re as _re
+
 from . import qspi_contract as _contract_mod
 from . import qspi_master_bfm as _bfm_mod
 from . import qspi_rom_bfm as _rom_mod
-from .maxgeo import BusMaxgeoCoverage, bus_maxgeo_coverage
+from .maxgeo import BusMaxgeoCoverage, bus_maxgeo_coverage, functional_maxgeo_dims
 from .qspi_contract import QSPIContract
 from .qspi_rom_bfm import QSPIRomContract
-from .stimulus import StimulusPlan
+from .stimulus import MaxGeoCase, StimulusPlan
 
 # ---------------------------------------------------------------------------
 # CFG read-back probe patterns (bus-protocol conformance, phase A)
@@ -352,34 +354,191 @@ async def qspi_slave_protocol_conformance(dut):
 {op_probe}{maxgeo_block}'''
 
 
-def render_maxgeo_markers(coverage: BusMaxgeoCoverage | None) -> str:
+def marker_token(text: str) -> str:
+    """Collapse free-form text to a single whitespace-free marker token.
+
+    Marker lines are whitespace-separated ``key=value`` records; a case name
+    carrying a space would silently split into two bogus records.
+    """
+    tok = _re.sub(r"\s+", "_", str(text).strip())
+    return tok or "(unnamed)"
+
+
+def render_maxgeo_case_marker(case: MaxGeoCase | None) -> str:
+    """The ``# MAXGEO_CASE:`` marker naming the max-configuration host-flow case.
+
+    ``# MAXGEO_CASE: name=<case> cfg0=<value> in_bytes=<n> out_bytes=<n>``
+
+    Like ``MAXGEO_NOT_COVERED`` and ``MAXGEO_SCOPE``, the underscore form does
+    NOT match the gate's ``#\\s*MAXGEO\\b`` coverage regex, so the case record
+    can never be misparsed as a coverage claim for a dim literally named
+    ``cfg0``/``in_bytes``/``out_bytes``. It is a provenance record: WHICH case
+    the max-geometry functional test drives, and at what magnitudes.
+    """
+    if case is None:
+        return ""
+    return (
+        "# MAXGEO_CASE: name=%s cfg0=%d in_bytes=%d out_bytes=%d"
+        % (marker_token(case.plan.case_name), int(case.cfg0),
+           int(case.in_bytes), int(case.out_bytes))
+    )
+
+
+def render_maxgeo_markers(
+    coverage: BusMaxgeoCoverage | None,
+    functional: dict | None = None,
+    case: MaxGeoCase | None = None,
+) -> str:
     """The ``# MAXGEO`` header block for a generated testbench.
 
-    Three lines, all machine-readable:
+    Machine-readable, all of it:
 
-      ``# MAXGEO: <dim>=<max> ...``       -- ONLY dims this TB drives at maximum
+      ``# MAXGEO: <dim>=<max> ...``       -- BUS dims driven at maximum extent
+      ``# MAXGEO: <dim>=<max> ...``       -- COMPUTE-LANE dims the max-geometry
+                                             functional case drives at maximum
+                                             (omitted when there are none)
+      ``# MAXGEO_CASE: name=... ...``     -- which acceptance case that is
       ``# MAXGEO_SCOPE: ...``             -- what kind of coverage this is
       ``# MAXGEO_NOT_COVERED: <dim>=<max> ...`` -- what it does NOT reach
 
-    The last two deliberately do NOT match the gate's ``# MAXGEO\\b`` marker
-    regex (``MAXGEO_`` has no word boundary after ``MAXGEO``), so recording an
-    UNCOVERED dim can never be misread as coverage. A marker is a claim; a claim
-    without the traffic behind it is worse than no claim at all.
+    Only the ``# MAXGEO:`` lines match the gate's marker regex; every other tag
+    carries an underscore right after ``MAXGEO`` (no word boundary), so a
+    confession or a provenance record can never be misread as coverage. A marker
+    is a claim; a claim without the traffic behind it is worse than no claim.
+
+    ``functional`` dims are SUBTRACTED from the confession -- and only those: a
+    dim the functional case does not drive at its declared maximum stays
+    confessed, however large the case is.
     """
-    if coverage is None:
+    covered_line = coverage.marker_line() if coverage is not None else ""
+    func = {str(k): int(v) for k, v in (functional or {}).items()}
+    uncovered = {}
+    if coverage is not None:
+        uncovered = {n: v for n, v in coverage.uncovered.items() if n not in func}
+    case_line = render_maxgeo_case_marker(case)
+    if not (covered_line or func or uncovered or case_line):
         return ""
-    lines = [ln for ln in (coverage.marker_line(),) if ln]
-    if not lines and not coverage.uncovered:
-        return ""
-    lines.append(
-        "# MAXGEO_SCOPE: bus-contract-only -- this testbench is the deterministic "
-        "QSPI-slave\n#   conformance DV. It has NO compute oracle, so it drives the "
-        "BUS dimensions at\n#   their declared maxima and cannot drive compute-lane "
-        "geometry at all."
-    )
-    if coverage.uncovered_line():
-        lines.append(coverage.uncovered_line())
+
+    lines: list[str] = []
+    if covered_line:
+        lines.append(covered_line)
+    if func:
+        lines.append(
+            "# MAXGEO: "
+            + " ".join(f"{n}={v}" for n, v in sorted(func.items()))
+        )
+    if case_line:
+        lines.append(case_line)
+    if func or case is not None:
+        lines.append(
+            ("# MAXGEO_SCOPE: bus contract at declared maxima PLUS the "
+             if covered_line else
+             "# MAXGEO_SCOPE: no bus-maxima probes in this testbench; the ")
+            + "max-configuration\n#   host-flow case named in MAXGEO_CASE, whose "
+            "golden was evaluated at\n#   GENERATION time and is asserted "
+            "byte-exact. Compute-lane dimensions the\n#   selected case does not "
+            "drive at their declared maximum stay in\n#   MAXGEO_NOT_COVERED."
+        )
+    else:
+        lines.append(
+            "# MAXGEO_SCOPE: bus-contract-only -- this testbench is the deterministic "
+            "QSPI-slave\n#   conformance DV. It has NO compute oracle, so it drives the "
+            "BUS dimensions at\n#   their declared maxima and cannot drive compute-lane "
+            "geometry at all."
+        )
+    if uncovered:
+        pairs = " ".join(f"{n}={v}" for n, v in sorted(uncovered.items()))
+        lines.append(f"# MAXGEO_NOT_COVERED: {pairs}")
     return "\n".join(lines) + "\n"
+
+
+def render_maxgeo_functional_test_fn(
+    contract: QSPIContract, case: MaxGeoCase, marked: dict | None = None
+) -> str:
+    """Emit the MAX-CONFIGURATION host-flow ``@cocotb.test()`` as source.
+
+    Same shape as the primary host-flow test -- CFG writes, IN burst, START,
+    poll DONE, read OUT, byte-exact vs the golden -- but for the acceptance case
+    that drives the LARGEST geometry, with its golden baked at GENERATION time
+    exactly like the primary's. No runtime import of the reference model: the
+    emitted testbench stays hermetic.
+
+    The point is the counters, not a second correctness sample: a length/index
+    width sized below the declared maximum survives the small canonical case and
+    wraps here, and the first-differing-byte message says where.
+    """
+    plan = case.plan
+    clk = contract.clk_name
+    cfg_lits = ", ".join(f"({a}, {v}, {w})" for (a, v, w) in plan.cfg)
+    write_lits = ", ".join(
+        f"({a}, bytes.fromhex({d.hex()!r}))" for (a, d) in plan.writes
+    )
+    marked_txt = (
+        " ".join(f"{n}={v}" for n, v in sorted((marked or {}).items()))
+        or "(bus dimensions only)"
+    )
+    return f'''
+
+# ---- MAX-CONFIGURATION host-flow plan (largest acceptance case; baked here) --
+# Selected GENERICALLY: the acceptance case maximizing (IN payload bytes, CFG0).
+# Declared maxima this case drives directly: {marked_txt}
+MAXGEO_CFG_WRITES = [{cfg_lits}]      # (addr, value, width_bytes)
+MAXGEO_IN_WRITES = [{write_lits}]     # (addr, data)
+MAXGEO_OUT_LEN = {plan.out_len}
+MAXGEO_EXPECTED = bytes.fromhex({plan.expected.hex()!r})
+MAXGEO_CASE_NAME = {plan.case_name!r}
+
+
+@cocotb.test()
+async def deterministic_qspi_dv_max_geometry(dut):
+    """MAX-GEOMETRY host-flow DV for case {plan.case_name!r} (byte-exact vs golden).
+
+    A chip can pass every fixed-small-geometry test and still ship an index /
+    length / address counter that wraps at a 2^n boundary BELOW the declared
+    maximum. This test drives the largest configuration the acceptance suite
+    declares ({case.in_bytes} IN bytes, CFG0={case.cfg0}, {case.out_bytes} OUT
+    bytes) and asserts the full OUT window byte-for-byte.
+    """
+    c = CONTRACT
+    cocotb.start_soon(Clock(dut.{clk}, c.clk_period_ns, unit="ns").start())
+    bfm = QSPIMasterBFM(dut, c)
+    await bfm.reset_dut(10)
+
+    for addr, value, width in MAXGEO_CFG_WRITES:
+        await bfm.write_reg(addr, value, width)
+    for addr, data in MAXGEO_IN_WRITES:
+        await bfm.write(addr, data)
+
+    await bfm.start()
+    done = await bfm.wait_done()
+    assert done, (
+        "MAX-GEOMETRY: DUT never signalled STATUS.DONE for the max-configuration "
+        "op (case %s, {case.in_bytes} IN bytes, CFG0={case.cfg0}). It completes "
+        "the small case, so this is a counter/state machine that does not survive "
+        "the declared maximum." % MAXGEO_CASE_NAME
+    )
+
+    out = await bfm.read(OUT_ADDR, MAXGEO_OUT_LEN)
+    dut._log.info("[det-bfm/maxgeo] case=%s expected_len=%d observed_len=%d",
+                  MAXGEO_CASE_NAME, len(MAXGEO_EXPECTED), len(out))
+    if out != MAXGEO_EXPECTED:
+        _fd = next(
+            (i for i in range(min(len(out), len(MAXGEO_EXPECTED)))
+             if out[i] != MAXGEO_EXPECTED[i]),
+            min(len(out), len(MAXGEO_EXPECTED)),
+        )
+        raise AssertionError(
+            "MAX-GEOMETRY: OUT != golden reference at maximum configuration "
+            "(case %s). first_diff_byte=%d exp=0x%02x got=0x%02x "
+            "(exp_len=%d got_len=%d). The small canonical case passes, so look "
+            "for an index/length/address width that wraps below the declared "
+            "maximum." % (
+                MAXGEO_CASE_NAME, _fd,
+                MAXGEO_EXPECTED[_fd] if _fd < len(MAXGEO_EXPECTED) else 0,
+                out[_fd] if _fd < len(out) else 0,
+                len(MAXGEO_EXPECTED), len(out))
+        )
+'''
 
 
 def render_conformance_tb(
@@ -445,6 +604,8 @@ def render_integration_tb(
     *,
     include_conformance: bool = False,
     declared_dims: dict | None = None,
+    maxgeo_case: MaxGeoCase | None = None,
+    schema_dims: dict | None = None,
 ) -> str:
     """Emit a hermetic deterministic cocotb integration testbench.
 
@@ -467,15 +628,28 @@ def render_integration_tb(
 
     ``declared_dims`` (with ``include_conformance``) additionally drives the
     design's BUS maxima at maximum extent and emits the matching ``# MAXGEO``
-    marker. It never invents coverage for the compute lane: the golden host-flow
-    case above is whatever geometry the golden reference chose, and this
-    testbench does not claim otherwise.
+    marker.
+
+    ``maxgeo_case`` is the MAX-CONFIGURATION acceptance case (see
+    :func:`stimulus.build_max_geometry_case`). When supplied -- and when it is
+    not already the primary case -- a SECOND host-flow test is emitted for it,
+    with its golden baked at generation time exactly like the primary's, plus a
+    ``# MAXGEO_CASE`` provenance marker. Compute-lane dims that case drives at
+    their declared maximum (matched against ``schema_dims``, the typed ERS
+    parameter table, by name-token AND value) join the ``# MAXGEO`` marker;
+    everything else stays in the ``MAXGEO_NOT_COVERED`` confession. ``None``
+    keeps the emitted testbench byte-identical to before this existed.
     """
     coverage = (
         bus_maxgeo_coverage(contract, declared_dims)
         if (declared_dims and include_conformance) else None
     )
-    maxgeo_markers = render_maxgeo_markers(coverage)
+    functional = (
+        functional_maxgeo_dims(
+            maxgeo_case.scalars, schema_dims if schema_dims else declared_dims)
+        if maxgeo_case is not None else {}
+    )
+    maxgeo_markers = render_maxgeo_markers(coverage, functional, maxgeo_case)
     bfm_src = render_bfm_module(contract)
     cfg_lits = ", ".join(f"({a}, {v}, {w})" for (a, v, w) in plan.cfg)
     write_lits = ", ".join(f"({a}, bytes.fromhex({d.hex()!r}))" for (a, d) in plan.writes)
@@ -583,6 +757,12 @@ async def deterministic_qspi_dv(dut):
         f"exp={{EXPECTED.hex()}} got={{out.hex()}}"
     )
 '''
+    if maxgeo_case is not None and not maxgeo_case.is_primary:
+        # The MAX-CONFIGURATION functional case. Emitted only when it is a
+        # DIFFERENT case from the primary: when the largest case already IS the
+        # primary, a second identical test would prove nothing (the marker still
+        # records that the primary is the max-geometry case).
+        tb += render_maxgeo_functional_test_fn(contract, maxgeo_case, functional)
     if include_conformance:
         # Append the compute-lane-independent bus-protocol conformance test to the
         # SAME module: the golden host-flow test above already started the clock

--- a/orchestrator/langgraph/bfm_lib/maxgeo.py
+++ b/orchestrator/langgraph/bfm_lib/maxgeo.py
@@ -11,11 +11,11 @@ and still ship an index/address width that wraps at a 2^n boundary below the
 declared maximum.
 
 The deterministic QSPI conformance testbench is COMPUTE-LANE INDEPENDENT: it has
-no golden model, so it cannot render a frame, rasterize a triangle or transform a
-block. What it CAN do is drive the *bus* at maximum extent -- the full-width
-address, the longest legal write burst, the longest legal read burst, the largest
-command opcode -- and those are real dimensional maxima with real index widths
-behind them.
+no golden model, so it cannot evaluate any compute-lane transform at all. What it
+CAN do is drive the *bus* at maximum extent -- the full-width address, the
+longest legal write burst, the longest legal read burst, the largest command
+opcode -- and those are real dimensional maxima with real index widths behind
+them.
 
 This module decides, from the bus contract plus the design's declared maxima,
 exactly which dims fall in that set. Two callers use it, and they must agree:
@@ -27,6 +27,23 @@ exactly which dims fall in that set. Two callers use it, and they must agree:
 
 That split is the point. If only codegen decided, the testbench would be marking
 its own homework -- the failure mode this repo keeps paying for.
+
+SINGLE SOURCE (dimension-registry alignment). Three numbers used to disagree on
+a live run: the gate ENFORCED 9 dims, the testbench CONFESSED 13 uncovered, and
+the design's own declared table had 18. Nothing was lying -- the three were
+derived three different ways. They are now derived here, once:
+
+  * :func:`declared_dimensional_maxima` -- THE declared table (param schema
+    first, the legacy generic harvest folded in), for gate and generator alike.
+  * :func:`bus_maxgeo_coverage` -- THE classification (bus-drivable vs
+    compute-lane), for the generator's confession and the gate's demand alike.
+  * :func:`maxgeo_demand` -- THE marker verdict: which declared maxima the
+    testbench actually PROVED (name AND value), which merely collide in VALUE
+    with some other dim's marker (weak evidence -- the old gate silently counted
+    these as covered, which is the whole 13-vs-9 delta), and which are missing.
+
+``proven + value_only + missing`` is always the full declared table, so the
+three numbers now reconcile by construction.
 
 **A marker is a claim about coverage that EXISTS.** Nothing here ever reports a
 dim as covered unless the emitted testbench actually drives that value on the
@@ -43,9 +60,11 @@ the protocol knowledge lives in the protocol layer.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from .qspi_contract import QSPIContract
 
@@ -228,3 +247,195 @@ def bus_maxgeo_coverage(
 
 def _is_pos_int(v) -> bool:
     return isinstance(v, int) and not isinstance(v, bool) and v > 0
+
+
+# ---------------------------------------------------------------------------
+# THE declared-dimension registry (one derivation, two consumers)
+# ---------------------------------------------------------------------------
+
+#: Machine-readable spec artifacts the legacy generic ``{name, extent}`` harvest
+#: reads. Identical to ``pipeline_graph``'s list, deliberately: this function
+#: exists to REPLACE that one, not to disagree with it.
+DIM_SOURCE_FILES = (
+    "ers_spec.json", "prd_spec.json", "block_specs.json", "block_queue.json",
+)
+
+
+def declared_dimensional_maxima(project_root: str) -> dict[str, int]:
+    """``{dim_name: max}`` -- the design's declared dimensional maxima.
+
+    ONE derivation, for both the generator (what may I claim / what must I
+    confess?) and the gate (what do I demand?). Two sources, merged max-wise,
+    exactly as the gate's own ``_declared_dimensions`` merged them:
+
+      * PRIMARY -- the typed ERS ``parameters`` block (``role`` in
+        ``dimension``/``range`` carries an extent). Authoritative and
+        deterministic; ``mode`` parameters are control-selects, not geometry,
+        and are excluded.
+      * FOLDED IN -- the legacy generic ``{name-role, extent-role}`` harvest
+        over the ERS/PRD/block-spec JSON plus the FRD FUNC vectors, so a legacy
+        prose ERS (no ``parameters`` block) behaves exactly as before.
+
+    Returns ``{}`` when the design declares nothing dimensional (the gate then
+    no-ops). NEVER raises: a dimensional registry that can throw would take a
+    run down over an unreadable spec file.
+    """
+    dims: dict[str, int] = {}
+    root = Path(project_root)
+    try:
+        from orchestrator.architecture import param_schema as _psch
+    except Exception:  # noqa: BLE001 - no schema module -> no registry
+        return dims
+    try:
+        for name, mx in _psch.declared_maxima(
+                _psch.parameters_from_ers(project_root)).items():
+            dims[str(name)] = max(int(mx), dims.get(str(name), 0))
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        for fname in DIM_SOURCE_FILES:
+            p = root / ".coresmith" / fname
+            if not p.exists():
+                continue
+            try:
+                _psch._harvest_candidate_dims(
+                    json.loads(p.read_text(encoding="utf-8")), dims)
+            except (OSError, json.JSONDecodeError, ValueError, TypeError):
+                continue
+        frd = root / "arch" / "frd_spec.md"
+        if frd.exists():
+            try:
+                from orchestrator.architecture.composition import (
+                    parse_func_vectors,
+                )
+                _psch._harvest_candidate_dims(
+                    parse_func_vectors(frd.read_text(encoding="utf-8")), dims)
+            except Exception:  # noqa: BLE001
+                pass
+    except Exception:  # noqa: BLE001
+        return {k: int(v) for k, v in dims.items() if _is_pos_int(int(v))}
+    return {k: int(v) for k, v in dims.items() if _is_pos_int(int(v))}
+
+
+def schema_dimensional_maxima(project_root: str) -> dict[str, int]:
+    """``{name: max}`` from the typed ERS ``parameters`` block ONLY.
+
+    The subset of :func:`declared_dimensional_maxima` whose names are
+    design-AFFIRMED parameter identifiers rather than free-form strings scraped
+    out of arbitrary spec JSON. Functional max-geometry coverage is claimed
+    against THIS table (see :func:`functional_maxgeo_dims`) because the claim
+    rests on matching a declared parameter to a stimulus key by name, and a
+    scraped name is not a declared parameter. ``{}`` for a legacy prose ERS.
+    """
+    try:
+        from orchestrator.architecture import param_schema as _psch
+        return {
+            str(n): int(v) for n, v in _psch.declared_maxima(
+                _psch.parameters_from_ers(project_root)).items()
+            if _is_pos_int(int(v))
+        }
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+@dataclass(frozen=True)
+class MaxgeoDemand:
+    """What a testbench's ``# MAXGEO`` marker actually PROVES about the table.
+
+    ``proven``     -- the marker names the dim AND carries its declared maximum.
+                      Real, attributable evidence.
+    ``value_only`` -- the declared maximum appears in the marker, but under some
+                      OTHER dim's name. Two dims of the same extent (a 4096-deep
+                      framebuffer and a 4096-byte read burst) make this happen
+                      constantly, and the name-agnostic gate counted it as
+                      coverage -- claiming a compute-lane maximum was exercised
+                      because a bus burst happened to be the same number.
+    ``missing``    -- no marker evidence of any kind.
+
+    The three partition the declared table, which is the point: the gate's demand
+    (``missing``), the generator's confession (``value_only | missing``) and the
+    declared table (all three) are now three views of ONE computation.
+    """
+
+    proven: dict[str, int] = field(default_factory=dict)
+    value_only: dict[str, int] = field(default_factory=dict)
+    missing: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def unproven(self) -> dict[str, int]:
+        """Everything without name-attributable evidence -- the honest confession."""
+        return {**self.value_only, **self.missing}
+
+    def describe(self) -> str:
+        return (
+            f"proven={self.proven} value_only(weak)={self.value_only} "
+            f"missing={self.missing}"
+        )
+
+
+def maxgeo_demand(declared_dims: dict | None, marker: dict | None) -> MaxgeoDemand:
+    """Split a declared table against a testbench's parsed ``# MAXGEO`` pairs.
+
+    Pure function -- no disk, no testbench text, no DUT. ``marker`` is
+    ``{name: value}`` as parsed from the artifact's ``# MAXGEO:`` lines.
+    """
+    dims = {str(k): int(v) for k, v in (declared_dims or {}).items()
+            if _is_pos_int(v)}
+    pairs = {str(k): int(v) for k, v in (marker or {}).items()
+             if _is_pos_int(v)}
+    values = set(pairs.values())
+    proven: dict[str, int] = {}
+    value_only: dict[str, int] = {}
+    missing: dict[str, int] = {}
+    for name, mx in sorted(dims.items()):
+        if pairs.get(name) == mx:
+            proven[name] = mx
+        elif mx in values:
+            value_only[name] = mx
+        else:
+            missing[name] = mx
+    return MaxgeoDemand(proven=proven, value_only=value_only, missing=missing)
+
+
+def token_match(dim_name: str, key: str) -> bool:
+    """True when a declared dimension NAME and a stimulus KEY name the same axis.
+
+    Subset in either direction, never a bare intersection: ``frame_width`` and
+    ``burst_width`` share the token ``width`` yet are different axes, so an
+    intersection rule would let a driven burst width claim coverage of a frame
+    width. ``{width} <= {frame, width}`` (key ``width`` for dim ``frame_width``)
+    and an exact match both pass; ``{burst,width}`` vs ``{frame,width}`` does not.
+    """
+    a, b = _tokens(dim_name), _tokens(key)
+    if not a or not b:
+        return False
+    return a <= b or b <= a
+
+
+def functional_maxgeo_dims(
+    scalars: dict | None, declared_dims: dict | None
+) -> dict[str, int]:
+    """Declared maxima a FUNCTIONAL host-flow case DRIVES, by direct evidence.
+
+    ``scalars`` is the integer-valued subset of the chosen acceptance case's
+    stimulus dict -- the numbers the generated testbench actually writes onto the
+    pins for that case. A dim is claimed only when BOTH hold:
+
+      * some scalar key :func:`token_match`-es the dimension name, and
+      * that scalar's VALUE equals the declared maximum.
+
+    Everything else stays in the ``MAXGEO_NOT_COVERED`` confession. A marker is a
+    claim about traffic that exists; a dimension we merely believe is implied by
+    a big case is not driven evidence and is not claimed.
+    """
+    dims = {str(k): int(v) for k, v in (declared_dims or {}).items()
+            if _is_pos_int(v)}
+    vals = {str(k): int(v) for k, v in (scalars or {}).items()
+            if _is_pos_int(v)}
+    out: dict[str, int] = {}
+    for name, mx in sorted(dims.items()):
+        for key, val in sorted(vals.items()):
+            if val == mx and token_match(name, key):
+                out[name] = mx
+                break
+    return out

--- a/orchestrator/langgraph/bfm_lib/stimulus.py
+++ b/orchestrator/langgraph/bfm_lib/stimulus.py
@@ -17,15 +17,26 @@ following the QSPI-slave *host flow*:
 The stimulus->pins mapping is the documented QSPI-slave convention (PROTOCOL.md
 "Per-design mapping"): a stimulus ``dict`` contributes its ``key`` bytes (if
 any) followed by its ``data``/``plaintext``/``payload`` bytes to the IN window,
-and a block/length scalar to CFG0. This covers the aes exemplar and the
-data-in/result-out designs (fft/raster). Anything that does not fit returns
-``None`` so the caller falls back to the LLM BFM with a loud advisory.
+and a block/length scalar to CFG0. This covers the block-cipher exemplar and the
+data-in/result-out designs. Anything that does not fit returns ``None`` so the
+caller falls back to the LLM BFM with a loud advisory.
+
+TWO cases, not one. The canonical (first) acceptance case is the KAT: small,
+deterministic, representative -- and therefore NOT a max-geometry test. A run
+that ships only that case can pass every fixed-small-geometry check and still
+carry an index/length counter that wraps below the declared maximum. So this
+module also selects, GENERICALLY, the case that drives the largest geometry
+(:func:`select_max_geometry_case`, ranked by IN-payload bytes then the CFG0
+scalar) and bakes its golden the same generation-time way. No case-name
+literals, no design-specific keys: the ranking is over magnitudes the host flow
+actually drives on the pins.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -70,11 +81,33 @@ def _flatten_bytes(value: Any) -> bytes:
 
 
 def _import_from_path(path: Path, mod_name: str):
+    """Import a run-input module by path, with its OWN directory importable.
+
+    The acceptance stimulus routinely imports its sibling golden by bare module
+    name (``from <design>_golden import make_stimulus``). Loading it by path
+    alone leaves that sibling unresolvable, so whether the plan builds at all
+    depended on whether some EARLIER engine step happened to have put
+    ``inputs/`` on ``sys.path`` first -- an import-order coincidence, and a
+    silent fallback to the LLM BFM when it did not hold. The parent directory is
+    inserted for the duration of the exec and removed after, so nothing leaks
+    into the process's import path.
+    """
     spec = importlib.util.spec_from_file_location(mod_name, str(path))
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot load {path}")
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    parent = str(path.resolve().parent)
+    injected = parent not in sys.path
+    if injected:
+        sys.path.insert(0, parent)
+    try:
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    finally:
+        if injected:
+            try:
+                sys.path.remove(parent)
+            except ValueError:  # pragma: no cover - another thread removed it
+                pass
     return mod
 
 
@@ -102,52 +135,63 @@ def _load_reference(project_root: str) -> Callable | None:
     return None
 
 
+def load_acceptance_cases(project_root: str) -> list[tuple[str, Any]]:
+    """EVERY acceptance case ``(name, stimulus)`` for this run, in declared order.
+
+    ``[]`` when the run declares no acceptance stimulus at all. A single-stimulus
+    module (``stimulus = ...`` rather than ``cases = [...]``) yields one entry, so
+    callers never special-case the shape.
+    """
+    p = Path(project_root) / "inputs" / "acceptance_stimulus.py"
+    if not p.exists():
+        p2 = Path(project_root) / "inputs" / "model_stimulus.py"
+        if not p2.exists():
+            return []
+        try:
+            mod = _import_from_path(p2, "_cs_model_stim")
+        except Exception:  # noqa: BLE001
+            return []
+        stim = getattr(mod, "stimulus", None)
+        return [("model_stimulus", stim)] if stim is not None else []
+    try:
+        mod = _import_from_path(p, "_cs_accept_stim")
+    except Exception:  # noqa: BLE001
+        return []
+    cases = getattr(mod, "cases", None)
+    out: list[tuple[str, Any]] = []
+    if cases:
+        for entry in cases:
+            try:
+                name, stim = entry
+            except (TypeError, ValueError):
+                continue
+            out.append((str(name), stim))
+        return out
+    stim = getattr(mod, "stimulus", None)
+    return [("stimulus", stim)] if stim is not None else []
+
+
 def _load_acceptance_case(project_root: str) -> tuple[str, Any] | None:
     """Load the FIRST acceptance case ``(name, stimulus)`` for this run.
 
     The deterministic DV uses the first acceptance case (the KAT) as its
     canonical vector -- deterministic and representative.
     """
-    p = Path(project_root) / "inputs" / "acceptance_stimulus.py"
-    if not p.exists():
-        p2 = Path(project_root) / "inputs" / "model_stimulus.py"
-        if not p2.exists():
-            return None
-        try:
-            mod = _import_from_path(p2, "_cs_model_stim")
-        except Exception:  # noqa: BLE001
-            return None
-        stim = getattr(mod, "stimulus", None)
-        return ("model_stimulus", stim) if stim is not None else None
-    try:
-        mod = _import_from_path(p, "_cs_accept_stim")
-    except Exception:  # noqa: BLE001
-        return None
-    cases = getattr(mod, "cases", None)
-    if cases:
-        name, stim = cases[0]
-        return (str(name), stim)
-    stim = getattr(mod, "stimulus", None)
-    return ("stimulus", stim) if stim is not None else None
+    cases = load_acceptance_cases(project_root)
+    return cases[0] if cases else None
 
 
-def build_plan_from_run(
-    project_root: str, contract: QSPIContract
-) -> StimulusPlan | None:
-    """Build a deterministic host-flow plan + oracle from the run artifacts.
+def map_stimulus(stim: Any) -> tuple[bytes, int | None]:
+    """``(IN-window bytes, CFG0 scalar)`` for one stimulus -- the host-flow
+    convention, in ONE place so case selection and plan construction rank and
+    drive the same magnitudes.
 
-    Returns None when a contract-faithful, self-contained plan cannot be
-    derived (no acceptance stimulus, no pure reference, or a stimulus shape the
-    host-flow convention does not cover) -- the caller then falls back to the
-    LLM BFM with a loud advisory.
+    A stimulus ``dict`` contributes ``key`` bytes then ``data``/``plaintext``/
+    ``payload`` bytes; the CFG0 scalar comes from the first of ``n_blocks``,
+    ``length``, ``count``, ``mode``, ``cfg0`` that is present, else defaults to
+    the number of 16-byte blocks in the data window. A non-dict stimulus is
+    flattened whole into the IN window.
     """
-    case = _load_acceptance_case(project_root)
-    ref = _load_reference(project_root)
-    if case is None or ref is None:
-        return None
-    case_name, stim = case
-
-    # Map stimulus -> IN-window bytes + CFG0 scalar (host-flow convention).
     key_bytes = b""
     data_bytes = b""
     cfg0_val: int | None = None
@@ -166,23 +210,72 @@ def build_plan_from_run(
     else:
         data_bytes = _flatten_bytes(stim)
 
-    in_bytes = key_bytes + data_bytes
+    if cfg0_val is None and data_bytes:
+        cfg0_val = max(1, (len(data_bytes) + 15) // 16)
+    return key_bytes + data_bytes, cfg0_val
+
+
+def stimulus_scalars(stim: Any) -> dict[str, int]:
+    """The integer-valued entries of a stimulus dict (``{}`` for other shapes).
+
+    These are the design's OWN parameter names carrying the values this case
+    drives -- the evidence a functional max-geometry marker is allowed to rest
+    on. Names are opaque data: nothing here knows any design's vocabulary.
+    """
+    if not isinstance(stim, dict):
+        return {}
+    out: dict[str, int] = {}
+    for k, v in stim.items():
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, int):
+            out[str(k)] = v
+        elif isinstance(v, float) and float(v).is_integer():
+            out[str(k)] = int(v)
+    return out
+
+
+def select_max_geometry_case(
+    cases: list[tuple[str, Any]]
+) -> tuple[str, Any] | None:
+    """The acceptance case that drives the LARGEST geometry, chosen generically.
+
+    Ranked by ``(len(IN payload bytes), CFG0 scalar)`` -- the two magnitudes the
+    QSPI host flow actually puts on the pins, so the winner is the case whose
+    length/index counters run furthest. Ties keep the earlier-declared case, so
+    selection is deterministic for a given acceptance module. ``None`` for an
+    empty list.
+    """
+    best: tuple[str, Any] | None = None
+    best_key: tuple[int, int] | None = None
+    for name, stim in cases or []:
+        try:
+            in_bytes, cfg0 = map_stimulus(stim)
+        except Exception:  # noqa: BLE001 - a malformed case is skipped, not fatal
+            continue
+        key = (len(in_bytes), int(cfg0 or 0))
+        if best_key is None or key > best_key:
+            best_key, best = key, (str(name), stim)
+    return best
+
+
+def _plan_from_case(
+    case_name: str, stim: Any, ref: Callable, contract: QSPIContract
+) -> StimulusPlan | None:
+    """One acceptance case -> a concrete host-flow plan with a BAKED oracle.
+
+    The golden reference is evaluated HERE, at generation time, exactly once per
+    case -- the emitted testbench carries bytes, never an import of the model.
+    """
+    in_bytes, cfg0_val = map_stimulus(stim)
     if not in_bytes:
         return None
-
-    # Reference oracle (pure). Must return bytes-like.
     try:
         expected = bytes(_flatten_bytes(ref(stim)))
     except Exception:  # noqa: BLE001
         return None
     if not expected:
         return None
-
-    # CFG0 default: number of 16-byte blocks in the data window (aes/stream
-    # convention) when the design did not name a scalar explicitly.
-    if cfg0_val is None and data_bytes:
-        cfg0_val = max(1, (len(data_bytes) + 15) // 16)
-
     plan = StimulusPlan(
         out_addr=contract.out_addr,
         out_len=len(expected),
@@ -193,6 +286,76 @@ def build_plan_from_run(
         plan.cfg.append((contract.cfg0_addr, cfg0_val, 4))
     plan.writes.append((contract.in_addr, in_bytes))
     return plan
+
+
+@dataclass
+class MaxGeoCase:
+    """The largest acceptance case, with its baked plan and driven scalars.
+
+    ``is_primary`` is True when the largest case IS the canonical first case --
+    the generator then emits no second test (there is nothing extra to drive)
+    but still advertises the ``# MAXGEO_CASE`` marker, because the primary test
+    genuinely IS the max-geometry case and the artifact should say so.
+    """
+
+    plan: StimulusPlan
+    scalars: dict[str, int] = field(default_factory=dict)
+    in_bytes: int = 0
+    out_bytes: int = 0
+    cfg0: int = 0
+    is_primary: bool = False
+
+
+def build_max_geometry_case(
+    project_root: str, contract: QSPIContract, primary_case_name: str = ""
+) -> MaxGeoCase | None:
+    """Select + bake the maximum-configuration acceptance case for this run.
+
+    ``None`` when the run declares no acceptance cases, no pure reference, or the
+    winning case's stimulus shape the host-flow convention does not cover -- the
+    generator then emits exactly what it emitted before this existed.
+    """
+    cases = load_acceptance_cases(project_root)
+    if not cases:
+        return None
+    ref = _load_reference(project_root)
+    if ref is None:
+        return None
+    chosen = select_max_geometry_case(cases)
+    if chosen is None:
+        return None
+    case_name, stim = chosen
+    plan = _plan_from_case(case_name, stim, ref, contract)
+    if plan is None:
+        return None
+    in_bytes = sum(len(d) for (_a, d) in plan.writes)
+    cfg0 = plan.cfg[0][1] if plan.cfg else 0
+    return MaxGeoCase(
+        plan=plan,
+        scalars=stimulus_scalars(stim),
+        in_bytes=in_bytes,
+        out_bytes=plan.out_len,
+        cfg0=int(cfg0),
+        is_primary=bool(primary_case_name) and case_name == primary_case_name,
+    )
+
+
+def build_plan_from_run(
+    project_root: str, contract: QSPIContract
+) -> StimulusPlan | None:
+    """Build a deterministic host-flow plan + oracle from the run artifacts.
+
+    Returns None when a contract-faithful, self-contained plan cannot be
+    derived (no acceptance stimulus, no pure reference, or a stimulus shape the
+    host-flow convention does not cover) -- the caller then falls back to the
+    LLM BFM with a loud advisory.
+    """
+    case = _load_acceptance_case(project_root)
+    ref = _load_reference(project_root)
+    if case is None or ref is None:
+        return None
+    case_name, stim = case
+    return _plan_from_case(case_name, stim, ref, contract)
 
 
 def load_plan_json(path: str) -> StimulusPlan:

--- a/orchestrator/langgraph/drc_verdict.py
+++ b/orchestrator/langgraph/drc_verdict.py
@@ -11,7 +11,7 @@ DRC run that produced NO REPORT AT ALL as::
 
     {"pass": false, "violation_count": -1}   ->   stage {"ok": false, "violations": -1}
 
-Two real macros in ``exp-raster-macro-20260727`` (``w32_d64``, ``w9_d512``)
+Two real macros from a validation run (``w32_d64``, ``w9_d512``)
 carry exactly that, and the ``precheck_magic_drc.rpt`` those verdicts name was
 never written -- Magic produced nothing even though the binary was on PATH.
 ``-1`` was *intended* as a "could not measure" sentinel, but every consumer read

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -87,7 +87,7 @@ def parse_verilog_ports(rtl_path: str, module: str | None = None) -> VerilogModu
 
     ``module`` selects WHICH module to parse; without it the first one wins,
     which is frequently the wrong answer. A generated block file commonly
-    declares its internal stages first -- raster_scan_pipeline.v declares four
+    declares its internal stages first -- one measured block file declared four
     sub-stages before the block itself at line 668 -- so integration judged a
     sub-stage's ports as the block's interface and raised 22 wiring hazards for
     a block that conforms perfectly. Callers that know the block name should

--- a/orchestrator/langgraph/macro_prebind.py
+++ b/orchestrator/langgraph/macro_prebind.py
@@ -168,7 +168,7 @@ def macro_ports(verilog_path) -> set[str]:
     A missing name here is read by ``_ports_for`` as "the macro has no such pin",
     so the binder leaves it unconnected and it floats low -- a dropped ``addr0``
     is a memory stuck at word zero, and a dropped ``wmask0`` is what suppressed
-    every framebuffer write in exp-raster-macro-20260727. The previous regex
+    every write to a wrapped memory on a validation run. The previous regex
     (``[^;)]*``) could not cross a ``)``, so it lost the name in
     ``input [$clog2(DEPTH)-1:0] addr0;`` -- a form the sky130 macro family and
     plenty of generated models use.

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -6768,7 +6768,7 @@ async def integration_check_node(state: OrchestratorState) -> dict:
 
         # BLOCK-RTL COMPLETENESS GATE: refuse to assemble a chip that is MISSING
         # a block. `discover_block_rtl` used to drop an unresolvable block
-        # SILENTLY, which structurally DELETES it from the chip: the raster run
+        # SILENTLY, which structurally DELETES it from the chip: one graded run
         # lost its locked Caravel pad adapter (whose file is
         # rtl/user_project_wrapper.v, NOT <block_name>.v, because an interface
         # contract locks the module name), so `detect_wrapper_block` returned
@@ -8608,9 +8608,14 @@ async def begin_rtl_pass_node(state: OrchestratorState) -> dict:
     the already-computed list (R8).
     """
     pr = state.get("project_root", str(PROJECT_ROOT))
-    log(f"\n{'='*60}", CYAN)
-    log("  µARCH GATE CLEAN -> beginning RTL pass (pass 2)", CYAN)
-    log(f"{'='*60}", CYAN)
+    # run3-followups: the banner reflects the ACTUAL gate outcome -- a green
+    # CLEAN was printed four lines after an advisory-dismissed model mismatch,
+    # suppressing a true early detection for ~2.5 h of downstream work.
+    from orchestrator.langgraph.pipeline_helpers import uarch_gate_banner
+    _banner, _colour = uarch_gate_banner(state.get("model_integration_result"))
+    log(f"\n{'='*60}", _colour)
+    log(f"  {_banner}", _colour)
+    log(f"{'='*60}", _colour)
     write_graph_event(pr, "Begin RTL Pass", "graph_node_exit", {
         "pipeline_phase": "rtl",
     })
@@ -9357,7 +9362,7 @@ def _maxgeo_conformance_scope(
         the gate exactly as before.
 
     What it relaxes is only this: a compute-lane dimension (frame_width,
-    num_triangles, ...) cannot be driven by a testbench that has no compute
+    record counts, coordinate extents, ...) cannot be driven by a testbench that has no compute
     oracle, so demanding it makes the gate a permanent brick wall for that whole
     class of run rather than a defect detector. Those dims are reported, logged
     loudly, and carried forward as a defect -- never silently dropped.
@@ -9450,19 +9455,27 @@ def _maxgeo_gate_verdict(
     try:
         if not _maxgeo_gate_enabled():
             return None
-        dims = _declared_dimensions(project_root)
+        # run3-followups: single-sourced declared table (byte-equality with
+        # the legacy _declared_dimensions is pinned by test).
+        from orchestrator.langgraph.bfm_lib import maxgeo as _maxgeo_lib
+        dims = _maxgeo_lib.declared_dimensional_maxima(project_root)
         if not dims:
             return None
         marker = _tb_maxgeo_pairs(tb_path)
-        marker_values = set(marker.values())
-        missing = {
-            name: mx for name, mx in dims.items() if mx not in marker_values
-        }
+        # run3-followups: single-sourced demand partition (bfm_lib.maxgeo).
+        # `missing` is provably identical to the old value-set computation;
+        # `value_only` newly NAMES the dims whose only evidence is a value
+        # collision with another marker pair, so the gate's number and the
+        # TB's confession finally agree.
+        _demand = _maxgeo_lib.maxgeo_demand(dims, marker)
+        missing = _demand.missing
+        value_only = _demand.value_only
         if not missing:
             # run3-followups: an evaluated PASS is a verdict, not a silence --
             # the caller logs it so a suppressed gate can never read as green.
             return {"verdict": "pass", "declared_dims": dims,
-                    "marker_pairs": marker}
+                    "marker_pairs": marker,
+                    "value_only_dims": value_only}
         scoped = _maxgeo_conformance_scope(
             project_root, tb_path, tb_result, dims, marker, missing)
         if scoped is not None:
@@ -9487,6 +9500,7 @@ def _maxgeo_gate_verdict(
                     "advisory": True,
                     "scope": "functional-max-case",
                     "uncovered_dims": missing,
+                    "value_only_dims": value_only,
                     "declared_dims": dims,
                     "marker_pairs": marker,
                     "functional_max_case": case,
@@ -9512,13 +9526,15 @@ def _maxgeo_gate_verdict(
             f"  declared maxima : {dims}\n"
             f"  marker pairs    : {marker or '(no # MAXGEO marker found)'}\n"
             f"  uncovered dims  : {missing}\n"
+            f"  value-collision-only (not individually proven): {value_only}\n"
             "Fix: regenerate/edit the testbench to drive a max-geometry case "
             "(sparse/short content at the maximum dimensions is acceptable if a "
             "full workload is too slow -- the point is to exercise the index/"
             "address widths at maximum extent) and emit the marker."
         )
         return {"reason": reason, "declared_dims": dims,
-                "marker_pairs": marker, "uncovered_dims": missing}
+                "marker_pairs": marker, "uncovered_dims": missing,
+                "value_only_dims": value_only}
     except Exception:  # noqa: BLE001
         return None
 
@@ -9744,7 +9760,7 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                         # advisory and PROCEEDED on the LLM-authored, DUT-co-tuned
                         # BFM: DV was silently downgraded exactly when the design
                         # is most likely to be non-conformant, and the run still
-                        # reported "INTEGRATION DV PASSED" (exp-raster-macro-
+                        # reported "INTEGRATION DV PASSED" (observed live on a graded run
                         # 20260727). It is now the run's normal tb_generation
                         # interrupt (retry/fix_rtl/fix_tb/abort), per the local
                         # honest-gate idiom.
@@ -10378,7 +10394,7 @@ def _load_ers_validation_context(project_root: str) -> tuple[str, int]:
 # therefore STABLE, path: every integration-DV failure of the same stage writes
 # the same filename. So a failed or skipped audit leaves the PREVIOUS failure's
 # verdict lying in the exact place the next one is read from. Observed on the
-# raster run: a 0.99-confidence TESTBENCH_BUG audit describing an already-fixed
+# graded run: a 0.99-confidence TESTBENCH_BUG audit describing an already-fixed
 # crash sat next to a new, different failure and was quoted as its diagnosis.
 #
 # A verdict is only about the failure it actually read, so it now carries that

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -9297,6 +9297,33 @@ def _tb_maxgeo_pairs(tb_path: str) -> dict:
     return pairs
 
 
+_MAXGEO_CASE_RE = re.compile(r"#\s*MAXGEO_CASE:\s*(.+)$")
+
+
+def _tb_maxgeo_case(tb_path: str) -> dict:
+    """Parse the ``# MAXGEO_CASE: name=<s> cfg0=<int> in_bytes=<int>
+    out_bytes=<int>`` marker the deterministic codegen emits for its
+    maximum-configuration functional test. ``{}`` when absent."""
+    out: dict = {}
+    try:
+        text = Path(tb_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return out
+    for line in text.splitlines():
+        m = _MAXGEO_CASE_RE.search(line)
+        if not m:
+            continue
+        for tok in m.group(1).split():
+            if "=" not in tok:
+                continue
+            k, _, v = tok.partition("=")
+            try:
+                out[k] = int(v)
+            except ValueError:
+                out[k] = v
+    return out
+
+
 def _maxgeo_conformance_scope_enabled() -> bool:
     """Scope the MAX-GEOMETRY demand for the ENGINE'S OWN compute-lane-independent
     conformance testbench. Default ON; ``CORESMITH_MAXGEO_CONFORMANCE_SCOPE=0``
@@ -9401,9 +9428,12 @@ def _maxgeo_conformance_scope(
 def _maxgeo_gate_verdict(
     project_root: str, tb_path: str, tb_result: dict | None = None
 ) -> dict | None:
-    """``None`` -> gate passes / no-ops. Otherwise a violation dict: the design
-    declares dimensional maxima but the testbench's ``# MAXGEO`` marker does not
-    prove a max-geometry case for every declared dimension.
+    """``None`` -> gate disabled or no declared dims (a true no-op).
+    ``{"verdict": "pass", ...}`` -> evaluated and fully covered (callers LOG
+    it). ``{"advisory": True, ...}`` -> covered in scope with a loud recorded
+    gap. Anything else -> violation dict: the design declares dimensional
+    maxima but the testbench's ``# MAXGEO`` marker does not prove a
+    max-geometry case for every declared dimension.
 
     NAME-AGNOSTIC: each declared dimension's max VALUE must appear as a marker
     ``key=value`` pair (the key name is free-form data). Testing at the declared
@@ -9429,11 +9459,47 @@ def _maxgeo_gate_verdict(
             name: mx for name, mx in dims.items() if mx not in marker_values
         }
         if not missing:
-            return None
+            # run3-followups: an evaluated PASS is a verdict, not a silence --
+            # the caller logs it so a suppressed gate can never read as green.
+            return {"verdict": "pass", "declared_dims": dims,
+                    "marker_pairs": marker}
         scoped = _maxgeo_conformance_scope(
             project_root, tb_path, tb_result, dims, marker, missing)
         if scoped is not None:
             return scoped
+        # run3-followups: a functional MAXIMUM-CONFIGURATION case (baked by the
+        # deterministic codegen, advertised via # MAXGEO_CASE) drives the max
+        # config register value and the full IN/OUT payload extents end-to-end
+        # against the golden -- the 2^n index/address wrap class this gate
+        # exists to catch IS exercised. Remaining per-dimension attainment is
+        # downgraded to a LOUD advisory gap (carried-forward defect), the same
+        # treatment as the bus-scoped conformance path. The gate stays HARD
+        # when no such case exists or its extents miss the declared maxima.
+        case = _tb_maxgeo_case(tb_path)
+        if case:
+            dim_values = set(dims.values())
+            attained = all(
+                isinstance(case.get(k), int) and case[k] in dim_values
+                for k in ("cfg0", "in_bytes", "out_bytes")
+            )
+            if attained:
+                return {
+                    "advisory": True,
+                    "scope": "functional-max-case",
+                    "uncovered_dims": missing,
+                    "declared_dims": dims,
+                    "marker_pairs": marker,
+                    "functional_max_case": case,
+                    "reason": (
+                        "MAX-GEOMETRY gate: functional max-configuration case "
+                        f"{case} drives the maximum configuration and full "
+                        "payload extents end-to-end against the golden "
+                        "reference, exercising the 2^n index/address wrap "
+                        "class. Per-dimension attainment for "
+                        f"{sorted(missing)} is not individually proven -- "
+                        "recorded as a loud advisory gap, not a hard failure."
+                    ),
+                }
         reason = (
             "MAX-GEOMETRY DV GATE FAILED: the design declares dimensional "
             "maxima but the testbench does not exercise them. A chip can pass "
@@ -9835,6 +9901,7 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                 sim_log=error_msg,
                 sim_log_path="",
                 block_rtl_paths=block_rtl_paths,
+                            supported_actions=["retry", "fix_rtl", "fix_tb", "abort"],
             )
             payload = {
                 "type": "integration_dv_failure",
@@ -9872,35 +9939,28 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                     "contract_audit": contract_audit.get("audit_path", ""),
                 },
             }
-            response = interrupt(payload)
-            action = response.get("action", "abort")
+            # run3-followups: park in integration_dv_decision instead of a
+            # tail interrupt() (see the sim-failure branch for the
+            # one-cycle-late defect).
             write_graph_event(pr, "Integration DV", "graph_node_exit", {
                 "error": str(e),
                 "phase": "tb_generation",
-                "action": action,
+                "action": "pending_decision",
             })
-            dv_result = {
-                "passed": False,
-                "error": error_msg,
-                "phase": "tb_generation",
-                "test_count": 0,
-                "testbench_path": "",
-                "design_name": design_name,
-                "action_taken": action,
-                "contract_audit": contract_audit,
-                "contract_audit_path": contract_audit.get("audit_path", ""),
-            }
-            if action == "abort":
-                dv_result["aborted"] = True
-                log("  [INTEG-DV] Aborted", RED)
-            elif action in ("retry", "fix_rtl", "fix_tb"):
-                fix_desc = response.get("rtl_fix_description", "")
-                dv_result["fix_applied"] = fix_desc
-                log(f"  [INTEG-DV] Fix applied: {fix_desc}", GREEN)
             return {
-                "integration_dv_result": dv_result,
+                "integration_dv_result": {
+                    "passed": False,
+                    "pending_decision": True,
+                    "interrupt_payload": payload,
+                    "error": error_msg,
+                    "phase": "tb_generation",
+                    "test_count": 0,
+                    "testbench_path": "",
+                    "design_name": design_name,
+                    "contract_audit": contract_audit,
+                    "contract_audit_path": contract_audit.get("audit_path", ""),
+                },
                 "pipeline_done": False,
-                "pipeline_aborted": action == "abort",
             }
 
         tb_path = tb_result.get("testbench_path", "")
@@ -9955,26 +10015,46 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                     f"(non-blocking): {chip_equiv_result.get('reason','')}", YELLOW)
 
         # MAX-GEOMETRY gate (rung3-fixes-2): a green sim is NOT sufficient when
-        # the design declares dimensional maxima but the (freshly generated) TB
-        # never exercised them -- that is how a truncated index-width bug ships
-        # in a "verified" chip. Flip the DV to failed -> existing failure
-        # interrupt. Operator-reused TBs (fix_tb/fix_rtl) are trusted as-is.
-        if passed and not reuse_existing_tb:
+        # the design declares dimensional maxima but the TB never exercised
+        # them -- that is how a truncated index-width bug ships in a "verified"
+        # chip. Flip the DV to failed -> existing failure interrupt.
+        # run3-followups: the gate runs on EVERY passing cycle, including
+        # operator-reused TBs (fix_tb/fix_rtl). "Trusted as-is" silently
+        # DISARMED the gate on exactly the cycles that deserve more scrutiny --
+        # proven live when a clobbered 2-test TB passed DV with no MAXGEO line
+        # at all. Every evaluated outcome logs a verdict; silence now means
+        # only "gate disabled or no declared dims".
+        if passed:
             _mg = _maxgeo_gate_verdict(pr, tb_path, tb_result)
-            if _mg is not None and _mg.get("advisory"):
-                # SCOPED, not silent. The engine's own compute-lane-independent
-                # conformance TB drove every BUS maximum and cannot drive the
-                # compute lane; the gap is logged RED, written to the event
-                # stream, and carried forward as a defect so the final report
-                # and validation DV both see it.
-                log("  [INTEG-DV] MAX-GEOMETRY gate SCOPED to the bus contract "
-                    "(deterministic conformance TB, compute lane UNMODELED) -- "
-                    "this is NOT full max-geometry coverage. NOT COVERED: "
-                    f"{_mg['uncovered_dims']}", RED)
+            if reuse_existing_tb and _mg is not None:
+                log("  [INTEG-DV] MAX-GEOMETRY gate: evaluating an OPERATOR-"
+                    "REUSED testbench (fix_tb/fix_rtl) -- operator edits get "
+                    "more scrutiny, not less.", YELLOW)
+            if _mg is not None and _mg.get("verdict") == "pass":
+                log("  [INTEG-DV] MAX-GEOMETRY gate PASS -- every declared "
+                    f"maximum appears in the TB markers: "
+                    f"{_mg.get('marker_pairs', {})}", GREEN)
+                write_graph_event(pr, "Integration DV", "maxgeo_gate_pass", {
+                    "gate": "maxgeo",
+                    "marker_pairs": _mg.get("marker_pairs", {}),
+                })
+            elif _mg is not None and _mg.get("advisory"):
+                # SCOPED, not silent. Either the engine's compute-lane-
+                # independent conformance TB drove every BUS maximum and cannot
+                # drive the compute lane, or a functional max-configuration
+                # case covered the wrap class without per-dimension proof; the
+                # gap is logged RED, written to the event stream, and carried
+                # forward as a defect so the final report and validation DV
+                # both see it.
+                _mg_scope = _mg.get("scope", "bus-contract-only")
+                log("  [INTEG-DV] MAX-GEOMETRY gate ADVISORY "
+                    f"(scope={_mg_scope}) -- this is NOT full max-geometry "
+                    f"coverage. NOT COVERED: {_mg['uncovered_dims']}", RED)
                 write_graph_event(pr, "Integration DV", "maxgeo_gate_scoped", {
                     "gate": "maxgeo",
-                    "scope": "bus-contract-only",
+                    "scope": _mg_scope,
                     "bus_covered": _mg.get("bus_covered", {}),
+                    "functional_max_case": _mg.get("functional_max_case", {}),
                     "uncovered_dims": _mg.get("uncovered_dims", {}),
                 })
                 record_carried_forward_defect(pr, {
@@ -9982,10 +10062,9 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
                     "kind": "max_geometry_not_covered",
                     "advisory": True,
                     "unmodeled": (
-                        "compute-lane dimensional maxima never driven at "
+                        "dimensional maxima never individually driven at "
                         f"maximum extent: {_mg.get('uncovered_dims', {})} "
-                        "(integration DV is the deterministic QSPI conformance "
-                        "TB -- no compute oracle)"
+                        f"(scope={_mg_scope})"
                     ),
                     "first_divergence_block": "",
                     "note": _mg["reason"],
@@ -10078,6 +10157,7 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
             sim_log=sim_log,
             sim_log_path=sim_result.get("log_path", ""),
             block_rtl_paths=block_rtl_paths,
+                    supported_actions=["retry", "fix_rtl", "fix_tb", "abort"],
         )
         _record_dv_row(
             pr, block=design_name, scope="chip", source="gate", passed=False,
@@ -10138,56 +10218,116 @@ async def integration_dv_node(state: OrchestratorState) -> dict:
         ):
             payload["supported_actions"].insert(-1, "skip")
 
-        response = interrupt(payload)
-
-        action = response.get("action", "abort")
+        # run3-followups: do NOT call interrupt() here. LangGraph re-executes
+        # this entire node from the top on resume, so a response delivered to
+        # a tail interrupt() is consumed ONE FULL CYCLE LATE -- the intervening
+        # default cycle regenerates the testbench and destroys operator fix_tb
+        # edits (proven live: three consecutive clobbers, then a false PASS on
+        # the clobbered TB). The failure parks in integration_dv_decision,
+        # whose re-execution is just the interrupt() call: the response lands
+        # immediately and the TB on disk at decision time is the TB the next
+        # cycle sees.
         write_graph_event(pr, "Integration DV", "graph_node_exit", {
-            "action": action,
+            "action": "pending_decision",
             "passed": False,
             "test_count": test_count,
         })
-
-        dv_result = {
-            "passed": False,
-            "test_count": test_count,
-            "testbench_path": tb_path,
-            "sim_log_path": sim_result.get("log_path", ""),
-            "design_name": design_name,
-            "action_taken": action,
-            "contract_audit": contract_audit,
-            "contract_audit_path": contract_audit.get("audit_path", ""),
-            "chip_equiv_result": chip_equiv_result,
-        }
-
-        if action == "skip":
-            dv_result["skipped_by_user"] = True
-            log("  [INTEG-DV] Skipped by user/agent", YELLOW)
-        elif action == "abort":
-            dv_result["aborted"] = True
-            log("  [INTEG-DV] Aborted", RED)
-        elif action in ("retry", "fix_rtl", "fix_tb"):
-            fix_desc = response.get("rtl_fix_description", "")
-            log(f"  [INTEG-DV] Fix applied: {fix_desc}", GREEN)
-            dv_result["fix_applied"] = fix_desc
-            if action == "fix_tb":
-                # A-Fix 5(c): the operator hand-edited the testbench. The chip
-                # sim will re-run trusting that TB, but the chip-top equivalence
-                # gate (A-Fix 5d) remains the gate of record -- record + LOUDLY
-                # flag the operator TB edit so a loosened TB can't quietly pass.
-                dv_result["tb_operator_edited"] = True
-                log(
-                    "  [INTEG-DV] fix_tb: operator EDITED the testbench "
-                    "(tb_operator_edited=True). A green sim on an operator-edited "
-                    "TB is NOT sufficient -- the chip-top RTL-vs-model "
-                    "equivalence gate is the gate of record.",
-                    YELLOW,
-                )
-
         return {
-            "integration_dv_result": dv_result,
+            "integration_dv_result": {
+                "passed": False,
+                "pending_decision": True,
+                "interrupt_payload": payload,
+                "test_count": test_count,
+                "testbench_path": tb_path,
+                "sim_log_path": sim_result.get("log_path", ""),
+                "design_name": design_name,
+                "contract_audit": contract_audit,
+                "contract_audit_path": contract_audit.get("audit_path", ""),
+                "chip_equiv_result": chip_equiv_result,
+            },
             "pipeline_done": False,
-            "pipeline_aborted": action == "abort",
         }
+
+
+async def integration_dv_decision_node(state: OrchestratorState) -> dict:
+    """Consume the operator's decision for a parked integration-DV failure.
+
+    Split out of ``integration_dv_node`` (run3-followups): a LangGraph resume
+    re-executes the interrupted node from the top, so an ``interrupt()`` at the
+    tail of the big DV node consumed its response one full default cycle late,
+    regenerating the testbench over operator edits before the action landed.
+    This node's body is ONLY the interrupt + response handling: re-execution is
+    free, the response lands immediately, and a fix_tb reuse sees the disk
+    state as of decision time."""
+    pr = state["project_root"]
+    dv = dict(state.get("integration_dv_result") or {})
+    payload = dv.get("interrupt_payload") or {
+        "type": "integration_dv_failure",
+        "supported_actions": ["retry", "fix_rtl", "fix_tb", "abort"],
+    }
+    response = interrupt(payload) or {}
+    action = response.get("action", "abort")
+    test_count = dv.get("test_count", 0)
+    write_graph_event(pr, "Integration DV", "graph_node_exit", {
+        "action": action,
+        "passed": False,
+        "test_count": test_count,
+    })
+
+    dv_result = dict(dv)
+    dv_result.pop("interrupt_payload", None)
+    dv_result["passed"] = False
+    dv_result["pending_decision"] = False
+    dv_result["action_taken"] = action
+
+    if action == "skip":
+        dv_result["skipped_by_user"] = True
+        log("  [INTEG-DV] Skipped by user/agent", YELLOW)
+    elif action == "abort":
+        dv_result["aborted"] = True
+        log("  [INTEG-DV] Aborted", RED)
+    elif action in ("retry", "fix_rtl", "fix_tb"):
+        fix_desc = response.get("rtl_fix_description", "")
+        log(
+            f"  [INTEG-DV] Fix applied (action={action}): "
+            f"{fix_desc or '(no description provided)'}",
+            GREEN,
+        )
+        dv_result["fix_applied"] = fix_desc
+        if action == "fix_tb":
+            # A-Fix 5(c): the operator hand-edited the testbench. The chip sim
+            # re-runs trusting that TB, and the MAX-GEOMETRY + chip-top
+            # equivalence gates evaluate it with MORE scrutiny -- record +
+            # LOUDLY flag the operator TB edit so a loosened TB can't quietly
+            # pass.
+            dv_result["tb_operator_edited"] = True
+            log(
+                "  [INTEG-DV] fix_tb: operator EDITED the testbench "
+                "(tb_operator_edited=True). A green sim on an operator-edited "
+                "TB is NOT sufficient -- the MAX-GEOMETRY and chip-top "
+                "equivalence gates still evaluate it.",
+                YELLOW,
+            )
+
+    return {
+        "integration_dv_result": dv_result,
+        "pipeline_done": False,
+        "pipeline_aborted": action == "abort",
+    }
+
+
+def route_after_integration_dv_decision(state: OrchestratorState) -> str:
+    """Route the operator's decision back into integration DV or terminate."""
+    result = state.get("integration_dv_result") or {}
+    if result.get("action_taken") in ("retry", "fix_rtl", "fix_tb"):
+        return "integration_dv"
+    return END
+
+
+route_after_integration_dv_decision.__edge_labels__ = {
+    "integration_dv": "RETRY / FIX",
+    END: "DONE",
+}
 
 
 def _load_ers_validation_context(project_root: str) -> tuple[str, int]:
@@ -10320,6 +10460,7 @@ async def _run_top_level_contract_audit(
     sim_log: str = "",
     sim_log_path: str = "",
     block_rtl_paths: dict[str, str] | None = None,
+    supported_actions: list[str] | None = None,
 ) -> dict:
     """Run contract audit for a top-level DV failure.
 
@@ -10402,6 +10543,28 @@ async def _run_top_level_contract_audit(
     )
     if stale:
         log(f"  [CONTRACT-AUDIT] {stale}", RED)
+    # run3-followups: the audit's SEMANTIC recommendation (e.g. revise_uarch,
+    # forced by the agent for spec-level categories) may not be an offerable
+    # resume action for the parked interrupt -- the operator was told to take
+    # an action the resume endpoint rejects. Keep the semantic recommendation,
+    # and add the closest OFFERABLE action plus how to use it.
+    rec = str(result.get("recommended_action", "") or "")
+    if supported_actions and rec and rec not in supported_actions:
+        resume_action = ("retry" if "retry" in supported_actions
+                         else supported_actions[0])
+        result["recommended_resume_action"] = resume_action
+        result["recommended_action_note"] = (
+            f"'{rec}' is the audit's semantic recommendation but is not an "
+            "offerable resume action for this interrupt "
+            f"(offerable: {supported_actions}). Apply the fix at its source "
+            f"(spec/uarch documents), then resume with '{resume_action}' -- "
+            "regeneration will read the corrected documents."
+        )
+        log(
+            f"  [CONTRACT-AUDIT] recommended '{rec}' is not an offerable "
+            f"resume action; operator path: fix at source + '{resume_action}'",
+            YELLOW,
+        )
     result["audit_path"] = str(output_path)
     result["context_path"] = str(context_path)
     return result
@@ -10412,6 +10575,8 @@ def route_after_integration_dv(state: OrchestratorState) -> str:
     result = state.get("integration_dv_result") or {}
     if result.get("passed") is True:
         return "validation_dv"
+    if result.get("pending_decision"):
+        return "integration_dv_decision"
     if result.get("action_taken") in ("retry", "fix_rtl", "fix_tb"):
         return "integration_dv"
     return END
@@ -10419,6 +10584,7 @@ def route_after_integration_dv(state: OrchestratorState) -> str:
 
 route_after_integration_dv.__edge_labels__ = {
     "validation_dv": "Validation DV",
+    "integration_dv_decision": "Park for decision",
     "integration_dv": "Retry",
     END: "DONE",
 }
@@ -10642,6 +10808,7 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
                 sim_log=error_msg,
                 sim_log_path="",
                 block_rtl_paths=block_rtl_paths,
+                            supported_actions=["retry", "fix_rtl", "fix_tb", "abort"],
             )
             payload = {
                 "type": "validation_dv_failure",
@@ -10682,36 +10849,28 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
                     "contract_audit": contract_audit.get("audit_path", ""),
                 },
             }
-            response = interrupt(payload)
-            action = response.get("action", "abort")
+            # run3-followups: park in validation_dv_decision instead of a tail
+            # interrupt() (see integration_dv for the one-cycle-late defect).
             write_graph_event(pr, "Validation DV", "graph_node_exit", {
                 "error": str(e),
                 "phase": "tb_generation",
-                "action": action,
+                "action": "pending_decision",
             })
-            dv_result = {
-                "passed": False,
-                "error": error_msg,
-                "phase": "tb_generation",
-                "requirement_count": requirement_count,
-                "test_count": 0,
-                "testbench_path": "",
-                "design_name": design_name,
-                "action_taken": action,
-                "contract_audit": contract_audit,
-                "contract_audit_path": contract_audit.get("audit_path", ""),
-            }
-            if action == "abort":
-                dv_result["aborted"] = True
-                log("  [VALIDATION-DV] Aborted", RED)
-            elif action in ("retry", "fix_rtl", "fix_tb"):
-                fix_desc = response.get("rtl_fix_description", "")
-                dv_result["fix_applied"] = fix_desc
-                log(f"  [VALIDATION-DV] Fix applied: {fix_desc}", GREEN)
             return {
-                "validation_dv_result": dv_result,
+                "validation_dv_result": {
+                    "passed": False,
+                    "pending_decision": True,
+                    "interrupt_payload": payload,
+                    "error": error_msg,
+                    "phase": "tb_generation",
+                    "requirement_count": requirement_count,
+                    "test_count": 0,
+                    "testbench_path": "",
+                    "design_name": design_name,
+                    "contract_audit": contract_audit,
+                    "contract_audit_path": contract_audit.get("audit_path", ""),
+                },
                 "pipeline_done": False,
-                "pipeline_aborted": action == "abort",
             }
 
         tb_path = tb_result.get("testbench_path", "")
@@ -10861,6 +11020,7 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
             sim_log=sim_log,
             sim_log_path=sim_result.get("log_path", ""),
             block_rtl_paths=block_rtl_paths,
+                    supported_actions=["retry", "fix_rtl", "fix_tb", "abort"],
         )
         _record_dv_row(
             pr, block=design_name, scope="validation", source="gate", passed=False,
@@ -10914,54 +11074,106 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
         ):
             payload["supported_actions"].insert(-1, "skip")
 
-        response = interrupt(payload)
-        action = response.get("action", "abort")
+        # run3-followups: park in validation_dv_decision instead of a tail
+        # interrupt() (see integration_dv for the one-cycle-late defect).
         write_graph_event(pr, "Validation DV", "graph_node_exit", {
-            "action": action,
+            "action": "pending_decision",
             "passed": False,
             "test_count": test_count,
             "requirement_count": requirement_count,
         })
-
-        dv_result = {
-            "passed": False,
-            "test_count": test_count,
-            "requirement_count": requirement_count,
-            "testbench_path": tb_path,
-            "sim_log_path": sim_result.get("log_path", ""),
-            "design_name": design_name,
-            "action_taken": action,
-            "contract_audit": contract_audit,
-            "contract_audit_path": contract_audit.get("audit_path", ""),
-        }
-
-        if action == "skip":
-            dv_result["skipped_by_user"] = True
-            log("  [VALIDATION-DV] Skipped by explicit configuration", YELLOW)
-        elif action == "abort":
-            dv_result["aborted"] = True
-            log("  [VALIDATION-DV] Aborted", RED)
-        elif action in ("retry", "fix_rtl", "fix_tb"):
-            fix_desc = response.get("rtl_fix_description", "")
-            log(f"  [VALIDATION-DV] Fix applied: {fix_desc}", GREEN)
-            dv_result["fix_applied"] = fix_desc
-
         return {
-            "validation_dv_result": dv_result,
+            "validation_dv_result": {
+                "passed": False,
+                "pending_decision": True,
+                "interrupt_payload": payload,
+                "test_count": test_count,
+                "requirement_count": requirement_count,
+                "testbench_path": tb_path,
+                "sim_log_path": sim_result.get("log_path", ""),
+                "design_name": design_name,
+                "contract_audit": contract_audit,
+                "contract_audit_path": contract_audit.get("audit_path", ""),
+            },
             "pipeline_done": False,
-            "pipeline_aborted": action == "abort",
         }
 
 
-def route_after_validation_dv(state: OrchestratorState) -> str:
-    """Route after validation DV: terminal frontend pipeline."""
+async def validation_dv_decision_node(state: OrchestratorState) -> dict:
+    """Consume the operator's decision for a parked validation-DV failure.
+
+    Same split as ``integration_dv_decision_node`` (run3-followups): the
+    interrupt lives in its own node so the resume response is consumed
+    immediately instead of one regeneration cycle late."""
+    pr = state["project_root"]
+    dv = dict(state.get("validation_dv_result") or {})
+    payload = dv.get("interrupt_payload") or {
+        "type": "validation_dv_failure",
+        "supported_actions": ["retry", "fix_rtl", "fix_tb", "abort"],
+    }
+    response = interrupt(payload) or {}
+    action = response.get("action", "abort")
+    write_graph_event(pr, "Validation DV", "graph_node_exit", {
+        "action": action,
+        "passed": False,
+        "phase": dv.get("phase", "simulation"),
+        "test_count": dv.get("test_count", 0),
+        "requirement_count": dv.get("requirement_count", 0),
+    })
+
+    dv_result = dict(dv)
+    dv_result.pop("interrupt_payload", None)
+    dv_result["pending_decision"] = False
+    dv_result["action_taken"] = action
+
+    if action == "skip":
+        dv_result["skipped_by_user"] = True
+        log("  [VALIDATION-DV] Skipped by explicit configuration", YELLOW)
+    elif action == "abort":
+        dv_result["aborted"] = True
+        log("  [VALIDATION-DV] Aborted", RED)
+    elif action in ("retry", "fix_rtl", "fix_tb"):
+        fix_desc = response.get("rtl_fix_description", "")
+        log(
+            f"  [VALIDATION-DV] Fix applied (action={action}): "
+            f"{fix_desc or '(no description provided)'}",
+            GREEN,
+        )
+        dv_result["fix_applied"] = fix_desc
+
+    return {
+        "validation_dv_result": dv_result,
+        "pipeline_done": False,
+        "pipeline_aborted": action == "abort",
+    }
+
+
+def route_after_validation_dv_decision(state: OrchestratorState) -> str:
+    """Route the operator's decision back into validation DV or terminate."""
     result = state.get("validation_dv_result") or {}
     if result.get("action_taken") in ("retry", "fix_rtl", "fix_tb"):
         return "validation_dv"
     return END
 
 
+route_after_validation_dv_decision.__edge_labels__ = {
+    "validation_dv": "RETRY / FIX",
+    END: "DONE",
+}
+
+
+def route_after_validation_dv(state: OrchestratorState) -> str:
+    """Route after validation DV: terminal frontend pipeline."""
+    result = state.get("validation_dv_result") or {}
+    if result.get("pending_decision"):
+        return "validation_dv_decision"
+    if result.get("action_taken") in ("retry", "fix_rtl", "fix_tb"):
+        return "validation_dv"
+    return END
+
+
 route_after_validation_dv.__edge_labels__ = {
+    "validation_dv_decision": "Park for decision",
     "validation_dv": "Retry",
     END: "DONE",
 }
@@ -11070,7 +11282,13 @@ def build_pipeline_graph(checkpointer=None):
     orchestrator.add_node("pipeline_complete", pipeline_complete_node)
     orchestrator.add_node("integration_check", integration_check_node)
     orchestrator.add_node("integration_dv", integration_dv_node)
+    # run3-followups: interrupts live in dedicated decision nodes so a resume
+    # re-executes only the interrupt() call -- the big DV nodes never replay a
+    # default cycle over an operator's response (the one-cycle-late defect).
+    orchestrator.add_node(
+        "integration_dv_decision", integration_dv_decision_node)
     orchestrator.add_node("validation_dv", validation_dv_node)
+    orchestrator.add_node("validation_dv_decision", validation_dv_decision_node)
     # Deterministic signoff scorecard: the single pre-END funnel for every
     # GENUINE terminal (validation_dv done, integration_dv terminal-fail,
     # pipeline_complete abort). It does NOT sit on the interrupt()-based
@@ -11103,11 +11321,27 @@ def build_pipeline_graph(checkpointer=None):
         {
             "validation_dv": "validation_dv",
             "integration_dv": "integration_dv",
+            "integration_dv_decision": "integration_dv_decision",
+            END: "final_report",
+        },
+    )
+    orchestrator.add_conditional_edges(
+        "integration_dv_decision", route_after_integration_dv_decision,
+        {
+            "integration_dv": "integration_dv",
             END: "final_report",
         },
     )
     orchestrator.add_conditional_edges(
         "validation_dv", route_after_validation_dv,
+        {
+            "validation_dv": "validation_dv",
+            "validation_dv_decision": "validation_dv_decision",
+            END: "final_report",
+        },
+    )
+    orchestrator.add_conditional_edges(
+        "validation_dv_decision", route_after_validation_dv_decision,
         {
             "validation_dv": "validation_dv",
             END: "final_report",

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -744,6 +744,62 @@ def rtl_reference_source(block: dict) -> tuple[str, bool]:
 
 
 # ---------------------------------------------------------------------------
+# µarch composition gate -- honest exit banner
+# ---------------------------------------------------------------------------
+
+def uarch_gate_banner(model_integration_result: dict | None) -> tuple[str, str]:
+    """``(banner_text, colour)`` for the µarch gate's exit banner.
+
+    CLEAN means nothing fired. Measured live: the gate detected a model-level
+    mismatch, logged it, DISMISSED it as advisory (the deterministic-BFM bypass,
+    which is a legitimate non-blocking decision) -- and four lines later the run
+    printed a green "µARCH GATE CLEAN". Two true statements were composed into a
+    false one, and the green line is the one a reader carries away.
+
+    This function does not change what the gate DOES -- the bypass stays
+    advisory, the run still proceeds -- only what it SAYS. Every outcome that is
+    not "nothing fired" gets a yellow banner naming the finding and stating
+    explicitly that it is non-blocking.
+    """
+    res = model_integration_result if isinstance(model_integration_result, dict) else {}
+    tail = " -> beginning RTL pass (pass 2)"
+
+    if res.get("advisory_bypass"):
+        n = len(res.get("violations") or [])
+        where = res.get("first_divergence_block") or ""
+        return (
+            "µARCH GATE NOT CLEAN: "
+            + (f"{n} model-level mismatch(es)" if n else "a model-level mismatch")
+            + " were DISMISSED as ADVISORY (non-blocking; the deterministic "
+            "integration DV on the real RTL is the authoritative check) and "
+            "carried forward"
+            + (f"; first-divergence block: {where}" if where else
+               "; first-divergence block: (unlocalized)")
+            + tail,
+            YELLOW,
+        )
+
+    if res and res.get("passed") is False:
+        return (
+            "µARCH GATE NOT CLEAN: the gate did not pass"
+            + (f" (action taken: {res.get('action_taken')})"
+               if res.get("action_taken") else "")
+            + tail,
+            YELLOW,
+        )
+
+    if res.get("derate_signed_off"):
+        return (
+            "µARCH GATE PASSED WITH A SIGNED-OFF DERATE (within budget, "
+            "recorded in the derate ledger)" + tail,
+            YELLOW,
+        )
+
+    # Nothing fired (or no record at all -- the gate never ran on this path).
+    return ("µARCH GATE CLEAN" + tail, CYAN)
+
+
+# ---------------------------------------------------------------------------
 # Microarchitecture Spec Generation
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/langgraph/tapeout_helpers.py
+++ b/orchestrator/langgraph/tapeout_helpers.py
@@ -1297,7 +1297,7 @@ def _run_magic_drc_on_gds(gds_path: str, output_dir: str, timeout: int = 600) ->
     when no measurement exists. This function used to return
     ``{"pass": False, "violation_count": -1}`` when Magic produced nothing at
     all, which every consumer read as "this layout HAS violations" -- see the
-    ``exp-raster-macro-20260727`` w32_d64 / w9_d512 macro reports, whose named
+    measured w32_d64 / w9_d512 macro reports from a validation run, whose named
     ``precheck_magic_drc.rpt`` was never written.
     """
     from orchestrator.langgraph.backend_helpers import (

--- a/orchestrator/tests/test_backend_graph.py
+++ b/orchestrator/tests/test_backend_graph.py
@@ -614,3 +614,147 @@ class TestSafeFormat:
         # ... and the rendered example is natural single-brace Verilog.
         assert "assign io_out = {31'b0, done, qspi_o, 2'b0};" in rendered
         assert "{4{oe}}, 2'b1};" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Synthesis self-recovery is never silent (run3-followups #3)
+# ---------------------------------------------------------------------------
+#
+# PRODUCTION CALL PATH: these drive ``flat_top_synthesis_node`` itself, with only
+# the LLM step faked. The bug was that a driver-internal retry left no trace, so
+# a test that exercised the collector alone would have proved nothing about the
+# artifact a later reader actually opens.
+
+class TestFlatSynthAttemptHistoryWiring:
+    def _state(self, tmp_path, **kw):
+        top = tmp_path / "rtl" / "integration" / "chip_top.v"
+        top.parent.mkdir(parents=True, exist_ok=True)
+        top.write_text("module chip_top(input wb_clk_i);\nendmodule\n")
+        state = {
+            "project_root": str(tmp_path),
+            "design_name": "chip_top",
+            "integration_top_path": str(top),
+            "block_rtl_paths": {},
+            "target_clock_mhz": 50.0,
+            "attempt": 1,
+            "current_block": {"name": "chip_top"},
+        }
+        state.update(kw)
+        return state
+
+    def _syn_dir(self, tmp_path):
+        d = tmp_path / "syn" / "output" / "chip_top"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    @pytest.mark.asyncio
+    async def test_success_on_attempt_2_retains_attempt_1(self, tmp_path, monkeypatch):
+        """THE defect, end to end: the driver succeeds on its second internal
+        attempt; attempt 1's reason lands in synth_result.json AND in state."""
+        from orchestrator.langgraph import backend_graph as bg
+
+        d = self._syn_dir(tmp_path)
+        net = d / "chip_top_netlist.v"
+        net.write_text("module chip_top(); endmodule\n")
+        (d / "synth_attempt1.log").write_text(
+            "ERROR: Module `cs_sram_1rw' referenced in module `chip_top' "
+            "is not part of the design.\n")
+
+        async def _fake_llm(**kwargs):
+            return {
+                "success": True,
+                "netlist_path": str(net),
+                "sdc_path": "",
+                "gate_count": 10,
+                "_llm_reply": "Synthesis succeeded on attempt 2.",
+            }
+
+        monkeypatch.setattr(bg, "_run_llm_eda_step", _fake_llm)
+        monkeypatch.setattr(bg, "_bind_macro_shells_for_backend",
+                            lambda _n: ([], ""))
+        monkeypatch.setattr(bg, "_run_chip_top_gate_sim",
+                            lambda _s, _n: (None, "not_run", "no TB"))
+
+        out = await bg.flat_top_synthesis_node(self._state(tmp_path))
+
+        hist = out["synth_attempt_history"]
+        assert [h["attempt"] for h in hist] == [1]
+        assert "cs_sram_1rw" in hist[0]["error_summary"]
+
+        import json as _json
+        artifact = _json.loads((d / "synth_result.json").read_text())
+        assert artifact["attempt_history"] == hist
+        assert artifact["attempt_failures"] == 1
+
+    @pytest.mark.asyncio
+    async def test_claimed_retry_with_no_evidence_is_recorded_as_a_gap(
+            self, tmp_path, monkeypatch):
+        from orchestrator.langgraph import backend_graph as bg
+
+        d = self._syn_dir(tmp_path)
+        net = d / "chip_top_netlist.v"
+        net.write_text("module chip_top(); endmodule\n")
+
+        async def _fake_llm(**kwargs):
+            return {"success": True, "netlist_path": str(net),
+                    "_llm_reply": "Synthesis succeeded on attempt 3."}
+
+        monkeypatch.setattr(bg, "_run_llm_eda_step", _fake_llm)
+        monkeypatch.setattr(bg, "_bind_macro_shells_for_backend",
+                            lambda _n: ([], ""))
+        monkeypatch.setattr(bg, "_run_chip_top_gate_sim",
+                            lambda _s, _n: (None, "not_run", ""))
+
+        out = await bg.flat_top_synthesis_node(self._state(tmp_path))
+        hist = out["synth_attempt_history"]
+        assert [h["attempt"] for h in hist] == [1, 2]
+        assert all(h["unrecorded"] for h in hist)
+
+    @pytest.mark.asyncio
+    async def test_a_failed_synthesis_carries_its_history_into_previous_error(
+            self, tmp_path, monkeypatch):
+        """diagnose reads previous_error. "attempt 3 failed" without the two
+        reasons before it is what made the same defect recur every run."""
+        from orchestrator.langgraph import backend_graph as bg
+
+        d = self._syn_dir(tmp_path)
+        (d / "run1.log").write_text("ERROR: cannot open liberty file\n")
+
+        async def _fake_llm(**kwargs):
+            return {"success": False, "error": "Flat synthesis failed",
+                    "_llm_reply": "gave up after attempt 2"}
+
+        monkeypatch.setattr(bg, "_run_llm_eda_step", _fake_llm)
+        out = await bg.flat_top_synthesis_node(self._state(tmp_path))
+        assert out["flat_netlist_path"] == ""
+        assert "Flat synthesis failed" in out["previous_error"]
+        assert "cannot open liberty file" in out["previous_error"]
+        # the FINAL attempt's reason is result["error"] (already in
+        # previous_error); the history retains the EARLIER attempt, which is
+        # exactly what used to vanish.
+        assert len(out["synth_attempt_history"]) == 1
+        assert out["synth_attempt_history"][0]["attempt"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_clean_first_attempt_is_byte_identical(
+            self, tmp_path, monkeypatch):
+        """No retry -> no history, no artifact mutation: the pre-fix shape."""
+        from orchestrator.langgraph import backend_graph as bg
+
+        d = self._syn_dir(tmp_path)
+        net = d / "chip_top_netlist.v"
+        net.write_text("module chip_top(); endmodule\n")
+
+        async def _fake_llm(**kwargs):
+            return {"success": True, "netlist_path": str(net),
+                    "_llm_reply": "Synthesis succeeded."}
+
+        monkeypatch.setattr(bg, "_run_llm_eda_step", _fake_llm)
+        monkeypatch.setattr(bg, "_bind_macro_shells_for_backend",
+                            lambda _n: ([], ""))
+        monkeypatch.setattr(bg, "_run_chip_top_gate_sim",
+                            lambda _s, _n: (None, "not_run", ""))
+
+        out = await bg.flat_top_synthesis_node(self._state(tmp_path))
+        assert out["synth_attempt_history"] == []
+        assert not (d / "synth_result.json").exists()

--- a/orchestrator/tests/test_backend_helpers.py
+++ b/orchestrator/tests/test_backend_helpers.py
@@ -838,3 +838,117 @@ class TestLvsIntegration:
         # Expected tap cell delta
         assert lvs["device_delta"] <= 2
         assert Path(lvs["report_path"]).exists()
+
+
+# ---------------------------------------------------------------------------
+# Synthesis attempt-history retention (run3-followups #3)
+# ---------------------------------------------------------------------------
+#
+# The flat-synth driver retries Yosys inside its own LLM step. A live run logged
+# "Synthesis succeeded on attempt 2" and attempt 1's failure reason was retained
+# NOWHERE -- not in attempt_history, not in previous_error, not in
+# synth_result.json. A driver that heals itself in silence teaches nobody: the
+# same script defect recurs every run and the only trace is a discarded
+# transcript.
+
+class TestSynthAttemptHistory:
+    def _collect(self, **kw):
+        from orchestrator.langgraph.backend_helpers import (
+            collect_synth_attempt_history,
+        )
+        kw.setdefault("now", "2026-07-31T00:00:00")
+        return collect_synth_attempt_history(kw.pop("result", {}), **kw)
+
+    def test_clean_first_attempt_records_nothing(self, tmp_path):
+        assert self._collect(
+            result={"success": True},
+            output_dir=str(tmp_path),
+            llm_reply="Synthesis succeeded.",
+        ) == []
+
+    def test_driver_reported_failures_are_retained_on_a_SUCCESS(self, tmp_path):
+        h = self._collect(
+            result={"success": True, "attempt_history": [
+                {"attempt": 1, "error_summary": "ERROR: Module `cs_sram_1rw' "
+                                                "is not part of the design"},
+            ]},
+            output_dir=str(tmp_path),
+            llm_reply="Synthesis succeeded on attempt 2.",
+        )
+        assert [e["attempt"] for e in h] == [1]
+        assert "cs_sram_1rw" in h[0]["error_summary"]
+        assert h[0]["source"] == "driver_reported"
+        assert h[0]["unrecorded"] is False
+
+    def test_yosys_logs_on_disk_are_harvested_without_the_driver(self, tmp_path):
+        """Deterministic evidence: the driver need not be honest about its own
+        retries for the failure reason to survive."""
+        (tmp_path / "synth_attempt1.log").write_text(
+            "1. Executing Verilog frontend\n"
+            "ERROR: syntax error, unexpected TOK_ID at line 12\n")
+        h = self._collect(result={"success": True}, output_dir=str(tmp_path),
+                          llm_reply="done")
+        assert len(h) == 1
+        assert h[0]["source"] == "yosys_log"
+        assert "syntax error" in h[0]["error_summary"]
+        assert "synth_attempt1.log" in h[0]["error_summary"]
+
+    def test_a_claimed_retry_with_no_evidence_is_recorded_as_NOT_RETAINED(
+            self, tmp_path):
+        """THE defect. The driver says it took two attempts and supplies nothing
+        about the first. The gap becomes a record instead of a silence."""
+        h = self._collect(result={"success": True}, output_dir=str(tmp_path),
+                          llm_reply="Synthesis succeeded on attempt 2.")
+        assert len(h) == 1
+        assert h[0]["attempt"] == 1
+        assert h[0]["unrecorded"] is True
+        assert "not retained" in h[0]["error_summary"]
+
+    def test_real_evidence_wins_over_the_not_retained_placeholder(self, tmp_path):
+        (tmp_path / "a.log").write_text("ERROR: cannot open liberty file\n")
+        h = self._collect(result={"success": True}, output_dir=str(tmp_path),
+                          llm_reply="succeeded on attempt 3")
+        assert [e["attempt"] for e in h] == [1, 2]
+        assert h[0]["unrecorded"] is False and "liberty" in h[0]["error_summary"]
+        assert h[1]["unrecorded"] is True
+
+    def test_node_level_prior_failure_is_folded_in(self, tmp_path):
+        h = self._collect(result={"success": True}, output_dir=str(tmp_path),
+                          prior_error="hierarchy -check failed on top",
+                          node_attempt=2, llm_reply="ok")
+        assert [e["source"] for e in h] == ["node_previous_error"]
+        assert h[0]["attempt"] == 1
+
+    def test_collector_never_raises_on_garbage(self, tmp_path):
+        assert self._collect(result={"attempt_history": "not-a-list"},
+                             output_dir="/nonexistent/dir",
+                             llm_reply=None) == []
+
+    def test_persist_merges_into_the_synth_result_artifact(self, tmp_path):
+        from orchestrator.langgraph.backend_helpers import (
+            persist_synth_attempt_history,
+        )
+        import json as _json
+        p = tmp_path / "synth_result.json"
+        p.write_text(_json.dumps({"success": True, "gate_count": 42}))
+        hist = [{"attempt": 1, "error_summary": "ERROR: boom",
+                 "source": "yosys_log", "timestamp": "t", "unrecorded": False}]
+        assert persist_synth_attempt_history(str(p), hist) is True
+        data = _json.loads(p.read_text())
+        assert data["gate_count"] == 42                 # existing keys survive
+        assert data["attempt_history"] == hist
+        assert data["attempt_failures"] == 1
+        assert data["attempt_history_unrecorded"] == 0
+
+    def test_describe_names_every_attempt(self):
+        from orchestrator.langgraph.backend_helpers import (
+            describe_synth_attempt_history,
+        )
+        assert describe_synth_attempt_history([]) == ""
+        txt = describe_synth_attempt_history([
+            {"attempt": 1, "error_summary": "boom", "source": "yosys_log",
+             "timestamp": "t", "unrecorded": False},
+            {"attempt": 2, "error_summary": "(not retained) ...",
+             "source": "unrecorded", "timestamp": "t", "unrecorded": True},
+        ])
+        assert "attempt 1" in txt and "attempt 2 [NOT RETAINED]" in txt

--- a/orchestrator/tests/test_composition_gate_wiring.py
+++ b/orchestrator/tests/test_composition_gate_wiring.py
@@ -346,3 +346,83 @@ class TestUarchGateAdvisoryBypass:
         assert mir.get("passed") is not True
         assert mir.get("first_divergence_block") == "raster"
         assert route_after_uarch_gate(result) == "begin_rtl_pass"
+
+
+# ---------------------------------------------------------------------------
+# The gate's EXIT BANNER must state the actual outcome (run3-followups #4a)
+# ---------------------------------------------------------------------------
+#
+# Measured live: the gate detected a model-level mismatch, logged it, and
+# DISMISSED it as advisory -- a legitimate non-blocking decision. Four lines
+# later the run printed a green "µARCH GATE CLEAN". Two true statements composed
+# into a false one, and the green line is the one a reader carries away.
+#
+# ``uarch_gate_banner`` does not change what the gate DOES (the bypass stays
+# advisory and the run still proceeds) -- only what it SAYS.
+
+class TestUarchGateBanner:
+    def _banner(self, result):
+        from orchestrator.langgraph.pipeline_helpers import uarch_gate_banner
+        return uarch_gate_banner(result)
+
+    def test_clean_only_when_nothing_fired(self):
+        from orchestrator.langgraph.pipeline_helpers import CYAN
+        for res in (None, {}, {"passed": True}):
+            text, colour = self._banner(res)
+            assert text.startswith("µARCH GATE CLEAN"), res
+            assert colour == CYAN
+            assert "beginning RTL pass" in text
+
+    def test_an_advisory_dismissal_is_NOT_reported_as_clean(self):
+        """THE defect. A dismissed mismatch must never print CLEAN."""
+        from orchestrator.langgraph.pipeline_helpers import YELLOW
+        text, colour = self._banner({
+            "passed": False,
+            "advisory_bypass": True,
+            "first_divergence_block": "stage_b",
+            "violations": [{"expected": "0102", "observed": "0000"}],
+        })
+        assert "GATE CLEAN" not in text        # the green claim, gone
+        assert "NOT CLEAN" in text
+        assert colour == YELLOW
+        # it names the finding, says it was non-blocking, and still says the
+        # run proceeds -- all three, because all three are true
+        assert "1 model-level mismatch(es)" in text
+        assert "ADVISORY" in text and "non-blocking" in text
+        assert "stage_b" in text
+        assert "beginning RTL pass" in text
+
+    def test_an_advisory_dismissal_without_localization_says_so(self):
+        text, _ = self._banner({"passed": False, "advisory_bypass": True,
+                                "violations": []})
+        assert "NOT CLEAN" in text
+        assert "(unlocalized)" in text
+
+    def test_a_signed_off_derate_is_not_plain_clean_either(self):
+        from orchestrator.langgraph.pipeline_helpers import YELLOW
+        text, colour = self._banner({"passed": True, "derate_signed_off": True})
+        assert "DERATE" in text and colour == YELLOW
+        assert "GATE CLEAN" not in text
+
+    def test_a_non_advisory_failure_is_also_never_clean(self):
+        text, _ = self._banner({"passed": False, "action_taken": "retry"})
+        assert "NOT CLEAN" in text and "retry" in text
+
+    @pytest.mark.asyncio
+    async def test_the_advisory_bypass_result_the_NODE_produces_is_not_clean(
+            self, tmp_path, monkeypatch):
+        """PRODUCTION SHAPE: feed the banner the dict the real advisory-bypass
+        branch returns, not a hand-written one -- the shapes cannot drift."""
+        monkeypatch.setenv("CORESMITH_DETERMINISTIC_BFM", "1")
+        calls = _install_failing_gate(monkeypatch)
+        result = await pipeline_graph.uarch_integration_gate_node(
+            {"project_root": str(tmp_path)}
+        )
+        mir = result["model_integration_result"]
+        assert mir.get("advisory_bypass") is True
+        assert calls["interrupt"] == 0
+        # ...and the run proceeds to the RTL pass, which is exactly where the
+        # green banner used to be printed.
+        assert route_after_uarch_gate(result) == "begin_rtl_pass"
+        text, _ = self._banner(mir)
+        assert "NOT CLEAN" in text and "ADVISORY" in text

--- a/orchestrator/tests/test_engine_provenance.py
+++ b/orchestrator/tests/test_engine_provenance.py
@@ -56,3 +56,59 @@ def test_final_report_includes_engine_sha(tmp_path):
     assert report["engine_sha_changed_mid_run"] is True
     md = fr.render_markdown(report)
     assert "abc123abc123" in md and "CHANGED MID-RUN" in md
+
+
+# ---------------------------------------------------------------------------
+# Engine source carries no benchmark-exercise vocabulary (run3-followups #5)
+# ---------------------------------------------------------------------------
+#
+# Standing repo rule: engine source must be exercise-agnostic. Naming a specific
+# benchmark exercise (or a specific reference design's internals) in a comment
+# looks harmless and is not: it leaks the evaluation set into the engine, and it
+# teaches every later reader -- human and model -- that this file is allowed to
+# know which exercise it is running.
+#
+# Protocol-generic identifiers are FINE and deliberately not matched here: the
+# QSPI contract fields in ``bfm_lib`` describe a bus protocol, not an exercise,
+# and ``rasterise``/``TRIANGLES`` in the layout renderer are graphics primitives.
+# The guard is scoped to the files this sweep cleaned, so it pins the fix rather
+# than asserting a repo-wide invariant that other work would have to keep true.
+
+_EXERCISE_WORDS = ("raster", "triangle", "h264", "h.264", "cavlc")
+
+_SCRUBBED_FILES = (
+    "orchestrator/langgraph/bfm_lib/maxgeo.py",
+    "orchestrator/langgraph/bfm_lib/stimulus.py",
+    "orchestrator/langgraph/drc_verdict.py",
+    "orchestrator/langgraph/macro_prebind.py",
+    "orchestrator/langgraph/tapeout_helpers.py",
+    "orchestrator/langgraph/integration_helpers.py",
+    "orchestrator/langchain/agents/contract_audit_agent.py",
+    "orchestrator/langchain/agents/uarch_spec_generator.py",
+    "orchestrator/architecture/model_integration.py",
+)
+
+
+def _engine_root():
+    from pathlib import Path
+
+    import orchestrator
+    return Path(orchestrator.__file__).resolve().parent.parent
+
+
+def test_scrubbed_engine_files_name_no_benchmark_exercise():
+    root = _engine_root()
+    offenders = []
+    for rel in _SCRUBBED_FILES:
+        p = root / rel
+        assert p.exists(), rel
+        for i, line in enumerate(
+                p.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            low = line.lower()
+            for word in _EXERCISE_WORDS:
+                if word in low:
+                    offenders.append(f"{rel}:{i}: {line.strip()[:100]}")
+    assert not offenders, (
+        "benchmark-exercise vocabulary in engine source:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/orchestrator/tests/test_full_model_dv.py
+++ b/orchestrator/tests/test_full_model_dv.py
@@ -172,3 +172,147 @@ def simulate(stimulus):
         violations = model_integration.run_model_integration_gate(str(root))
         assert violations
         assert "BYTE-SHIFT DETECTED" in str(violations[0].get("suggested_fix", ""))
+
+
+# ---------------------------------------------------------------------------
+# Timeout localization (run3-followups #4b)
+# ---------------------------------------------------------------------------
+#
+# When the composed model runs unbounded there is no divergence offset and no
+# traceback, so the failure reported "First-divergence block: (unlocalized)" and
+# the router broadcast a re-spec to EVERY block. A stall has one first cause, and
+# this is the failure mode where saying WHERE matters most.
+#
+# The probe is static (ast over the composition + a standalone import of each
+# block model), so it costs nothing and works on a run that is already hung.
+
+HANGING_CHIP = '''\
+def simulate(stimulus):
+    while True:
+        pass
+'''
+
+# A composition where one block's ports are wired to signals nothing else in the
+# whole chip model touches -- an output no one consumes / an input no one drives.
+DANGLING_CHIP = '''\
+from amaranth import Module, Signal
+
+from producer import producer
+from orphan import orphan
+
+
+class chip_model:
+    def elaborate(self, platform):
+        m = Module()
+        shared = Signal(8)
+        shared_valid = Signal()
+        never_read_a = Signal(8)
+        never_read_b = Signal()
+        m.submodules.p = producer(shared, shared_valid)
+        m.submodules.o = orphan(never_read_a, never_read_b)
+        m.d.comb += shared.eq(shared_valid)
+        return m
+
+
+def simulate(stimulus):
+    while True:
+        pass
+'''
+
+BROKEN_BLOCK = "import a_module_that_does_not_exist_anywhere\n"
+
+
+def _good_block(name: str) -> str:
+    """A block model that imports cleanly and exposes its own name."""
+    return f"class {name}:\n    def __init__(self, *args):\n        pass\n"
+
+
+def _stall_project(tmp_path: Path, chip: str, blocks: dict) -> Path:
+    d = tmp_path / "arch" / "block_models"
+    for stem, text in blocks.items():
+        _write(d / f"{stem}.py", text if text else _good_block(stem))
+    _write(d / "_chip_model.py", chip)
+    _write(tmp_path / "inputs" / "toy_golden.py", REFERENCE_IMPL)
+    return tmp_path
+
+
+class TestStallLocalization:
+    def test_probe_names_a_block_that_does_not_even_import(self, tmp_path):
+        root = _stall_project(tmp_path, HANGING_CHIP, {
+            "producer": "", "orphan": BROKEN_BLOCK})
+        rep = model_integration.probe_composition_stall(
+            str(root), root / "arch" / "block_models")
+        assert set(rep["blocks"]) == {"producer", "orphan"}
+        assert "orphan" in rep["import_failures"]
+        assert "producer" not in rep["import_failures"]
+        assert rep["candidates"] == ["orphan"]
+        assert "DOES NOT IMPORT" in rep["summary"]
+
+    def test_probe_names_a_block_whose_ports_are_wired_to_nothing(self, tmp_path):
+        root = _stall_project(tmp_path, DANGLING_CHIP, {
+            "producer": "", "orphan": ""})
+        rep = model_integration.probe_composition_stall(
+            str(root), root / "arch" / "block_models")
+        assert rep["dangling"].get("orphan") == ["never_read_a", "never_read_b"]
+        assert "producer" not in rep["dangling"]     # its signals ARE consumed
+        assert rep["candidates"] == ["orphan"]
+        assert "read NOWHERE else" in rep["summary"]
+
+    def test_probe_reports_nothing_when_the_composition_is_well_formed(
+            self, tmp_path):
+        chip = DANGLING_CHIP.replace(
+            "m.submodules.o = orphan(never_read_a, never_read_b)",
+            "m.submodules.o = orphan(shared, shared_valid)")
+        root = _stall_project(tmp_path, chip, {
+            "producer": "", "orphan": ""})
+        rep = model_integration.probe_composition_stall(
+            str(root), root / "arch" / "block_models")
+        assert rep["candidates"] == []
+        assert rep["summary"] == ""
+
+    def test_probe_never_raises_on_a_missing_or_unparseable_dir(self, tmp_path):
+        rep = model_integration.probe_composition_stall(
+            str(tmp_path), tmp_path / "nope")
+        assert rep["candidates"] == [] and rep["blocks"] == []
+
+    def test_timeout_violation_says_WHERE(self, tmp_path, monkeypatch):
+        """PRODUCTION PATH: the real gate, a real (fast) timeout, and the
+        violation the router consumes now NAMES the block instead of reporting
+        '(unlocalized)'."""
+        _env(monkeypatch)
+        monkeypatch.setenv("CORESMITH_GATE_SIM_TIMEOUT", "1")
+        root = _stall_project(tmp_path, DANGLING_CHIP, {
+            "producer": "", "orphan": ""})
+        violations = model_integration.run_model_integration_gate(str(root))
+        assert violations, "a hanging simulate() must be a violation"
+        v = violations[0]
+        assert v["criterion"] == "simulate_timeout"
+        assert v["first_divergence_block"] == "orphan"
+        assert "LOCALIZED to block 'orphan'" in v["observed"]
+        assert "read NOWHERE else" in v["suggested_fix"]
+        assert v["stall_localization"]["candidates"] == ["orphan"]
+
+    def test_localization_can_be_switched_off(self, tmp_path, monkeypatch):
+        """Env-gate convention: 0 restores the pre-fix '(unlocalized)' report,
+        so both branches are covered."""
+        _env(monkeypatch)
+        monkeypatch.setenv("CORESMITH_GATE_SIM_TIMEOUT", "1")
+        monkeypatch.setenv("CORESMITH_GATE_STALL_LOCALIZE", "0")
+        root = _stall_project(tmp_path, DANGLING_CHIP, {
+            "producer": "", "orphan": ""})
+        violations = model_integration.run_model_integration_gate(str(root))
+        assert violations
+        v = violations[0]
+        assert v["first_divergence_block"] == ""
+        assert "NOT localized" in v["observed"]
+        assert v["stall_localization"] == {}
+
+    def test_ambiguous_evidence_does_not_invent_a_single_block(self, tmp_path):
+        """Two candidate blocks -> the probe reports both and names NEITHER as
+        the first-divergence block. A false-precise pointer misdirects a re-spec,
+        which is why the broadcast default exists."""
+        root = _stall_project(tmp_path, DANGLING_CHIP, {
+            "producer": BROKEN_BLOCK, "orphan": BROKEN_BLOCK})
+        rep = model_integration.probe_composition_stall(
+            str(root), root / "arch" / "block_models")
+        assert len(rep["candidates"]) == 2

--- a/orchestrator/tests/test_maxgeo_conformance.py
+++ b/orchestrator/tests/test_maxgeo_conformance.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 
 import pytest
 
@@ -286,4 +287,316 @@ def test_a_bus_only_design_gets_a_clean_pass_not_an_advisory(tmp_path):
     involved."""
     pr = _project(tmp_path, BUS_DIMS)
     tb, res = _conformance_tb(tmp_path, BUS_DIMS)
-    assert pipeline_graph._maxgeo_gate_verdict(pr, tb, res) is None
+    v = pipeline_graph._maxgeo_gate_verdict(pr, tb, res)
+    # run3-followups: full coverage is an explicit PASS verdict, not None.
+    assert v is not None and v.get("verdict") == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Generator-side MAX-CONFIGURATION functional case (run3-followups #1)
+# ---------------------------------------------------------------------------
+#
+# The deterministic codegen baked exactly ONE host-flow case -- the FIRST
+# acceptance case, which is the small canonical KAT. It therefore proved nothing
+# about any declared maximum, and the operator had to hand-add a max-geometry
+# functional test to the generated artifact. These tests pin the generator-side
+# fix, and they run it through the PRODUCTION writer
+# (``write_deterministic_integration_tb``), not through a test-shaped call.
+
+# A generic two-parameter design: one small canonical case and one larger one.
+# Names are placeholders on purpose -- the selection rule is over MAGNITUDES.
+_GEN_GOLDEN = '''
+def run(stimulus):
+    n = int(stimulus["unit_count"])
+    data = bytes(stimulus["data"])
+    # two output bytes per input byte -> OUT extent differs from IN extent
+    return bytes(v for b in data for v in (((b + n) & 0xFF), ((b ^ n) & 0xFF)))
+'''
+
+_GEN_ACCEPT = '''
+def _case(n):
+    return {"unit_count": n, "cfg0": n, "data": bytes((i * 7) & 0xFF for i in range(16 * n))}
+
+cases = [
+    ("canonical_smoke", _case(1)),
+    ("mid", _case(4)),
+    ("max_config", _case(8)),
+    ("mid2", _case(2)),
+]
+'''
+
+# What such a design declares. ``unit_count`` is the only compute-lane dim a
+# stimulus scalar names AND drives at its maximum.
+_GEN_DIMS = {
+    "unit_count": 8,
+    "internal_store_depth": 128,
+    "qspi_address": 16777215,
+    "in_write_length": 128,
+    "out_read_length": 256,
+}
+
+
+def _generic_run(tmp_path, *, dims: dict | None = None) -> str:
+    root = tmp_path / "run"
+    (root / ".coresmith").mkdir(parents=True, exist_ok=True)
+    (root / "inputs").mkdir(parents=True, exist_ok=True)
+    (root / "inputs" / "design_golden.py").write_text(_GEN_GOLDEN, encoding="utf-8")
+    (root / "inputs" / "acceptance_stimulus.py").write_text(
+        _GEN_ACCEPT, encoding="utf-8")
+    (root / ".coresmith" / "ers_spec.json").write_text(json.dumps({"ers": {
+        "parameters": [
+            {"name": n, "role": "dimension", "max": v}
+            for n, v in (dims if dims is not None else _GEN_DIMS).items()
+        ]
+    }}), encoding="utf-8")
+    return str(root)
+
+
+def _write_integration_tb(pr: str) -> tuple[str, dict]:
+    """The PRODUCTION path: plan -> writer -> artifact on disk."""
+    from orchestrator.langgraph.bfm_lib import (
+        build_plan_from_run,
+        declared_dimensional_maxima,
+        write_deterministic_integration_tb,
+    )
+    c = QSPIContract()
+    plan = build_plan_from_run(pr, c)
+    assert plan is not None, "the generic run must yield a host-flow plan"
+    out = str(Path(pr) / "tb" / "integration" / "test_chip_top.py")
+    res = write_deterministic_integration_tb(
+        pr, "chip_top", c, plan, out, include_conformance=True,
+        declared_dims=declared_dimensional_maxima(pr),
+    )
+    return out, res
+
+
+def test_max_config_case_is_selected_by_magnitude_not_by_order(tmp_path):
+    """Generic selection: the case maximizing (IN payload bytes, cfg0) wins --
+    it is neither first nor last in the declared list."""
+    from orchestrator.langgraph.bfm_lib import (
+        load_acceptance_cases,
+        select_max_geometry_case,
+    )
+    pr = _generic_run(tmp_path)
+    cases = load_acceptance_cases(pr)
+    assert [n for n, _ in cases] == ["canonical_smoke", "mid", "max_config", "mid2"]
+    assert select_max_geometry_case(cases)[0] == "max_config"
+
+
+def test_writer_emits_a_second_baked_max_geometry_test(tmp_path):
+    """The production writer emits a SECOND host-flow test for the max case,
+    with its golden baked at GENERATION time (bytes in the file, no runtime
+    import of the reference)."""
+    pr = _generic_run(tmp_path)
+    tb, res = _write_integration_tb(pr)
+    src = Path(tb).read_text(encoding="utf-8")
+    compile(src, "<integration_tb>", "exec")          # must parse
+
+    assert res["case_name"] == "canonical_smoke"       # primary is unchanged
+    assert res["maxgeo_case"]["name"] == "max_config"
+    assert res["maxgeo_case"]["emitted_test"] is True
+    assert res["test_count"] == 3                      # host-flow + max + conformance
+
+    assert "async def deterministic_qspi_dv_max_geometry(dut):" in src
+    assert "MAXGEO_EXPECTED = bytes.fromhex(" in src   # baked, not imported
+    assert "import acceptance_stimulus" not in src
+    assert "MAXGEO_IN_WRITES" in src
+
+
+def test_max_geometry_case_marker_is_emitted_and_is_not_a_coverage_claim(tmp_path):
+    """``# MAXGEO_CASE`` records WHICH case and at what magnitudes -- and the
+    underscore form must not be readable as a coverage claim for dims literally
+    named cfg0 / in_bytes / out_bytes."""
+    pr = _generic_run(tmp_path)
+    tb, _res = _write_integration_tb(pr)
+    src = Path(tb).read_text(encoding="utf-8")
+    assert "# MAXGEO_CASE: name=max_config cfg0=8 in_bytes=128 out_bytes=256" in src
+    read = _gate_reads(src)
+    for k in ("cfg0", "in_bytes", "out_bytes", "name"):
+        assert k not in read, k
+
+
+def test_functional_dims_are_claimed_only_with_driven_evidence(tmp_path):
+    """A declared dim joins ``# MAXGEO`` only when a stimulus scalar NAMES it and
+    carries its declared maximum. Everything else stays confessed -- a big case
+    is not evidence for a dimension it does not drive."""
+    pr = _generic_run(tmp_path)
+    tb, res = _write_integration_tb(pr)
+    src = Path(tb).read_text(encoding="utf-8")
+    read = _gate_reads(src)
+
+    assert res["maxgeo_functional"] == {"unit_count": 8}
+    assert read["unit_count"] == 8                     # driven: cfg0/unit_count=8
+    # declared, NOT driven by any scalar of the chosen case -> still confessed
+    assert "internal_store_depth" not in read
+    assert "internal_store_depth=128" in src
+    assert "# MAXGEO_NOT_COVERED: " in src
+
+
+def test_no_larger_case_means_no_second_test(tmp_path):
+    """When the FIRST case already is the largest, a second identical test would
+    prove nothing: no extra test is emitted, but the marker still records that
+    the primary IS the max-geometry case."""
+    root = tmp_path / "run"
+    (root / ".coresmith").mkdir(parents=True, exist_ok=True)
+    (root / "inputs").mkdir(parents=True, exist_ok=True)
+    (root / "inputs" / "design_golden.py").write_text(_GEN_GOLDEN, encoding="utf-8")
+    (root / "inputs" / "acceptance_stimulus.py").write_text(
+        _GEN_ACCEPT.replace('("canonical_smoke", _case(1))', '("biggest", _case(8))')
+        .replace('("max_config", _case(8))', '("small", _case(1))'),
+        encoding="utf-8")
+    (root / ".coresmith" / "ers_spec.json").write_text(json.dumps({"ers": {
+        "parameters": [{"name": n, "role": "dimension", "max": v}
+                       for n, v in _GEN_DIMS.items()]}}), encoding="utf-8")
+    tb, res = _write_integration_tb(str(root))
+    src = Path(tb).read_text(encoding="utf-8")
+    assert res["maxgeo_case"]["is_primary"] is True
+    assert res["maxgeo_case"]["emitted_test"] is False
+    assert res["test_count"] == 2
+    assert "deterministic_qspi_dv_max_geometry" not in src
+    assert "# MAXGEO_CASE: name=biggest" in src
+
+
+def test_a_run_without_acceptance_cases_is_byte_identical(tmp_path):
+    """No acceptance module -> no max case -> the emitted TB is exactly what it
+    was before any of this existed."""
+    from orchestrator.langgraph.bfm_lib import (
+        StimulusPlan,
+        render_integration_tb,
+        write_deterministic_integration_tb,
+    )
+    c = QSPIContract()
+    plan = StimulusPlan(cfg=[(c.cfg0_addr, 1, 4)],
+                        writes=[(c.in_addr, bytes(range(16)))],
+                        out_addr=c.out_addr, out_len=16,
+                        expected=bytes(range(16)), case_name="unit")
+    out = str(tmp_path / "tb" / "test_chip_top.py")
+    res = write_deterministic_integration_tb(
+        str(tmp_path), "chip_top", c, plan, out)
+    assert res["maxgeo_case"] is None
+    assert res["test_count"] == 1
+    assert Path(out).read_text(encoding="utf-8") == render_integration_tb(
+        c, "chip_top", plan)
+
+
+def test_the_generated_max_geometry_tb_satisfies_the_gate(tmp_path):
+    """End-to-end through the PRODUCTION gate: the artifact the writer produces
+    is one the MAX-GEOMETRY gate accepts (pass or advisory), not a hard fail."""
+    pr = _generic_run(tmp_path)
+    tb, res = _write_integration_tb(pr)
+    v = pipeline_graph._maxgeo_gate_verdict(pr, tb, res)
+    assert v is None or v.get("verdict") == "pass" or v.get("advisory") is True, v
+
+
+# ---------------------------------------------------------------------------
+# Dimension-registry alignment (run3-followups #2)
+# ---------------------------------------------------------------------------
+#
+# On the live run three numbers disagreed: the gate ENFORCED 9 dims, the TB
+# CONFESSED 13, the declared table had 18. Nothing lied -- they were three
+# derivations. One derivation now, three views of it.
+
+def test_registry_matches_the_gate_declared_dimension_derivation(tmp_path):
+    """``declared_dimensional_maxima`` IS what the gate derives today, so the
+    call-site swap is a no-op on behaviour. Both the typed ``parameters`` block
+    and the legacy generic harvest are exercised."""
+    from orchestrator.langgraph.bfm_lib import declared_dimensional_maxima
+    cs = tmp_path / ".coresmith"
+    cs.mkdir(parents=True, exist_ok=True)
+    (cs / "ers_spec.json").write_text(json.dumps({"ers": {
+        "parameters": [
+            {"name": "unit_count", "role": "dimension", "max": 8},
+            {"name": "opcode_select", "role": "mode", "max": 255},
+        ],
+        # harvested generically (no parameters entry) -- must still appear
+        "constraints": [{"name": "scraped_depth", "max": 512}],
+    }}), encoding="utf-8")
+    assert declared_dimensional_maxima(str(tmp_path)) == \
+        pipeline_graph._declared_dimensions(str(tmp_path))
+
+
+def test_registry_is_empty_for_a_legacy_prose_spec(tmp_path):
+    from orchestrator.langgraph.bfm_lib import declared_dimensional_maxima
+    assert declared_dimensional_maxima(str(tmp_path)) == {}
+
+
+def test_demand_partitions_the_declared_table_and_exposes_value_collisions():
+    """The 18/13/9 reconciliation, on the exact shape that produced it: five bus
+    dims are PROVEN, four compute-lane dims merely COLLIDE in value with a bus
+    marker (the old gate counted those as covered), nine are MISSING. 5+4+9=18,
+    and the confession (value_only|missing) is 13."""
+    from orchestrator.langgraph.bfm_lib import maxgeo_demand
+    d = maxgeo_demand(RASTER_DIMS, BUS_DIMS)
+    assert set(d.proven) == set(BUS_DIMS)
+    assert len(d.proven) + len(d.value_only) + len(d.missing) == len(RASTER_DIMS)
+    # 4096 and 255 are bus marker values AND compute-lane maxima
+    assert d.value_only == {
+        "framebuffer_depth": 4096, "triangle_color": 255,
+        "triangle_depth": 255, "zbuffer_depth": 4096,
+    }
+    assert len(d.missing) == 9
+    assert len(d.unproven) == 13
+    # today's gate demands exactly `missing` -- swapping in maxgeo_demand is
+    # semantics-preserving for the demand, and ADDS the weak-evidence set
+    marker_values = set(BUS_DIMS.values())
+    assert d.missing == {
+        n: v for n, v in RASTER_DIMS.items() if v not in marker_values
+    }
+
+
+def test_demand_requires_name_and_value_together():
+    from orchestrator.langgraph.bfm_lib import maxgeo_demand
+    d = maxgeo_demand({"a": 64}, {"a": 32})     # right name, wrong value
+    assert d.proven == {} and d.missing == {"a": 64}
+    d2 = maxgeo_demand({"a": 64}, {"a": 64})
+    assert d2.proven == {"a": 64} and not d2.unproven
+
+
+def test_the_confession_and_the_classification_are_one_computation(tmp_path):
+    """The generator's ``MAXGEO_NOT_COVERED`` line and the shared bus/compute
+    classification cannot drift: the confession IS the classification's
+    ``uncovered``, minus exactly the dims a functional case drove."""
+    from orchestrator.langgraph.bfm_lib import (
+        bus_maxgeo_coverage,
+        declared_dimensional_maxima,
+    )
+    pr = _generic_run(tmp_path)
+    tb, res = _write_integration_tb(pr)
+    src = Path(tb).read_text(encoding="utf-8")
+    dims = declared_dimensional_maxima(pr)
+    cov = bus_maxgeo_coverage(QSPIContract(), dims)
+    confessed = {}
+    for line in src.splitlines():
+        if line.startswith("# MAXGEO_NOT_COVERED:"):
+            for n, v in _PAIR_RE.findall(line.split(":", 1)[1]):
+                confessed[n] = int(v)
+    assert confessed == {
+        n: v for n, v in cov.uncovered.items()
+        if n not in res["maxgeo_functional"]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Token matching -- never claim an axis you did not drive
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("dim,key,ok", [
+    ("unit_count", "unit_count", True),        # exact
+    ("frame_width", "width", True),            # key tokens subset of dim tokens
+    ("width", "frame_width", True),            # and the other direction
+    ("frame_width", "burst_width", False),     # shared token, different axis
+    ("num_triangles", "triangle_depth", False),
+    ("", "unit_count", False),
+])
+def test_token_match_rule(dim, key, ok):
+    from orchestrator.langgraph.bfm_lib import token_match
+    assert token_match(dim, key) is ok
+
+
+def test_functional_dims_need_the_value_too():
+    from orchestrator.langgraph.bfm_lib import functional_maxgeo_dims
+    dims = {"unit_count": 8, "frame_width": 64}
+    assert functional_maxgeo_dims({"unit_count": 8}, dims) == {"unit_count": 8}
+    # right name, BELOW the maximum -> not driven at max -> not claimed
+    assert functional_maxgeo_dims({"unit_count": 4}, dims) == {}
+    # right value, unrelated name -> a coincidence, not evidence
+    assert functional_maxgeo_dims({"unrelated_thing": 8}, dims) == {}

--- a/orchestrator/tests/test_param_schema.py
+++ b/orchestrator/tests/test_param_schema.py
@@ -305,7 +305,9 @@ class TestMaxgeoEndToEndFromSchema:
         tb = _write_tb(
             tmp_path / "tb" / "t.py",
             "import cocotb\n# MAXGEO: frame_width=640 frame_height=352\n")
-        assert pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb) is None
+        # run3-followups: full coverage is an explicit PASS verdict, not None.
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        assert v is not None and v.get("verdict") == "pass"
 
     def test_aes_nonvideo_schema_end_to_end(self, tmp_path):
         # NON-video two-domain proof: the deterministic gate fires identically
@@ -316,7 +318,8 @@ class TestMaxgeoEndToEndFromSchema:
         tb_ok = _write_tb(
             tmp_path / "tb" / "g.py",
             "import cocotb\n# MAXGEO: max_message_blocks=1024\n")
-        assert pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb_ok) is None
+        v_ok = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb_ok)
+        assert v_ok is not None and v_ok.get("verdict") == "pass"
 
     def test_legacy_prose_ers_still_noops(self, tmp_path):
         _write_ers(tmp_path, _LEGACY_PROSE)

--- a/orchestrator/tests/test_pipeline_graph.py
+++ b/orchestrator/tests/test_pipeline_graph.py
@@ -38,15 +38,19 @@ from orchestrator.langgraph.pipeline_graph import (
     build_block_subgraph,
     build_pipeline_graph,
     init_block_node,
+    integration_dv_decision_node,
     integration_dv_node,
     pipeline_complete_node,
     route_after_human,
     route_after_integration_dv,
+    route_after_integration_dv_decision,
     route_after_integration_review,
     route_after_uarch_review,
     route_after_validation_dv,
+    route_after_validation_dv_decision,
     route_decision,
     route_next_tier,
+    validation_dv_decision_node,
     validation_dv_node,
 )
 
@@ -216,6 +220,7 @@ class TestGraphConstruction:
             "init_tier", "process_block", "integration_review",
             "advance_tier", "pipeline_complete",
             "integration_check", "integration_dv", "validation_dv",
+            "integration_dv_decision", "validation_dv_decision",
         ]
         for name in expected:
             assert name in node_names, f"Missing orchestrator node: {name}"
@@ -298,15 +303,32 @@ class TestGraphConstruction:
             },
         })
 
+        # run3-followups two-phase flow: the DV node itself NEVER calls
+        # interrupt() (the one-cycle-late defect) -- it parks with the
+        # payload in state; the dedicated decision node consumes the
+        # response.
         dv_result = result["integration_dv_result"]
         assert dv_result["passed"] is False
         assert dv_result["phase"] == "tb_generation"
-        assert dv_result["action_taken"] == "fix_tb"
+        assert dv_result["pending_decision"] is True
         assert result["pipeline_done"] is False
-        assert route_after_integration_dv(result) == "integration_dv"
-        assert interrupts
-        assert interrupts[0]["phase"] == "tb_generation"
-        assert interrupts[0]["contract_audit"]["category"] == "INTEGRATION_TB_BUG"
+        assert not interrupts, "DV node must not call interrupt() directly"
+        payload = dv_result["interrupt_payload"]
+        assert payload["phase"] == "tb_generation"
+        assert payload["contract_audit"]["category"] == "INTEGRATION_TB_BUG"
+        assert route_after_integration_dv(result) == "integration_dv_decision"
+
+        decision = await integration_dv_decision_node({
+            "project_root": str(tmp_path),
+            "integration_dv_result": dv_result,
+        })
+        assert interrupts and interrupts[0] is payload
+        d_result = decision["integration_dv_result"]
+        assert d_result["action_taken"] == "fix_tb"
+        assert d_result["pending_decision"] is False
+        assert d_result["fix_applied"] == "repair generator"
+        assert route_after_integration_dv_decision(decision) == "integration_dv"
+        assert route_after_integration_dv(decision) == "integration_dv"
 
     @pytest.mark.asyncio
     async def test_integration_testbench_generator_accepts_written_file(self, tmp_path):
@@ -396,14 +418,27 @@ class TestGraphConstruction:
             },
         })
 
+        # run3-followups two-phase flow (see the integration variant).
         dv_result = result["validation_dv_result"]
         assert dv_result["passed"] is False
         assert dv_result["phase"] == "tb_generation"
-        assert dv_result["action_taken"] == "fix_tb"
-        assert route_after_validation_dv(result) == "validation_dv"
-        assert interrupts
-        assert interrupts[0]["phase"] == "tb_generation"
-        assert interrupts[0]["contract_audit"]["category"] == "VALIDATION_TB_BUG"
+        assert dv_result["pending_decision"] is True
+        assert not interrupts, "DV node must not call interrupt() directly"
+        payload = dv_result["interrupt_payload"]
+        assert payload["phase"] == "tb_generation"
+        assert payload["contract_audit"]["category"] == "VALIDATION_TB_BUG"
+        assert route_after_validation_dv(result) == "validation_dv_decision"
+
+        decision = await validation_dv_decision_node({
+            "project_root": str(tmp_path),
+            "validation_dv_result": dv_result,
+        })
+        assert interrupts and interrupts[0] is payload
+        d_result = decision["validation_dv_result"]
+        assert d_result["action_taken"] == "fix_tb"
+        assert d_result["pending_decision"] is False
+        assert route_after_validation_dv_decision(decision) == "validation_dv"
+        assert route_after_validation_dv(decision) == "validation_dv"
 
     def test_block_subgraph_has_expected_nodes(self):
         subgraph = build_block_subgraph().compile()
@@ -2129,6 +2164,9 @@ _SINGLE_PASS_NODES = {
     "init_tier", "process_block", "integration_review", "advance_tier",
     "pipeline_complete", "integration_check", "model_integration",
     "integration_dv", "validation_dv",
+    # run3-followups: dedicated interrupt-decision nodes (resume responses are
+    # consumed immediately, not one regeneration cycle late).
+    "integration_dv_decision", "validation_dv_decision",
     # Deterministic signoff-scorecard node: the pre-END funnel for the genuine
     # terminals (validation_dv done / integration_dv terminal-fail /
     # pipeline_complete abort). Shared by both topologies.

--- a/orchestrator/tests/test_rung3_fixes2.py
+++ b/orchestrator/tests/test_rung3_fixes2.py
@@ -153,7 +153,12 @@ class TestMaxgeoGateVerdict:
             tmp_path / "tb" / "t.py",
             "import cocotb\n# MAXGEO: frame_width=640 frame_height=352\n",
         )
-        assert pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb) is None
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        # run3-followups: an evaluated PASS is a verdict the caller LOGS,
+        # not a silent None (None now means only "gate disabled or no
+        # declared dims").
+        assert v is not None and v.get("verdict") == "pass"
+        assert v["marker_pairs"] == {"frame_width": 640, "frame_height": 352}
 
     def test_partial_marker_is_rejected(self, tmp_path):
         _write_ers(tmp_path, _VIDEO_DIMS_DOC)
@@ -201,7 +206,8 @@ class TestMaxgeoGateGenericNonVideo:
             "import cocotb\n"
             "# MAXGEO: cmd_fifo=512 max_burst_len=256 addr_range=1024\n",
         )
-        assert pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb) is None
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        assert v is not None and v.get("verdict") == "pass"
 
     def test_nonvideo_partial_marker_rejected(self, tmp_path):
         _write_ers(tmp_path, _NONVIDEO_DIMS_DOC)
@@ -268,10 +274,10 @@ class TestMaxgeoNodeWiring:
         self, tmp_path, monkeypatch
     ):
         _write_ers(tmp_path, _VIDEO_DIMS_DOC)
-        captured = {}
+        interrupts = []
 
         def fake_interrupt(payload):
-            captured.update(payload)
+            interrupts.append(payload)
             return {"action": "abort"}
         monkeypatch.setattr(pipeline_graph, "interrupt", fake_interrupt)
 
@@ -279,10 +285,15 @@ class TestMaxgeoNodeWiring:
             monkeypatch, tmp_path, tb_body="import cocotb\n# no marker\n")
         result = await pipeline_graph.integration_dv_node(state)
 
+        # run3-followups two-phase flow: the node parks with the payload in
+        # state; the decision node consumes the response.
         dv = result["integration_dv_result"]
         assert dv["passed"] is False
-        assert captured.get("type") == "integration_dv_failure"
-        assert "MAX-GEOMETRY" in captured.get("sim_log", "")
+        assert dv["pending_decision"] is True
+        assert not interrupts, "DV node must not call interrupt() directly"
+        payload = dv["interrupt_payload"]
+        assert payload.get("type") == "integration_dv_failure"
+        assert "MAX-GEOMETRY" in payload.get("sim_log", "")
 
     @pytest.mark.asyncio
     async def test_integration_dv_passes_when_marker_present(
@@ -348,3 +359,48 @@ class TestMaxgeoEquivNvectors:
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+class TestMaxgeoFunctionalMaxCase:
+    """run3-followups: a functional MAXIMUM-CONFIGURATION case (# MAXGEO_CASE,
+    emitted by the deterministic codegen) downgrades remaining per-dimension
+    gaps to a LOUD advisory -- the max config + full payload extents exercise
+    the 2^n wrap class end-to-end -- but ONLY when the case's extents attain
+    declared maxima. Otherwise the gate stays hard."""
+
+    def test_case_parser(self, tmp_path):
+        tb = _write_tb(
+            tmp_path / "tb" / "t.py",
+            "import cocotb\n"
+            "# MAXGEO_CASE: name=big_case cfg0=256 in_bytes=512 out_bytes=1024\n",
+        )
+        case = pipeline_graph._tb_maxgeo_case(tb)
+        assert case == {"name": "big_case", "cfg0": 256,
+                        "in_bytes": 512, "out_bytes": 1024}
+
+    def test_attaining_case_downgrades_to_advisory(self, tmp_path):
+        _write_ers(tmp_path, _NONVIDEO_DIMS_DOC)
+        tb = _write_tb(
+            tmp_path / "tb" / "t.py",
+            "import cocotb\n"
+            "# MAXGEO: addr_range=1024\n"
+            "# MAXGEO_CASE: name=big cfg0=256 in_bytes=512 out_bytes=1024\n",
+        )
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        assert v is not None and v.get("advisory") is True
+        assert v.get("scope") == "functional-max-case"
+        assert v["uncovered_dims"] == {"cmd_fifo": 512, "max_burst_len": 256}
+        assert "functional_max_case" in v
+
+    def test_non_attaining_case_stays_hard(self, tmp_path):
+        _write_ers(tmp_path, _NONVIDEO_DIMS_DOC)
+        tb = _write_tb(
+            tmp_path / "tb" / "t.py",
+            "import cocotb\n"
+            "# MAXGEO: addr_range=1024\n"
+            "# MAXGEO_CASE: name=small cfg0=7 in_bytes=512 out_bytes=1024\n",
+        )
+        v = pipeline_graph._maxgeo_gate_verdict(str(tmp_path), tb)
+        assert v is not None and not v.get("advisory")
+        assert v.get("verdict") != "pass"
+        assert "uncovered_dims" in v


### PR DESCRIPTION
## What

**Stacked on #80 (feat/pinmap-retires-adapter) — retarget after it merges.**

Closes the defects exposed by the raster autonomy run's DV phase — the run reached the chip gate-sim verdict, but only via operator interventions the engine itself then mishandled:

- **Resume responses consumed one cycle late**: LangGraph re-executes an interrupted node from the top, so the four DV interrupts (integration/validation × generation/sim) consumed their response only after a default cycle had regenerated the TB over the operator's `fix_tb` edit (three consecutive clobbers, then a false PASS on the clobbered TB). Interrupts now live in dedicated decision nodes (`integration_dv_decision` / `validation_dv_decision`) whose re-execution is just the `interrupt()` call.
- **MAXGEO disarmed by the operator flag**: "operator-reused TBs are trusted as-is" silently skipped the gate on exactly the cycles deserving more scrutiny. The gate now runs on every passing cycle and logs an explicit verdict whenever it evaluates.
- **Generator-side max-geometry case**: the deterministic codegen bakes a second host-flow test for the maximum-configuration acceptance case (golden at generation time) + `# MAXGEO_CASE` marker; an attaining case downgrades residual per-dim gaps to a loud carried-forward advisory instead of a structurally-undischargeable hard fail. The gate stays hard when no attaining case exists.
- **Registry single-sourcing**: the 18-declared / 13-confessed / 9-enforced disagreement is gone; value-collision-only "coverage" is now named (`value_only_dims`) in every verdict.
- **Honest reporting**: µarch gate banner reflects the actual outcome (a green CLEAN previously printed 4 lines after an advisory-dismissed true detection); composition-model timeouts run a static stall probe that localizes to a block when unambiguous; flat-synth attempt history is retained (silent self-recovery no longer possible); contract audits emit `recommended_resume_action` when their semantic recommendation isn't offerable; benchmark-shaped refs scrubbed.

## Evidence

420+ tests green across the touched suites; every pre-existing red triaged against a pristine `git archive HEAD` (byte-identical failures) and enumerated in the commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBWgL9qExhCeRdRMAXv7yX
