### PR TITLE
Backend resume + waive-and-proceed signoff, latched-control skill, PnR prompt fixes

### DIFF
--- a/orchestrator/architecture/constraints.py
+++ b/orchestrator/architecture/constraints.py
@@ -1345,6 +1345,31 @@ single violation MAY instead be reported with top-level ``violation_text`` /
 """
 
 
+def build_subagent_prompt(constraint: dict, artifact_bundle: str) -> str:
+    """One constraint subagent's user message: SHARED PREFIX first, charter last.
+
+    The eight subagents differ only in which constraint they check, and the
+    artifact bundle they share is the whole prompt by volume (measured: ~306 K
+    chars each, of which interface_contracts.json + block_diagram.json alone
+    are ~165 K, re-uploaded eight times at an 11 % prompt-cache hit rate).
+    Prompt caching is PREFIX-matched, so putting the per-subagent constraint
+    first made every one of the eight prompts diverge at character ~50 and none
+    of the shared bulk could be reused.
+
+    Bundle first, charter last => all eight prompts share a byte-identical
+    prefix. Nothing about WHAT a subagent checks changes.
+    """
+    return (
+        "## Artifact bundle\n"
+        f"{artifact_bundle}\n\n"
+        "## Constraint to verify\n"
+        f"**id:** `{constraint['id']}`\n\n"
+        f"**rule:**\n{constraint['description']}\n\n"
+        "Verify the constraint against the artifact bundle above. Respond "
+        "with JSON only."
+    )
+
+
 async def _run_constraint_subagent(
     constraint: dict,
     artifact_bundle: str,
@@ -1364,14 +1389,7 @@ async def _run_constraint_subagent(
 
     llm = ClaudeLLM(model=DEFAULT_MODEL, timeout=timeout_seconds)
 
-    user_prompt = (
-        "## Constraint to verify\n"
-        f"**id:** `{constraint['id']}`\n\n"
-        f"**rule:**\n{constraint['description']}\n\n"
-        "## Artifact bundle\n"
-        f"{artifact_bundle}\n\n"
-        "Verify the constraint. Respond with JSON only."
-    )
+    user_prompt = build_subagent_prompt(constraint, artifact_bundle)
 
     try:
         content = await llm.call(
@@ -1597,13 +1615,29 @@ async def check_constraints(
             os.environ.get("CORESMITH_CONSTRAINT_SUBAGENT_TIMEOUT", "600")
         )
 
-        subagent_results = await asyncio.gather(
-            *[
-                _run_constraint_subagent(c, artifact_bundle, timeout_seconds)
-                for c in applicable
-            ],
-            return_exceptions=False,
-        )
+        # CACHE WARM-UP: issue ONE subagent first, then the rest in parallel.
+        # Every prompt now shares a byte-identical prefix (the artifact
+        # bundle), but a cache entry only exists once some call has WRITTEN
+        # it -- firing all eight simultaneously means eight concurrent misses
+        # on the same prefix. One serial call primes it; the remaining N-1
+        # then run concurrently against a warm prefix.
+        subagent_results: list[list[dict]] = []
+        if applicable:
+            subagent_results.append(
+                await _run_constraint_subagent(
+                    applicable[0], artifact_bundle, timeout_seconds)
+            )
+            if len(applicable) > 1:
+                subagent_results.extend(
+                    await asyncio.gather(
+                        *[
+                            _run_constraint_subagent(
+                                c, artifact_bundle, timeout_seconds)
+                            for c in applicable[1:]
+                        ],
+                        return_exceptions=False,
+                    )
+                )
 
         llm_violations: list[dict] = [v for batch in subagent_results for v in batch]
         # LLM cross-artifact findings are CANDIDATES: render both cited sides

--- a/orchestrator/daemon/server.py
+++ b/orchestrator/daemon/server.py
@@ -973,6 +973,36 @@ async def backend_state():
     return state
 
 
+class BackendResumeRequest(BaseModel):
+    action: str = "retry"          # retry | skip | abort
+    constraint: str = ""
+
+
+@app.post("/backend/resume")
+async def backend_resume(req: BackendResumeRequest):
+    """Resume a parked backend interrupt (DRC/LVS/signoff ask_human).
+
+    Delegates to the MCP resume_backend (one implementation, two transports
+    -- the same split as /backend/start). Fire-and-forget is safe HERE
+    because the daemon event loop hosts the created task; the gap this
+    closes is that resume_backend was previously reachable only from a
+    short-lived MCP process, which silently lost the resume. Two campaigns
+    were run-blocked on this: backend start --full can only replay into the
+    same park, so a DRC/LVS-parked backend was terminal from the outside."""
+    try:
+        _mcp = _backend_handle()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(500, f"backend resume unavailable: {exc}") from exc
+    raw = await _mcp.resume_backend(action=req.action, constraint=req.constraint)
+    try:
+        result = json.loads(raw) if isinstance(raw, str) else dict(raw)
+    except (ValueError, TypeError):
+        return {"raw": raw}
+    if result.get("error"):
+        raise HTTPException(409, json.dumps(result))
+    return result
+
+
 @app.post("/backend/pause")
 async def backend_pause():
     try:

--- a/orchestrator/harness/gate_sim.py
+++ b/orchestrator/harness/gate_sim.py
@@ -515,9 +515,16 @@ def inout_is_inert(netlist_text: str, name: str) -> bool:
     zassign = re.compile(
         r"^\s*assign\s+\\?" + re.escape(name) +
         r"(?:\s*\[[^\]]*\])?\s*=\s*\d*'[hbodHBOD]?[zZ_]+\s*;")
+    # A same-name hierarchical pass-through (`.analog_io(analog_io),`) renames
+    # nothing and drives nothing: the parent hands the mandated pad bus to the
+    # leaf unchanged. Any OTHER connection shape (renamed net, expression,
+    # concatenation, slice) still disqualifies.
+    passthrough = re.compile(
+        r"^\s*\.\\?" + re.escape(name) +
+        r"\s*\(\s*\\?" + re.escape(name) + r"\s*\)\s*,?\s*$")
     for m in ref.finditer(netlist_text):
         line = m.group(0)
-        if decl.match(line) or zassign.match(line):
+        if decl.match(line) or zassign.match(line) or passthrough.match(line):
             continue
         return False
     return True

--- a/orchestrator/langchain/agents/block_golden_generator.py
+++ b/orchestrator/langchain/agents/block_golden_generator.py
@@ -39,7 +39,7 @@ from typing import Any
 from opentelemetry import trace
 
 from orchestrator._timeouts import scaled
-from orchestrator.langchain.prompts.skills import load_skills as _load_skills
+from orchestrator.langchain.prompts.skills import build_skill_section, select_skills
 
 from .coresmith_llm import ClaudeLLM
 
@@ -60,18 +60,46 @@ else:  # pragma: no cover - prompt ships with the repo
         "latency semantics."
     )
 
-# Inject the shared streaming-protocol skills so generated block models follow
-# the same handshake + framing (tvalid/tready, tlast/tuser) conventions every
-# other coresmith agent uses -- this is what lets the blocks COMPOSE.
-_SKILLS_TEXT = _load_skills(
-    "axi_stream", "srdy_drdy", "arithmetic_precision", "serialization_contract",
-    "buffer_stride_contract", "no_stimulus_keyed_memorization", "pipeline_contract")
-if _SKILLS_TEXT:
-    SYSTEM_PROMPT = (
-        SYSTEM_PROMPT
-        + "\n\n# Reference Skills (streaming protocol — follow these)\n\n"
-        + _SKILLS_TEXT
+# The shared streaming-protocol skills let the blocks COMPOSE, but they used to
+# be concatenated at IMPORT time -- ~82 K chars on every block model, most of it
+# inapplicable. They are now selected PER CALL from the block's own evidence
+# (see build_system_prompt); the rest are manifested with absolute paths for the
+# worker to read on demand.
+#
+#: Selected from this block's evidence.
+BLOCK_MODEL_SKILL_CANDIDATES: tuple[str, ...] = (
+    "axi_stream",
+    "srdy_drdy",
+    "arithmetic_precision",
+    "serialization_contract",
+    "buffer_stride_contract",
+    "pipeline_contract",
+)
+#: Always inline: port_naming (the contract is the naming authority and a
+#: collapsed name is only caught by a pre-sim gate) + the anti-cheat rule (a
+#: model that keys off the stimulus invalidates every DV verdict downstream).
+_BLOCK_MODEL_ALWAYS: tuple[str, ...] = (
+    "port_naming",
+    "no_stimulus_keyed_memorization",
+)
+
+
+def build_system_prompt(
+    block_spec: Any = None,
+    contracts: Any = None,
+    block_diagram: Any = None,
+) -> str:
+    """The block-model author's system prompt for ONE block."""
+    section = build_skill_section(
+        select_skills(
+            block_spec, contracts, block_diagram,
+            candidates=BLOCK_MODEL_SKILL_CANDIDATES,
+        ),
+        candidates=BLOCK_MODEL_SKILL_CANDIDATES,
+        always=_BLOCK_MODEL_ALWAYS,
+        heading="# Reference Skills (streaming protocol — follow these)",
     )
+    return SYSTEM_PROMPT + "\n\n" + section if section else SYSTEM_PROMPT
 
 
 def _contract_port_names(block_ports: Any, interface_contract: Any) -> list[str]:
@@ -252,9 +280,21 @@ class BlockGoldenGenerator:
                 except OSError:
                     pre_existing = ""
 
+            _system_prompt = build_system_prompt(
+                block_spec={
+                    "name": block_name,
+                    "ports": block_ports,
+                    "model_source": reference_impl_source,
+                    "golden_functions": slice_functions or [],
+                },
+                contracts=interface_contract,
+                block_diagram=block_ports or None,
+            )
+            span.set_attribute("system_prompt_chars", len(_system_prompt))
+
             run_name = f"Generate Block Model [{block_title}]"
             content = await self.llm.call(
-                system=SYSTEM_PROMPT,
+                system=_system_prompt,
                 prompt=user_message,
                 run_name=run_name,
             )

--- a/orchestrator/langchain/agents/debug_agent.py
+++ b/orchestrator/langchain/agents/debug_agent.py
@@ -96,6 +96,117 @@ Output a JSON object with:
 """
 
 
+#: Phases whose failure is decided by a DETERMINISTIC gate that runs BEFORE
+#: any testbench is generated. Nothing was simulated, so no VCD, no WaveKit
+#: audit and no cocotb log exists for these -- measured: 3/3 diagnosis agents
+#: sent to hunt for those artifacts reported the engine as broken instead of
+#: reading the conformance report that was sitting on disk.
+PRE_SIM_PHASES = ("conformance",)
+
+
+def _phase_evidence_section(block_name: str, phase: str) -> tuple[str, str]:
+    """(working-files block, instructions block) for the failure's REAL phase.
+
+    Split by phase so the diagnosis agent is never pointed at an artifact the
+    phase cannot have produced.
+    """
+    if phase in PRE_SIM_PHASES:
+        files = (
+            f"- Conformance / contract-gate report: "
+            f".coresmith/blocks/{block_name}/contract_conformance.json\n"
+            f"- Gate error (the EXACT expected port names): "
+            f".coresmith/blocks/{block_name}/previous_error.txt\n"
+            f"- FROZEN interface contract (the naming authority): "
+            f".coresmith/interface_contracts.json\n"
+            f"- RTL source (read its module header / port list): find the .v "
+            f"file for this block under rtl/\n"
+            f"- uArch spec: arch/uarch_specs/{block_name}.md\n"
+            f"- Constraints: .coresmith/blocks/{block_name}/constraints.json\n"
+            f"- Attempt history: .coresmith/blocks/{block_name}/attempt_history.json\n"
+            f"- Block diagram: .coresmith/block_diagram.json (for interface context)\n"
+            f"- ERS: arch/ers_spec.md\n\n"
+        )
+        instructions = (
+            f"## Instructions\n"
+            f"This is a PRE-SIMULATION failure: a deterministic contract gate "
+            f"FAILED the block BEFORE any testbench was generated. NO "
+            f"simulation ran. There is NO waveform, NO VCD, NO WaveKit audit "
+            f"and NO cocotb log for this attempt, and none is missing or "
+            f"broken -- they do not exist by construction. Do NOT ask for "
+            f"them, do NOT look for them, do NOT infer anything from "
+            f"simulation artifacts, and do NOT report their absence as an "
+            f"infrastructure failure.\n"
+            f"The evidence is exactly three things: the conformance report, "
+            f"the frozen interface contract, and the RTL's declared ports.\n"
+            f"1. Read the gate report + previous_error.txt: it names each "
+            f"deviating port and the EXACT name the contract requires\n"
+            f"2. Read the RTL's module header and compare its ports against "
+            f"the contract's channels (`<channel>_<field>`; a doubled token "
+            f"such as `data_write_write_enable` is CORRECT and must not be "
+            f"collapsed)\n"
+            f"3. Diagnose why the RTL deviated (category INTERFACE_MISMATCH "
+            f"unless the evidence says otherwise)\n"
+            f"4. Write your diagnosis to "
+            f".coresmith/blocks/{block_name}/diagnosis.json\n"
+            f"5. If you identify new constraints, append them to "
+            f".coresmith/blocks/{block_name}/constraints.json. Any naming "
+            f"constraint you write is SUBORDINATE to the contract: quote the "
+            f"contract's spelling, never a spelling you prefer\n\n"
+        )
+        return files, instructions
+
+    files = (
+        f"- Error log: .coresmith/blocks/{block_name}/previous_error.txt\n"
+        f"- Step logs: .coresmith/step_logs/{block_name}/ (read the latest {phase}_attempt*.log)\n"
+        f"- VCD waveform: sim_build/{block_name}/dump.vcd\n"
+        f"- WaveKit audit: sim_build/{block_name}/wavekit_audit.json\n"
+        f"- Integration VCD, if this is a chip-level failure: sim_build/integration/dump.vcd\n"
+        f"- Integration WaveKit audit, if relevant: sim_build/integration/wavekit_audit.json\n"
+        f"- RTL source: find the .v file for this block under rtl/\n"
+        f"- Testbench: tb/cocotb/test_{block_name}.py\n"
+        f"- uArch spec: arch/uarch_specs/{block_name}.md\n"
+        f"- Constraints: .coresmith/blocks/{block_name}/constraints.json\n"
+        f"- Attempt history: .coresmith/blocks/{block_name}/attempt_history.json\n"
+        f"- Block diagram: .coresmith/block_diagram.json (for interface context)\n"
+        f"- ERS: arch/ers_spec.md\n\n"
+    )
+    instructions = (
+        f"## Instructions\n"
+        f"1. Read the error log, step logs, VCD, and WaveKit audit to understand what failed\n"
+        f"2. Read the full RTL source and testbench to understand the design\n"
+        f"3. Read the uArch spec for design intent\n"
+        f"4. Diagnose the root cause\n"
+        f"5. Write your diagnosis to .coresmith/blocks/{block_name}/diagnosis.json\n"
+        f"6. If you identify new constraints, append them to "
+        f".coresmith/blocks/{block_name}/constraints.json\n\n"
+    )
+    return files, instructions
+
+
+def build_debug_user_message(block_name: str, phase: str = "sim") -> str:
+    """The failure-analysis agent's user message (the production constructor).
+
+    ``phase`` is the REAL phase the block died in. It used to be hardcoded
+    "sim" even for gates that fail pre-testbench.
+    """
+    files, instructions = _phase_evidence_section(block_name, phase)
+    return (
+        f"Block: {block_name}\n"
+        f"Failed phase: {phase}\n\n"
+        f"## Working Files\n"
+        f"Read these files to understand the failure:\n"
+        f"{files}"
+        f"{instructions}"
+        f"The diagnosis.json must contain these fields:\n"
+        f'  diagnosis, category, suggested_fix, affected_blocks, '
+        f'escalate, confidence, constraints, needs_human, '
+        f'human_question, is_testbench_bug\n\n'
+        f"Categories: LOGIC_ERROR, TIMING_ISSUE, INTERFACE_MISMATCH, "
+        f"RESET_BUG, ARITHMETIC_ERROR, STATE_MACHINE_BUG, "
+        f"TESTBENCH_BUG, INFRASTRUCTURE_ERROR"
+    )
+
+
 class DebugAgent:
     """Agent for failure analysis and debugging.
 
@@ -125,7 +236,11 @@ class DebugAgent:
 
         Args:
             block_name: Name of the failed block
-            phase: Failed phase ("lint", "sim", "synth")
+            phase: Failed phase ("lint", "sim", "synth", "conformance").
+                "conformance" (and anything else in PRE_SIM_PHASES) is
+                decided before a testbench exists -- the prompt then omits
+                every simulation artifact instead of sending the agent
+                looking for waveforms that cannot exist.
             project_root: Path to project root
             mode: "debug" or "architecture_review"
 
@@ -160,40 +275,7 @@ class DebugAgent:
         block_title = block_name.replace("_", " ").title()
 
         try:
-            user_message = (
-                f"Block: {block_name}\n"
-                f"Failed phase: {phase}\n\n"
-                f"## Working Files\n"
-                f"Read these files to understand the failure:\n"
-                f"- Error log: .coresmith/blocks/{block_name}/previous_error.txt\n"
-                f"- Step logs: .coresmith/step_logs/{block_name}/ (read the latest {phase}_attempt*.log)\n"
-                f"- VCD waveform: sim_build/{block_name}/dump.vcd\n"
-                f"- WaveKit audit: sim_build/{block_name}/wavekit_audit.json\n"
-                f"- Integration VCD, if this is a chip-level failure: sim_build/integration/dump.vcd\n"
-                f"- Integration WaveKit audit, if relevant: sim_build/integration/wavekit_audit.json\n"
-                f"- RTL source: find the .v file for this block under rtl/\n"
-                f"- Testbench: tb/cocotb/test_{block_name}.py\n"
-                f"- uArch spec: arch/uarch_specs/{block_name}.md\n"
-                f"- Constraints: .coresmith/blocks/{block_name}/constraints.json\n"
-                f"- Attempt history: .coresmith/blocks/{block_name}/attempt_history.json\n"
-                f"- Block diagram: .coresmith/block_diagram.json (for interface context)\n"
-                f"- ERS: arch/ers_spec.md\n\n"
-                f"## Instructions\n"
-                f"1. Read the error log, step logs, VCD, and WaveKit audit to understand what failed\n"
-                f"2. Read the full RTL source and testbench to understand the design\n"
-                f"3. Read the uArch spec for design intent\n"
-                f"4. Diagnose the root cause\n"
-                f"5. Write your diagnosis to .coresmith/blocks/{block_name}/diagnosis.json\n"
-                f"6. If you identify new constraints, append them to "
-                f".coresmith/blocks/{block_name}/constraints.json\n\n"
-                f"The diagnosis.json must contain these fields:\n"
-                f'  diagnosis, category, suggested_fix, affected_blocks, '
-                f'escalate, confidence, constraints, needs_human, '
-                f'human_question, is_testbench_bug\n\n'
-                f"Categories: LOGIC_ERROR, TIMING_ISSUE, INTERFACE_MISMATCH, "
-                f"RESET_BUG, ARITHMETIC_ERROR, STATE_MACHINE_BUG, "
-                f"TESTBENCH_BUG, INFRASTRUCTURE_ERROR"
-            )
+            user_message = build_debug_user_message(block_name, phase)
 
             run_name = f"Analyze Failure [{block_title}]"
             await self.llm.call(

--- a/orchestrator/langchain/agents/rtl_generator.py
+++ b/orchestrator/langchain/agents/rtl_generator.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from opentelemetry import trace
 
+from orchestrator.langchain.prompts.skills import load_skill_strict as _load_skill_strict
 from orchestrator.langchain.prompts.skills import load_skills as _load_skills
 
 from .coresmith_llm import DEFAULT_MODEL, ClaudeLLM
@@ -141,6 +142,19 @@ if _SKILLS_TEXT:
         + "\n\n"
         + _SKILLS_TEXT
     )
+
+# port_naming is ALWAYS inline (it is ~2 KB). The one rule that has no cheap
+# recovery path: a collapsed `<channel>_<field>` name is not caught until the
+# deterministic pre-sim conformance gate, and costs a whole regeneration. It
+# lived in NO prompt while the RTL generator was told to transcribe the golden
+# model's (collapsed) port list "byte-exact" -- see the AUTHORITATIVE PORT
+# NAMES table injected into every RTL user message.
+_PORT_NAMING_SKILL = _load_skill_strict("port_naming")
+SYSTEM_PROMPT = (
+    SYSTEM_PROMPT
+    + "\n\n# Reference Skill (canonical port naming -- MANDATORY)\n\n"
+    + _PORT_NAMING_SKILL
+)
 
 # QSPI-slave frontend / IO-subsystem blocks own the external chassis bus boundary
 # and keep shipping protocol-INCOMPLETE code (dropped cmd 0x05 read_status, short
@@ -302,6 +316,283 @@ def _recover_codex_artifact(
     return ""
 
 
+def _contract_port_table_fragment(project_root: str, block_name: str) -> str:
+    """The block's AUTHORITATIVE port names, derived from the frozen contract.
+
+    Reuses the conformance gate's own derivation
+    (``contract_conformance.contract_port_rows``) so the names the generator is
+    told to use are byte-identical to the names the gate demands. Without this
+    the RTL prompt carried only the golden model's COLLAPSED port list under a
+    "transcribe it EXACTLY (byte-exact)" directive, and the contract's port
+    table appeared in no prompt at all -- which is how a run lost 90 minutes to
+    `host_write_enable` where the contract said `host_write_write_enable`.
+
+    Best-effort: returns '' when there is no contract edge for this block or on
+    any error (never blocks RTL generation -- the gate still catches it).
+    """
+    if not project_root or not block_name:
+        return ""
+    try:
+        from orchestrator.langgraph.contract_conformance import (
+            format_contract_port_table,
+        )
+        return format_contract_port_table(project_root, block_name)
+    except Exception:  # noqa: BLE001 - best-effort, never block RTL generation
+        return ""
+
+
+def build_user_message(
+    block_name: str,
+    description: str = "",
+    attempt: int = 1,
+    rtl_target: str = "",
+    python_source_path: str = "",
+    reference_is_hw_golden: bool = False,
+    project_root: str = "",
+    rtl_language: str = "Verilog-2005",
+) -> str:
+    """Assemble the RTL generator's user message (the production constructor).
+
+    Split out of :meth:`RTLGeneratorAgent.generate` so the assembled prompt can
+    be asserted on directly, the way the other prompt builders in this repo
+    are.
+    """
+    parts = [
+        f"Block name: {block_name}",
+        f"Description: {description}",
+        f"Attempt: {attempt}",
+        "",
+        "## Working Files",
+        "Read these files to understand the design:",
+        f"- uArch Spec: arch/uarch_specs/{block_name}.md",
+        "- ERS: arch/ers_spec.md",
+        f"- Constraints: .coresmith/blocks/{block_name}/constraints.json",
+        (
+            f"- Hardware Golden Model (Amaranth): {python_source_path}"
+            if reference_is_hw_golden
+            else f"- Golden Model: {python_source_path}"
+        ),
+        "- Block Diagram: .coresmith/block_diagram.json (for interface context)",
+        "- Interface Contracts: .coresmith/interface_contracts.json "
+        "(canonical bit-level edge contracts — see inline excerpt below)",
+    ]
+
+    if reference_is_hw_golden:
+        # Step 1 of the microarchitecture restructure: the RTL is a
+        # *lowering* of the per-block Amaranth hardware golden, not an
+        # independent re-transcription of a float reference. This is the
+        # fix for "the RTL re-derives (and re-breaks) the hardware
+        # decisions the model already paid to make."
+        parts += [
+            "",
+            "## Reference is the HARDWARE GOLDEN — lower it, do not re-derive",
+            "The golden model above is the per-block Amaranth HARDWARE model, "
+            "NOT a floating-point reference. It is already in hardware "
+            "semantics: fixed-point arithmetic, resolved feedback/state, "
+            "and any performance derating already applied. Your job is to "
+            "LOWER it to RTL faithfully — the RTL must be FUNCTIONALLY "
+            "BYTE-EXACT to this model. Do NOT re-derive the algorithm from "
+            "a floating-point reference; do NOT change quantization, scan "
+            "order, rounding, saturation, or datapath widths; do NOT "
+            "'improve' or re-approximate the math. Transcribe its "
+            "arithmetic and control exactly. You MAY choose pipelining, "
+            "encoding, and resource sharing for PPA, but every produced "
+            "value must match the model bit-for-bit. This is about "
+            "BEHAVIOR: the model's PORT NAMES are not authoritative — see "
+            "the AUTHORITATIVE PORT NAMES table below.",
+        ]
+
+        # Inline the hardware-golden SOURCE (not just its path). The
+        # path-only reference let the RTL generator skim/skip the model
+        # and emit a cheap re-approximation that lints clean; inlining
+        # forces the byte-exact target into context, the same fix the
+        # interface contracts already use below.
+        _hw_src = _read_hw_golden_source(project_root, python_source_path)
+        if not _hw_src.strip():
+            # D1: the prompt three paragraphs up has just told the
+            # generator "the golden model above is the per-block Amaranth
+            # HARDWARE model ... the RTL must be FUNCTIONALLY BYTE-EXACT
+            # to this model". If the file cannot be read, that sentence
+            # is false and the generator is being asked to be byte-exact
+            # to nothing -- it will re-derive the algorithm, which is the
+            # precise failure the hardware-golden flag exists to stop.
+            # Reading "" and carrying on was a silent fail-open.
+            raise RuntimeError(
+                f"RTL generation for '{block_name}': the run promised a "
+                f"HARDWARE GOLDEN ({python_source_path}) as the "
+                "byte-exact lowering target (CORESMITH_RTL_FROM_HW_GOLDEN"
+                "), but it is empty or unreadable. Refusing to ask for a "
+                "byte-exact lowering of nothing -- the generator would "
+                "re-derive the algorithm and the equivalence gate would "
+                "then fail on RTL nobody could explain. Regenerate the "
+                "block model, or turn the flag off to fall back to the "
+                "reference golden."
+            )
+        if _hw_src and _prompt_slim_enabled():
+            # B4 prompt-slim: path + head instead of the full inline.
+            # The equivalence gate (with a fresh seed) catches any
+            # re-derivation, so the byte-exact target need not be dumped.
+            _head = "\n".join(_hw_src.splitlines()[:40])
+            parts += [
+                "",
+                "## HARDWARE GOLDEN MODEL — transcribe it EXACTLY (byte-exact)",
+                f"The hardware golden is `{python_source_path}` (READ THE "
+                "FULL FILE; first 40 lines shown for orientation). The RTL "
+                "must be functionally BYTE-EXACT to it: same algorithm, "
+                "mode/branch selection, arithmetic, quantization, scan "
+                "order, rounding, saturation, and datapath widths. Do NOT "
+                "substitute a heuristic or re-derive from a float reference "
+                "-- an RTL-vs-model equivalence gate "
+                "(`\"${CORESMITH_CLI:-coresmith}\" verify rtl <block>`) "
+                "checks this with a FRESH seed before the block "
+                "is accepted. Byte-exact applies to BEHAVIOR, not to the "
+                "model's port identifiers: take every port NAME from the "
+                "AUTHORITATIVE PORT NAMES table below.",
+                "```python",
+                _head,
+                "```",
+            ]
+        elif _hw_src:
+            parts += [
+                "",
+                "## HARDWARE GOLDEN MODEL SOURCE — transcribe this EXACTLY",
+                f"Below is `{python_source_path}` inlined. The RTL must be "
+                "functionally BYTE-EXACT to THIS code: same algorithm, "
+                "mode/branch selection, arithmetic, quantization, scan "
+                "order, rounding, saturation, and datapath widths. Do NOT "
+                "substitute a simpler heuristic, gradient/edge "
+                "approximation, or any re-derivation — every produced "
+                "value must match it bit-for-bit (an RTL-vs-model "
+                "equivalence gate checks this before the block is "
+                "accepted). Byte-exact applies to BEHAVIOR, not to the "
+                "model's port identifiers: take every port NAME from the "
+                "AUTHORITATIVE PORT NAMES table below.",
+                "```python",
+                _hw_src,
+                "```",
+            ]
+
+    # THE NAMING AUTHORITY. Derived from the frozen contract via the same
+    # machinery the pre-sim conformance gate uses, so what the generator is
+    # shown and what the gate demands cannot drift apart.
+    _port_table = _contract_port_table_fragment(project_root, block_name)
+    if _port_table:
+        parts.append(_port_table)
+        parts.append(
+            "\n" + _constraint_precedence_line()
+        )
+
+    # Inject the canonical contract slice for this block directly
+    # into the prompt. The v7 autopilot run proved that telling the
+    # agent "go read interface_contracts.json" is not enough — the
+    # RTL generator routinely ignored the file's bootstrap_policy.
+    # Inlining the relevant edges forces the contract into the
+    # generator's context window.
+    from .contract_lookup import (
+        format_block_contracts_prompt,
+        format_block_contracts_prompt_slim,
+        load_block_contracts,
+    )
+    _contracts_view = load_block_contracts(project_root, block_name)
+    # B4 prompt-slim: emit the bootstrap policy + a `coresmith contracts
+    # <block>` pointer instead of the full edge JSON dump.
+    if _prompt_slim_enabled():
+        _contracts_fragment = format_block_contracts_prompt_slim(
+            block_name, _contracts_view
+        )
+    else:
+        _contracts_fragment = format_block_contracts_prompt(
+            block_name, _contracts_view
+        )
+    if _contracts_fragment:
+        parts.append(_contracts_fragment)
+
+    # PDK arithmetic timing budget (gated; best-effort) -- the real
+    # per-op delays so the RTL sizes each registered pipeline stage
+    # instead of emitting a single-cycle combinational cloud. Same
+    # budget the uArch spec author consumed; honored here at RTL time.
+    _budget_text = _pdk_budget_fragment(project_root)
+    if _budget_text:
+        parts.append(
+            "\n--- PDK TIMING BUDGET (size each REGISTERED stage to "
+            "these per-op delays; the chained combinational delay in "
+            "any one stage must not exceed the clock period) ---\n"
+            + _budget_text
+        )
+
+    # Per-block PIPELINE STAGE MAP, audited from the Amaranth model's
+    # declared STAGE_BUDGET: each named stage -> a registered boundary
+    # with a known per-cycle op budget. This is the structural contract
+    # whose absence let the codec RD-search collapse into one comb cloud.
+    try:
+        from orchestrator.langgraph.latency_audit import (
+            stage_map_fragment as _stage_map,
+        )
+        _sm = _stage_map(project_root, block_name)
+        if _sm:
+            parts.append(
+                "\n--- PIPELINE STAGE MAP (from the model's audited "
+                "latency budget; realize EACH stage as a registered "
+                "always @(posedge clk) boundary) ---\n" + _sm
+            )
+    except Exception:  # noqa: BLE001 - best-effort, never block RTL gen
+        pass
+
+    # THROUGHPUT CONTRACT (v3): the block's DECLARED cyc/op + II as a
+    # HARD constraint. Delivery-time DV cycle-measures the RTL and
+    # rejects it above declared x 1.1 -- so the target the AES worker
+    # never saw is now in the RTL generator's context.
+    _thr_text = _throughput_contract_fragment(project_root, block_name)
+    if _thr_text:
+        parts.append(
+            "\n--- THROUGHPUT CONTRACT (your RTL is cycle-measured in "
+            "DV; exceeding declared x 1.1 is an automatic rejection -- "
+            "see system-prompt rule 18) ---\n" + _thr_text
+        )
+
+    if attempt > 1:
+        parts.extend([
+            f"- Previous Error: .coresmith/blocks/{block_name}/previous_error.txt",
+            f"- Existing RTL: {rtl_target} (use Edit to fix incrementally if possible)",
+        ])
+
+    parts.extend([
+        "",
+        "## Output",
+        f"Write the complete synthesizable {rtl_language} module to: {rtl_target}",
+        "Keep reset, handshakes, state, sideband metadata, error flags, "
+        "and pipeline boundary signals named and observable so the "
+        "downstream Verilator VCD can be audited with WaveKit.",
+        "",
+    ])
+
+    if attempt > 1:
+        parts.append(
+            "This is a RETRY. Read the previous error and the existing RTL. "
+            "If the fix is surgical, use the Edit tool to modify the existing "
+            "RTL in-place. Only regenerate from scratch if the design is "
+            "fundamentally wrong."
+        )
+    else:
+        parts.append(
+            "Read the uArch spec and golden model, then generate the "
+            "complete Verilog module and write it to the output path."
+        )
+
+    return "\n".join(parts)
+
+
+def _constraint_precedence_line() -> str:
+    """Naming precedence for the accumulated constraints.json ('' on error)."""
+    try:
+        from orchestrator.langgraph.contract_conformance import (
+            CONSTRAINT_PRECEDENCE_LINE,
+        )
+        return CONSTRAINT_PRECEDENCE_LINE
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 class RTLGeneratorAgent:
     """Agent for Python-to-Verilog RTL generation.
 
@@ -370,213 +661,16 @@ class RTLGeneratorAgent:
             _tool = synthesis_tool or self._DEFAULT_SYNTH_TOOL
             _pcon = process_constraints or self._DEFAULT_CONSTRAINTS
 
-            parts = [
-                f"Block name: {block_name}",
-                f"Description: {description}",
-                f"Attempt: {attempt}",
-                "",
-                "## Working Files",
-                "Read these files to understand the design:",
-                f"- uArch Spec: arch/uarch_specs/{block_name}.md",
-                "- ERS: arch/ers_spec.md",
-                f"- Constraints: .coresmith/blocks/{block_name}/constraints.json",
-                (
-                    f"- Hardware Golden Model (Amaranth): {python_source_path}"
-                    if reference_is_hw_golden
-                    else f"- Golden Model: {python_source_path}"
-                ),
-                "- Block Diagram: .coresmith/block_diagram.json (for interface context)",
-                "- Interface Contracts: .coresmith/interface_contracts.json "
-                "(canonical bit-level edge contracts — see inline excerpt below)",
-            ]
-
-            if reference_is_hw_golden:
-                # Step 1 of the microarchitecture restructure: the RTL is a
-                # *lowering* of the per-block Amaranth hardware golden, not an
-                # independent re-transcription of a float reference. This is the
-                # fix for "the RTL re-derives (and re-breaks) the hardware
-                # decisions the model already paid to make."
-                parts += [
-                    "",
-                    "## Reference is the HARDWARE GOLDEN — lower it, do not re-derive",
-                    "The golden model above is the per-block Amaranth HARDWARE model, "
-                    "NOT a floating-point reference. It is already in hardware "
-                    "semantics: fixed-point arithmetic, resolved feedback/state, "
-                    "and any performance derating already applied. Your job is to "
-                    "LOWER it to RTL faithfully — the RTL must be FUNCTIONALLY "
-                    "BYTE-EXACT to this model. Do NOT re-derive the algorithm from "
-                    "a floating-point reference; do NOT change quantization, scan "
-                    "order, rounding, saturation, or datapath widths; do NOT "
-                    "'improve' or re-approximate the math. Transcribe its "
-                    "arithmetic and control exactly. You MAY choose pipelining, "
-                    "encoding, and resource sharing for PPA, but every produced "
-                    "value must match the model bit-for-bit.",
-                ]
-
-                # Inline the hardware-golden SOURCE (not just its path). The
-                # path-only reference let the RTL generator skim/skip the model
-                # and emit a cheap re-approximation that lints clean; inlining
-                # forces the byte-exact target into context, the same fix the
-                # interface contracts already use below.
-                _hw_src = _read_hw_golden_source(project_root, python_source_path)
-                if not _hw_src.strip():
-                    # D1: the prompt three paragraphs up has just told the
-                    # generator "the golden model above is the per-block Amaranth
-                    # HARDWARE model ... the RTL must be FUNCTIONALLY BYTE-EXACT
-                    # to this model". If the file cannot be read, that sentence
-                    # is false and the generator is being asked to be byte-exact
-                    # to nothing -- it will re-derive the algorithm, which is the
-                    # precise failure the hardware-golden flag exists to stop.
-                    # Reading "" and carrying on was a silent fail-open.
-                    raise RuntimeError(
-                        f"RTL generation for '{block_name}': the run promised a "
-                        f"HARDWARE GOLDEN ({python_source_path}) as the "
-                        "byte-exact lowering target (CORESMITH_RTL_FROM_HW_GOLDEN"
-                        "), but it is empty or unreadable. Refusing to ask for a "
-                        "byte-exact lowering of nothing -- the generator would "
-                        "re-derive the algorithm and the equivalence gate would "
-                        "then fail on RTL nobody could explain. Regenerate the "
-                        "block model, or turn the flag off to fall back to the "
-                        "reference golden."
-                    )
-                if _hw_src and _prompt_slim_enabled():
-                    # B4 prompt-slim: path + head instead of the full inline.
-                    # The equivalence gate (with a fresh seed) catches any
-                    # re-derivation, so the byte-exact target need not be dumped.
-                    _head = "\n".join(_hw_src.splitlines()[:40])
-                    parts += [
-                        "",
-                        "## HARDWARE GOLDEN MODEL — transcribe it EXACTLY (byte-exact)",
-                        f"The hardware golden is `{python_source_path}` (READ THE "
-                        "FULL FILE; first 40 lines shown for orientation). The RTL "
-                        "must be functionally BYTE-EXACT to it: same algorithm, "
-                        "mode/branch selection, arithmetic, quantization, scan "
-                        "order, rounding, saturation, and datapath widths. Do NOT "
-                        "substitute a heuristic or re-derive from a float reference "
-                        "-- an RTL-vs-model equivalence gate "
-                        "(`\"${CORESMITH_CLI:-coresmith}\" verify rtl <block>`) "
-                        "checks this with a FRESH seed before the block "
-                        "is accepted.",
-                        "```python",
-                        _head,
-                        "```",
-                    ]
-                elif _hw_src:
-                    parts += [
-                        "",
-                        "## HARDWARE GOLDEN MODEL SOURCE — transcribe this EXACTLY",
-                        f"Below is `{python_source_path}` inlined. The RTL must be "
-                        "functionally BYTE-EXACT to THIS code: same algorithm, "
-                        "mode/branch selection, arithmetic, quantization, scan "
-                        "order, rounding, saturation, and datapath widths. Do NOT "
-                        "substitute a simpler heuristic, gradient/edge "
-                        "approximation, or any re-derivation — every produced "
-                        "value must match it bit-for-bit (an RTL-vs-model "
-                        "equivalence gate checks this before the block is "
-                        "accepted).",
-                        "```python",
-                        _hw_src,
-                        "```",
-                    ]
-
-            # Inject the canonical contract slice for this block directly
-            # into the prompt. The v7 autopilot run proved that telling the
-            # agent "go read interface_contracts.json" is not enough — the
-            # RTL generator routinely ignored the file's bootstrap_policy.
-            # Inlining the relevant edges forces the contract into the
-            # generator's context window.
-            from .contract_lookup import (
-                format_block_contracts_prompt,
-                format_block_contracts_prompt_slim,
-                load_block_contracts,
+            user_message = build_user_message(
+                block_name=block_name,
+                description=description,
+                attempt=attempt,
+                rtl_target=rtl_target,
+                python_source_path=python_source_path,
+                reference_is_hw_golden=reference_is_hw_golden,
+                project_root=project_root,
+                rtl_language=_lang,
             )
-            _contracts_view = load_block_contracts(project_root, block_name)
-            # B4 prompt-slim: emit the bootstrap policy + a `coresmith contracts
-            # <block>` pointer instead of the full edge JSON dump.
-            if _prompt_slim_enabled():
-                _contracts_fragment = format_block_contracts_prompt_slim(
-                    block_name, _contracts_view
-                )
-            else:
-                _contracts_fragment = format_block_contracts_prompt(
-                    block_name, _contracts_view
-                )
-            if _contracts_fragment:
-                parts.append(_contracts_fragment)
-
-            # PDK arithmetic timing budget (gated; best-effort) -- the real
-            # per-op delays so the RTL sizes each registered pipeline stage
-            # instead of emitting a single-cycle combinational cloud. Same
-            # budget the uArch spec author consumed; honored here at RTL time.
-            _budget_text = _pdk_budget_fragment(project_root)
-            if _budget_text:
-                parts.append(
-                    "\n--- PDK TIMING BUDGET (size each REGISTERED stage to "
-                    "these per-op delays; the chained combinational delay in "
-                    "any one stage must not exceed the clock period) ---\n"
-                    + _budget_text
-                )
-
-            # Per-block PIPELINE STAGE MAP, audited from the Amaranth model's
-            # declared STAGE_BUDGET: each named stage -> a registered boundary
-            # with a known per-cycle op budget. This is the structural contract
-            # whose absence let the codec RD-search collapse into one comb cloud.
-            try:
-                from orchestrator.langgraph.latency_audit import (
-                    stage_map_fragment as _stage_map,
-                )
-                _sm = _stage_map(project_root, block_name)
-                if _sm:
-                    parts.append(
-                        "\n--- PIPELINE STAGE MAP (from the model's audited "
-                        "latency budget; realize EACH stage as a registered "
-                        "always @(posedge clk) boundary) ---\n" + _sm
-                    )
-            except Exception:  # noqa: BLE001 - best-effort, never block RTL gen
-                pass
-
-            # THROUGHPUT CONTRACT (v3): the block's DECLARED cyc/op + II as a
-            # HARD constraint. Delivery-time DV cycle-measures the RTL and
-            # rejects it above declared x 1.1 -- so the target the AES worker
-            # never saw is now in the RTL generator's context.
-            _thr_text = _throughput_contract_fragment(project_root, block_name)
-            if _thr_text:
-                parts.append(
-                    "\n--- THROUGHPUT CONTRACT (your RTL is cycle-measured in "
-                    "DV; exceeding declared x 1.1 is an automatic rejection -- "
-                    "see system-prompt rule 18) ---\n" + _thr_text
-                )
-
-            if attempt > 1:
-                parts.extend([
-                    f"- Previous Error: .coresmith/blocks/{block_name}/previous_error.txt",
-                    f"- Existing RTL: {rtl_target} (use Edit to fix incrementally if possible)",
-                ])
-
-            parts.extend([
-                "",
-                "## Output",
-                f"Write the complete synthesizable {_lang} module to: {rtl_target}",
-                "Keep reset, handshakes, state, sideband metadata, error flags, "
-                "and pipeline boundary signals named and observable so the "
-                "downstream Verilator VCD can be audited with WaveKit.",
-                "",
-            ])
-
-            if attempt > 1:
-                parts.append(
-                    "This is a RETRY. Read the previous error and the existing RTL. "
-                    "If the fix is surgical, use the Edit tool to modify the existing "
-                    "RTL in-place. Only regenerate from scratch if the design is "
-                    "fundamentally wrong."
-                )
-            else:
-                parts.append(
-                    "Read the uArch spec and golden model, then generate the "
-                    "complete Verilog module and write it to the output path."
-                )
-
-            user_message = "\n".join(parts)
 
             # NOTE: use explicit placeholder substitution (NOT str.format) so
             # literal braces in prompt code examples -- e.g. the anti-memorization

--- a/orchestrator/langchain/agents/rtl_generator.py
+++ b/orchestrator/langchain/agents/rtl_generator.py
@@ -150,10 +150,13 @@ if _SKILLS_TEXT:
 # model's (collapsed) port list "byte-exact" -- see the AUTHORITATIVE PORT
 # NAMES table injected into every RTL user message.
 _PORT_NAMING_SKILL = _load_skill_strict("port_naming")
+_LATCHED_CTRL_SKILL = _load_skill_strict("latched_control_decisions")
 SYSTEM_PROMPT = (
     SYSTEM_PROMPT
     + "\n\n# Reference Skill (canonical port naming -- MANDATORY)\n\n"
     + _PORT_NAMING_SKILL
+    + "\n\n"
+    + _LATCHED_CTRL_SKILL
 )
 
 # QSPI-slave frontend / IO-subsystem blocks own the external chassis bus boundary

--- a/orchestrator/langchain/agents/uarch_spec_generator.py
+++ b/orchestrator/langchain/agents/uarch_spec_generator.py
@@ -24,7 +24,11 @@ from typing import Any
 from opentelemetry import trace
 
 from orchestrator._timeouts import scaled
-from orchestrator.langchain.prompts.skills import load_skills as _load_skills
+from orchestrator.langchain.prompts.skills import (
+    UARCH_SKILL_CANDIDATES,
+    build_skill_section,
+    select_skills,
+)
 
 from .coresmith_llm import ClaudeLLM
 
@@ -41,27 +45,18 @@ else:
         "Produce a detailed microarchitecture specification from a Python model."
     )
 
-# Inject handshake skills so every uArch spec author has access to the
-# coresmith conventions for AXI-Stream and sRdy/dRdy. Skills are loaded
-# at import time so a missing skill file is visible immediately rather
-# than at first agent call.
-_SKILLS_TEXT = _load_skills(
-    "axi_stream",
-    "srdy_drdy",
-    "arithmetic_precision",
-    "memory_macro_vs_flops",
-    "serialization_contract",
-    "buffer_stride_contract",
-    "pipeline_contract",
-    "throughput_budget_contract",
-    "control_pulse_handshake",
-)
-if _SKILLS_TEXT:
-    SYSTEM_PROMPT = (
-        SYSTEM_PROMPT
-        + "\n\n# Reference Skills (use when authoring interfaces)\n\n"
-        + _SKILLS_TEXT
-    )
+# Reference skills are NO LONGER concatenated at import time. All ten used to
+# be injected unconditionally, so a register-file block carried the full 18 K
+# bitstream-serialization skill: measured on a live run, 133 K of a 141 K-char
+# system prompt was skills, most of them inapplicable. They are now selected
+# PER CALL from the block's own evidence (see build_system_prompt below);
+# unselected skills are listed in a compact manifest with their absolute paths,
+# which the worker (which has filesystem read access) must read before
+# authoring in that domain. Nothing became unavailable; the token tax did.
+#
+# The missing-file fail-fast property is preserved and strengthened: a SELECTED
+# skill is loaded with load_skill_strict, which raises loudly at first use
+# instead of silently shrinking the prompt.
 
 # Inject the LIVE set of pre-built SRAM macros discovered in the PDK, so the
 # uArch author picks from what is actually available (not a hardcoded list) --
@@ -119,6 +114,42 @@ try:
     )
 except Exception:  # pragma: no cover - discovery is best-effort
     pass
+
+
+def _constraint_precedence_line() -> str:
+    """Naming precedence for a block's ACCUMULATED constraints ('' on error).
+
+    The accumulated constraints are a debug agent's reading of past failures;
+    the frozen contract is design intent. On a port NAME they disagree about,
+    the contract wins. Imported lazily so the agent module keeps no import-time
+    dependency on the langgraph package.
+    """
+    try:
+        from orchestrator.langgraph.contract_conformance import (
+            CONSTRAINT_PRECEDENCE_LINE,
+        )
+        return CONSTRAINT_PRECEDENCE_LINE
+    except Exception:  # noqa: BLE001 - prompt garnish, never blocks a spec
+        return ""
+
+
+def build_system_prompt(
+    block_spec: Any = None,
+    contracts: Any = None,
+    block_diagram: Any = None,
+) -> str:
+    """The uArch author's system prompt for ONE block.
+
+    ``SYSTEM_PROMPT`` (the authored prompt + the live SRAM macro menu) plus the
+    reference-skill section assembled for this block: ``port_naming`` always
+    inline, the skills this block's evidence implicates inline, everything else
+    named in the manifest with an absolute path to read.
+    """
+    section = build_skill_section(
+        select_skills(block_spec, contracts, block_diagram),
+        candidates=UARCH_SKILL_CANDIDATES,
+    )
+    return SYSTEM_PROMPT + "\n\n" + section if section else SYSTEM_PROMPT
 
 
 def normalize_feasibility(summary: dict) -> dict:
@@ -228,6 +259,13 @@ class UarchSpecGenerator:
                 f"Description: {description}",
             ]
 
+            # Evidence for per-call reference-skill selection (see
+            # build_system_prompt). Populated below from disk when a
+            # project_root is supplied; empty means "no evidence", and the
+            # classifier then conservatively inlines every skill.
+            _bd_block: dict = {}
+            _contracts_view: dict = {}
+
             if constraints:
                 parts.append("\n--- DESIGN CONSTRAINTS ---")
                 for i, c in enumerate(constraints, 1):
@@ -235,6 +273,7 @@ class UarchSpecGenerator:
                         parts.append(f"  {i}. {c.get('rule', str(c))}")
                     else:
                         parts.append(f"  {i}. {c}")
+                parts.append(_constraint_precedence_line())
                 parts.append("")
 
             # PDK arithmetic timing budget (gated; best-effort). Arms the author
@@ -365,6 +404,7 @@ class UarchSpecGenerator:
 
                         for blk in bd.get("blocks", []):
                             if blk.get("name") == block_name:
+                                _bd_block = blk if isinstance(blk, dict) else {}
                                 ifaces = blk.get("interfaces", {})
                                 if ifaces:
                                     parts.append(
@@ -423,7 +463,7 @@ class UarchSpecGenerator:
                     format_block_contracts_prompt,
                     load_block_contracts,
                 )
-                _contracts_view = load_block_contracts(project_root, block_name)
+                _contracts_view = load_block_contracts(project_root, block_name) or {}
                 _contracts_fragment = format_block_contracts_prompt(
                     block_name, _contracts_view
                 )
@@ -469,9 +509,25 @@ class UarchSpecGenerator:
 
             user_message = "\n".join(parts)
 
+            # Per-call system prompt: port_naming always inline, the rest
+            # selected from THIS block's evidence, unselected skills manifested
+            # with absolute paths.
+            _block_spec = dict(_bd_block)
+            _block_spec.update({
+                "name": block_name,
+                "description": description,
+                "model_source": python_source,
+            })
+            system_prompt = build_system_prompt(
+                block_spec=_block_spec,
+                contracts=_contracts_view or None,
+                block_diagram=_bd_block or None,
+            )
+            span.set_attribute("system_prompt_chars", len(system_prompt))
+
             run_name = f"Generate Uarch Spec [{block_title}]{revision_label}"
             content = await self.llm.call(
-                system=SYSTEM_PROMPT,
+                system=system_prompt,
                 prompt=user_message,
                 run_name=run_name,
                 resume_session_id=resume_session_id,

--- a/orchestrator/langchain/prompts/backend_pnr_llm.md
+++ b/orchestrator/langchain/prompts/backend_pnr_llm.md
@@ -102,15 +102,34 @@ The very first line of every OpenROAD TCL script you write MUST be
 routing single-threaded on a multi-core box wastes 3-8x wall clock and
 has caused step-timeout kills of routes that were converging cleanly.
 
-## PDN metal-4 min-area (REQUIRED on sky130)
+## PDN pin layer / metal-4 min-area (REQUIRED on sky130)
 
-PDN met4 pin/strap stubs narrower than the met4 minimum area are the
-dominant Magic-DRC artifact class on sky130 (met4.4a, ~0.24 um^2):
-`define_pdn_grid ... -pins met4` emits tiny stub rectangles in bands
-at the die edges. Prevent it in the PDN section of every script:
-put `-max_columns 2` on the **`add_pdn_connect`** call for every
-met4 layer pair -- NOT on `define_pdn_grid`, which does not accept it.
-This is verified against the installed OpenROAD build:
+**Put the top-level PDN pins on met5, not met4.** met4 pin emission at
+the die boundary produces min-area stub rectangles (Magic `met4.4a`,
+~0.24 um^2) that NO connection option can fix -- they are grid-emission
+geometry, not via geometry. Use met4 for straps only:
+
+    define_pdn_grid -name stdcell_grid \
+        -starts_with POWER \
+        -voltage_domain CORE \
+        -pins met5
+
+met5 as the top-level PDN pin layer is also the standard sky130 posture
+for macro/user-project designs: the harness power ring is normally met
+with met5 straps, so this matches how the chip actually takes power.
+
+Measured evidence for why met4 pins must not be used: on a sky130 chip
+with three SRAM macros, `-pins met4` produced 83 Magic violations, 100%
+of them `met4.4a`, as 76x76 rectangles in narrow bands at the die edges,
+while OpenROAD's own detailed-route DRC was 0. Adding `-max_columns 2`
+did not move the count and did not change a single rectangle -- the
+violating shapes were byte-identical before and after, because
+`max_columns` governs via-array columns on PDN *connections* and these
+shapes come from *pin* emission.
+
+If you do use `-max_columns` (for via-array control, which is a
+different purpose), put it on **`add_pdn_connect`**, never on
+`define_pdn_grid`:
 
     add_pdn_connect -grid stdcell_grid -layers {met1 met4} -max_columns 2
     add_pdn_connect -grid stdcell_grid -layers {met4 met5} -max_columns 2
@@ -119,11 +138,11 @@ This is verified against the installed OpenROAD build:
 `max_columns` is a parameter of `pdn::make_connect` (the SWIG entry point
 behind `add_pdn_connect`). Writing `define_pdn_grid ... -max_columns 2`
 fails at parse time with `[ERROR STA-0562] define_pdn_grid -max_columns
-is not a known keyword or flag`, and any `catch`/fallback around it
-silently reverts to the unmitigated grid -- the DRC count then does not
-move at all (observed: 83 met4.4a violations before and after). Do NOT
-wrap the PDN in a catch-and-fall-back: if the option is rejected, the
-script must FAIL LOUDLY rather than emit a layout with the same slivers.
+is not a known keyword or flag`.
 
-Also make met4 straps wide enough that every pin stub satisfies min-area.
-Signal routing is unaffected; this is purely the power-grid emission.
+Do NOT wrap the PDN in a `catch`/fallback. A rejected option that falls
+back silently emits the unmitigated grid and the DRC count does not move
+at all, while the log shows only a WARNING. If a PDN option is rejected,
+the script must FAIL LOUDLY rather than ship a layout with the same
+slivers. Signal routing is unaffected by any of this; it is purely the
+power-grid emission.

--- a/orchestrator/langchain/prompts/backend_pnr_llm.md
+++ b/orchestrator/langchain/prompts/backend_pnr_llm.md
@@ -108,7 +108,22 @@ PDN met4 pin/strap stubs narrower than the met4 minimum area are the
 dominant Magic-DRC artifact class on sky130 (met4.4a, ~0.24 um^2):
 `define_pdn_grid ... -pins met4` emits tiny stub rectangles in bands
 at the die edges. Prevent it in the PDN section of every script:
-pass `-max_columns 2` on the pdngen grid (proven recipe: 0 DRC on a
-prior sky130 chip), and make met4 straps wide enough that every pin
-stub satisfies min-area. Signal routing is unaffected; this is purely
-the power-grid emission.
+put `-max_columns 2` on the **`add_pdn_connect`** call for every
+met4 layer pair -- NOT on `define_pdn_grid`, which does not accept it.
+This is verified against the installed OpenROAD build:
+
+    add_pdn_connect -grid stdcell_grid -layers {met1 met4} -max_columns 2
+    add_pdn_connect -grid stdcell_grid -layers {met4 met5} -max_columns 2
+    add_pdn_connect -grid macro_grid   -layers {met4 met5} -max_columns 2
+
+`max_columns` is a parameter of `pdn::make_connect` (the SWIG entry point
+behind `add_pdn_connect`). Writing `define_pdn_grid ... -max_columns 2`
+fails at parse time with `[ERROR STA-0562] define_pdn_grid -max_columns
+is not a known keyword or flag`, and any `catch`/fallback around it
+silently reverts to the unmitigated grid -- the DRC count then does not
+move at all (observed: 83 met4.4a violations before and after). Do NOT
+wrap the PDN in a catch-and-fall-back: if the option is rejected, the
+script must FAIL LOUDLY rather than emit a layout with the same slivers.
+
+Also make met4 straps wide enough that every pin stub satisfies min-area.
+Signal routing is unaffected; this is purely the power-grid emission.

--- a/orchestrator/langchain/prompts/backend_pnr_llm.md
+++ b/orchestrator/langchain/prompts/backend_pnr_llm.md
@@ -94,3 +94,10 @@ If PnR fails after all retries:
 ```
 
 IMPORTANT: Write the result JSON file FIRST, then respond with a brief summary.
+
+## Threading (REQUIRED)
+
+The very first line of every OpenROAD TCL script you write MUST be
+`set_thread_count [exec nproc]` (or a explicit core count). Detailed
+routing single-threaded on a multi-core box wastes 3-8x wall clock and
+has caused step-timeout kills of routes that were converging cleanly.

--- a/orchestrator/langchain/prompts/backend_pnr_llm.md
+++ b/orchestrator/langchain/prompts/backend_pnr_llm.md
@@ -131,9 +131,9 @@ If you do use `-max_columns` (for via-array control, which is a
 different purpose), put it on **`add_pdn_connect`**, never on
 `define_pdn_grid`:
 
-    add_pdn_connect -grid stdcell_grid -layers {met1 met4} -max_columns 2
-    add_pdn_connect -grid stdcell_grid -layers {met4 met5} -max_columns 2
-    add_pdn_connect -grid macro_grid   -layers {met4 met5} -max_columns 2
+    add_pdn_connect -grid stdcell_grid -layers {{met1 met4}} -max_columns 2
+    add_pdn_connect -grid stdcell_grid -layers {{met4 met5}} -max_columns 2
+    add_pdn_connect -grid macro_grid   -layers {{met4 met5}} -max_columns 2
 
 `max_columns` is a parameter of `pdn::make_connect` (the SWIG entry point
 behind `add_pdn_connect`). Writing `define_pdn_grid ... -max_columns 2`

--- a/orchestrator/langchain/prompts/backend_pnr_llm.md
+++ b/orchestrator/langchain/prompts/backend_pnr_llm.md
@@ -101,3 +101,14 @@ The very first line of every OpenROAD TCL script you write MUST be
 `set_thread_count [exec nproc]` (or a explicit core count). Detailed
 routing single-threaded on a multi-core box wastes 3-8x wall clock and
 has caused step-timeout kills of routes that were converging cleanly.
+
+## PDN metal-4 min-area (REQUIRED on sky130)
+
+PDN met4 pin/strap stubs narrower than the met4 minimum area are the
+dominant Magic-DRC artifact class on sky130 (met4.4a, ~0.24 um^2):
+`define_pdn_grid ... -pins met4` emits tiny stub rectangles in bands
+at the die edges. Prevent it in the PDN section of every script:
+pass `-max_columns 2` on the pdngen grid (proven recipe: 0 DRC on a
+prior sky130 chip), and make met4 straps wide enough that every pin
+stub satisfies min-area. Signal routing is unaffected; this is purely
+the power-grid emission.

--- a/orchestrator/langchain/prompts/debug_agent.md
+++ b/orchestrator/langchain/prompts/debug_agent.md
@@ -64,8 +64,19 @@ COMMON FAILURE PATTERNS (check these FIRST before detailed analysis):
    or UARCH_SPEC_ERROR. Set confidence=0.99 and category=LOGIC_ERROR
    with diagnosis "false positive: prose words are not port names".
 
+FIRST, READ THE `Failed phase:` LINE IN THE USER MESSAGE. Not every failure
+came from a simulation. A PRE-SIMULATION phase (e.g. `conformance`) is decided
+by a deterministic gate that runs BEFORE the testbench is generated: no sim
+ran, so there is NO VCD, NO WaveKit audit and NO cocotb log for that attempt,
+and their absence is CORRECT, not a DV/process failure and not an
+infrastructure error. In a pre-simulation phase the evidence is the gate's
+report + the frozen interface contract + the RTL's declared ports, and nothing
+else; do not request, hunt for, or reason from simulation artifacts, and do not
+report the engine as broken for not producing them.
+
 Your job:
-1. Identify which signal diverged first. Read the WaveKit audit report and
+1. (SIMULATION PHASES ONLY -- skip entirely in a pre-simulation phase.)
+   Identify which signal diverged first. Read the WaveKit audit report and
    inspect the VCD when it exists. If the VCD or WaveKit audit is missing,
    empty, or header-only, classify that as a DV/process failure and include
    a concrete fix to restore waveform dumping/auditing.

--- a/orchestrator/langchain/prompts/skills/__init__.py
+++ b/orchestrator/langchain/prompts/skills/__init__.py
@@ -94,6 +94,10 @@ SKILL_PURPOSES: dict[str, str] = {
         "the canonical <channel>_<field> port name and the contract's primacy "
         "over golden-model port identifiers"
     ),
+    "latched_control_decisions": (
+        "Latch multi-cycle control decisions; never re-derive from live "
+        "signals in later FSM states (recurring silicon-bug class)."
+    ),
     "qspi_slave_frontend_protocol": (
         "complete QSPI-slave bus protocol for the block that owns the external "
         "chassis boundary"
@@ -133,7 +137,7 @@ UARCH_SKILL_CANDIDATES: tuple[str, ...] = (
 #: Injected INLINE on every call, never manifested. Small (~2 K) and the one
 #: rule with no cheap recovery path: a collapsed port name is not caught until
 #: the pre-sim conformance gate, and costs a full regeneration.
-ALWAYS_INLINE: tuple[str, ...] = ("port_naming",)
+ALWAYS_INLINE: tuple[str, ...] = ("port_naming", "latched_control_decisions")
 
 
 def skill_path(skill_id: str) -> Path:

--- a/orchestrator/langchain/prompts/skills/__init__.py
+++ b/orchestrator/langchain/prompts/skills/__init__.py
@@ -440,8 +440,9 @@ def _rule_buffer_stride(ev: _Evidence) -> bool | None:
         return None
     if _rule_serialization(ev):
         return True
-    if ev.hit("stride", "raster", "sub-block", "subblock", "sub_block",
-              "row_offset", "slot index", "slot_index", "byte offset"):
+    if ev.hit("stride", "sub-block", "subblock", "sub_block",
+              "row_offset", "slot index", "slot_index", "byte offset",
+              "scan order", "scan_order"):
         return True
     if ev.word("tile", "tiles"):
         return True

--- a/orchestrator/langchain/prompts/skills/__init__.py
+++ b/orchestrator/langchain/prompts/skills/__init__.py
@@ -1,4 +1,4 @@
-"""Skill loader for agent system prompts.
+"""Skill loader + per-call skill SELECTION for agent system prompts.
 
 Skills are reference markdown documents under
 `orchestrator/langchain/prompts/skills/`. Agents that author or consume
@@ -12,12 +12,133 @@ Usage:
 
 Each skill is a markdown file named `<id>.md`. The top-level heading
 and surrounding text become the prompt fragment as-is.
+
+WHY SELECTION EXISTS
+--------------------
+The uArch generator used to concatenate ten skills at IMPORT time, so every
+block -- a register file included -- carried the full 18 KB bitstream
+serialization skill plus 115 KB of other reference material it could not use.
+Measured on a live run: a 141 K-char system prompt of which ~133 K was skills.
+
+:func:`select_skills` maps EVIDENCE (the block's spec/description/model source,
+its contract edges, its block-diagram slice) to the skills that evidence
+implicates, and everything else is listed in a compact MANIFEST -- name, one
+sentence, absolute path -- with the instruction to READ THE FILE before
+authoring in that domain. The worker has filesystem read access, so nothing
+becomes unavailable; only the unconditional token tax goes away.
+
+The classifier is deliberately CONSERVATIVE: a rule that cannot judge (its
+evidence channel was not supplied) votes INCLUDE. A false include costs ~18 K
+chars; a false exclude costs a defect class.
 """
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
+from typing import Any
 
 _SKILLS_DIR = Path(__file__).resolve().parent
+
+
+class MissingSkillError(RuntimeError):
+    """A skill selected for INLINE injection has no file on disk.
+
+    Raised loudly at first use rather than degrading to an empty fragment: an
+    agent that silently loses its interface conventions produces RTL that
+    passes lint and fails composition.
+    """
+
+
+#: One sentence per skill, used for the "not inlined" manifest. Every skill
+#: that can be SELECTED must have an entry -- :func:`skill_manifest` raises
+#: otherwise, so adding a skill file without describing it fails loudly.
+SKILL_PURPOSES: dict[str, str] = {
+    "arithmetic_precision": (
+        "bit-width derivation, Q-format, rounding/saturation/wraparound rules "
+        "for fixed-point datapaths"
+    ),
+    "axi_stream": (
+        "AXI-Stream tvalid/tready/tlast/tuser framing, drain/EOF handshake and "
+        "the ack-and-drop trap"
+    ),
+    "buffer_stride_contract": (
+        "byte-identical buffer read/write address expressions; slot and row "
+        "stride agreement between producer and consumer"
+    ),
+    "control_pulse_handshake": (
+        "single-cycle control pulses (start/done/busy/event) and how they are "
+        "latched, acknowledged and cleared"
+    ),
+    "feedback_coupled_decomposition": (
+        "how to split blocks that sit in a feedback loop without creating a "
+        "combinational cycle"
+    ),
+    "memory_macro_vs_flops": (
+        "when storage must be a cs_sram macro instead of a flop array, and the "
+        "available sky130 SRAM geometries"
+    ),
+    "no_stimulus_keyed_memorization": (
+        "why a model/RTL must not key its behaviour off the test stimulus "
+        "(anti-cheat)"
+    ),
+    "output_contract_ownership": (
+        "which block owns each output field so no field is emitted twice or "
+        "dropped between blocks"
+    ),
+    "pipeline_contract": (
+        "arithmetic-per-stage scheduling: realize each declared stage as a "
+        "registered boundary instead of one combinational cloud"
+    ),
+    "port_naming": (
+        "the canonical <channel>_<field> port name and the contract's primacy "
+        "over golden-model port identifiers"
+    ),
+    "qspi_slave_frontend_protocol": (
+        "complete QSPI-slave bus protocol for the block that owns the external "
+        "chassis boundary"
+    ),
+    "serialization_contract": (
+        "bitstream serialization: emission cadence, field order, container "
+        "framing and terminal flush"
+    ),
+    "srdy_drdy": (
+        "sRdy/dRdy handshake semantics: a transfer is valid && ready sampled on "
+        "the clock edge, nothing more"
+    ),
+    "throughput_budget_contract": (
+        "declared cycles/op and initiation interval as a hard, measured "
+        "contract"
+    ),
+    "verify_in_context": (
+        "run your own check before declaring the artifact done"
+    ),
+}
+
+#: The reference-skill catalog the per-block AUTHORING agents (uArch spec,
+#: block model) choose from. Order is stable so assembled prompts are
+#: reproducible (and prompt-cacheable).
+UARCH_SKILL_CANDIDATES: tuple[str, ...] = (
+    "axi_stream",
+    "srdy_drdy",
+    "arithmetic_precision",
+    "memory_macro_vs_flops",
+    "serialization_contract",
+    "buffer_stride_contract",
+    "pipeline_contract",
+    "throughput_budget_contract",
+    "control_pulse_handshake",
+)
+
+#: Injected INLINE on every call, never manifested. Small (~2 K) and the one
+#: rule with no cheap recovery path: a collapsed port name is not caught until
+#: the pre-sim conformance gate, and costs a full regeneration.
+ALWAYS_INLINE: tuple[str, ...] = ("port_naming",)
+
+
+def skill_path(skill_id: str) -> Path:
+    """Absolute path of a skill's markdown file (whether or not it exists)."""
+    return _SKILLS_DIR / f"{skill_id}.md"
 
 
 def load_skill(skill_id: str) -> str:
@@ -27,10 +148,33 @@ def load_skill(skill_id: str) -> str:
     `axi_stream.md`). Missing skills return empty rather than raising
     so a prompt builder degrades gracefully.
     """
-    path = _SKILLS_DIR / f"{skill_id}.md"
+    path = skill_path(skill_id)
     if not path.exists():
         return ""
     return path.read_text(encoding="utf-8")
+
+
+def load_skill_strict(skill_id: str) -> str:
+    """Like :func:`load_skill` but RAISES when the file is missing.
+
+    Used by the per-call assembly path: a skill the classifier decided this
+    block needs must actually be in the prompt, and an empty string is not a
+    detectable failure downstream.
+    """
+    path = skill_path(skill_id)
+    try:
+        body = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MissingSkillError(
+            f"skill '{skill_id}' was selected for inline injection but "
+            f"{path} could not be read: {exc}"
+        ) from exc
+    if not body.strip():
+        raise MissingSkillError(
+            f"skill '{skill_id}' was selected for inline injection but "
+            f"{path} is empty"
+        )
+    return body
 
 
 def load_skills(*skill_ids: str, separator: str = "\n\n---\n\n") -> str:
@@ -43,4 +187,441 @@ def load_skills(*skill_ids: str, separator: str = "\n\n---\n\n") -> str:
     return separator.join(p for p in parts if p)
 
 
-__all__ = ["load_skill", "load_skills"]
+# ---------------------------------------------------------------------------
+# Evidence extraction
+# ---------------------------------------------------------------------------
+
+def _text_of(obj: Any) -> str:
+    """Flatten any JSON-ish object to lowercase searchable text."""
+    if obj is None:
+        return ""
+    if isinstance(obj, str):
+        return obj.lower()
+    try:
+        return json.dumps(obj, default=str).lower()
+    except (TypeError, ValueError):
+        return str(obj).lower()
+
+
+def _edges(contracts: Any) -> list[dict]:
+    """Accept any shape the callers actually hold.
+
+    ``contracts`` may be the full ``interface_contracts.json`` dict, the
+    per-block view from ``contract_lookup.load_block_contracts`` (``{"edges":
+    [...]}``), a bare list of edges, or a pre-rendered string.
+    """
+    if isinstance(contracts, dict):
+        for key in ("edges", "contracts"):
+            v = contracts.get(key)
+            if isinstance(v, list):
+                return [e for e in v if isinstance(e, dict)]
+        return []
+    if isinstance(contracts, list):
+        return [e for e in contracts if isinstance(e, dict)]
+    return []
+
+
+def _signal_names(edges: list[dict]) -> list[str]:
+    names: list[str] = []
+    for e in edges:
+        for key in ("fields", "sideband_signals"):
+            for f in e.get(key) or []:
+                n = f.get("name") if isinstance(f, dict) else f
+                if n:
+                    names.append(str(n).lower())
+        for key in ("producer_port", "consumer_port"):
+            v = e.get(key)
+            if v:
+                names.append(str(v).lower())
+    return names
+
+
+#: Contract VALUES that carry design intent. The contract schema's KEYS
+#: ("handshake_protocol", "consumer_can_stall", "signed", ...) are identical in
+#: every design, so dumping raw JSON would make several rules fire on schema
+#: boilerplate rather than on evidence. Only these values are searched.
+#:
+#: LABELS are machine-chosen identifiers (protocol name, channel name, packing
+#: convention). PROSE is free text an LLM wrote about the edge. They are kept
+#: apart because prose lies in the direction that matters: a real contract note
+#: reads "this is a physical pin bundle, NEVER axi or srdy/drdy", and a
+#: substring search over it selects both handshake skills for a block whose
+#: labels say `static`.
+_CONTRACT_LABEL_KEYS = (
+    "edge_id", "producer_block", "consumer_block", "producer_port",
+    "consumer_port", "handshake_protocol", "packing_convention", "encoding",
+    "policy_type", "semantics",
+)
+_CONTRACT_PROSE_KEYS = ("rate_description", "notes", "rationale", "description")
+
+
+def _contract_evidence_text(contracts: Any, edges: list[dict]) -> tuple[str, str]:
+    """``(labels, prose)`` from contract VALUES (never the schema's keys)."""
+    if isinstance(contracts, str):
+        return contracts.lower(), ""
+    labels: list[str] = []
+    prose: list[str] = []
+    if isinstance(contracts, dict):
+        v = contracts.get("default_packing_convention")
+        if isinstance(v, str):
+            labels.append(v)
+        for k in ("design_summary", "default_endianness_rationale"):
+            v = contracts.get(k)
+            if isinstance(v, str):
+                prose.append(v)
+
+    def _walk(obj: Any) -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if isinstance(v, (dict, list)):
+                    _walk(v)
+                elif v is None:
+                    continue
+                elif k in _CONTRACT_LABEL_KEYS:
+                    labels.append(str(v))
+                elif k in _CONTRACT_PROSE_KEYS:
+                    prose.append(str(v))
+        elif isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+
+    for e in edges:
+        _walk(e)
+    return " ".join(labels).lower(), " ".join(prose).lower()
+
+
+class _Evidence:
+    """What we actually know about the block, per channel.
+
+    Each channel is independently "supplied or not". A rule whose channel was
+    not supplied returns ``None`` (= no judgment) and the caller INCLUDES.
+    """
+
+    def __init__(self, block_spec: Any, contracts: Any, block_diagram: Any):
+        spec = block_spec if isinstance(block_spec, dict) else {}
+        self.spec = spec
+        self.spec_text = _text_of(block_spec) if block_spec else ""
+        self.model_source = str(
+            spec.get("model_source")
+            or spec.get("python_source")
+            or spec.get("golden_source")
+            or spec.get("source")
+            or ""
+        ).lower()
+        self.edges = _edges(contracts)
+        self.signals = _signal_names(self.edges)
+        self.contract_labels, self.contract_prose = (
+            _contract_evidence_text(contracts, self.edges) if contracts
+            else ("", "")
+        )
+        self.contract_text = f"{self.contract_labels} {self.contract_prose}"
+        self.diagram_text = _text_of(block_diagram) if block_diagram else ""
+        self.has_spec = bool(block_spec)
+        self.has_contracts = bool(contracts)
+        self.has_diagram = bool(block_diagram)
+        self.has_model = bool(self.model_source.strip())
+        self.any = self.has_spec or self.has_contracts or self.has_diagram
+        self.all_text = " ".join(
+            (self.spec_text, self.contract_text, self.diagram_text)
+        )
+        #: Everything EXCEPT the contract's free prose -- what the protocol
+        #: rules judge on, so a note that says "never AXI" cannot select the
+        #: AXI skill.
+        self.label_text = " ".join(
+            (self.spec_text, self.contract_labels, self.diagram_text)
+        )
+
+    def hit(self, *tokens: str) -> bool:
+        """Substring match -- for tokens long enough to be unambiguous."""
+        hay = self.all_text
+        return any(t in hay for t in tokens)
+
+    def label_hit(self, *tokens: str) -> bool:
+        """Substring match over LABELS only (contract prose excluded)."""
+        hay = self.label_text
+        return any(t in hay for t in tokens)
+
+    def label_word(self, *tokens: str) -> bool:
+        hay = self.label_text
+        return any(
+            re.search(r"(?<![a-z0-9_])" + re.escape(t) + r"(?![a-z0-9_])", hay)
+            for t in tokens
+        )
+
+    def word(self, *tokens: str) -> bool:
+        """Word-boundary match -- for short tokens.
+
+        ``"rom"``/``"lut"``/``"round"`` as substrings match ``from``,
+        ``absolute`` and ``background``; that is how a classifier ends up
+        including every skill for every block and proving nothing.
+        """
+        hay = self.all_text
+        return any(
+            re.search(r"(?<![a-z0-9_])" + re.escape(t) + r"(?![a-z0-9_])", hay)
+            for t in tokens
+        )
+
+    def signal_hit(self, *tokens: str) -> bool:
+        return any(t in s for s in self.signals for t in tokens)
+
+
+# --- per-skill rules: True = include, False = exclude, None = cannot judge ---
+
+def _rule_memory(ev: _Evidence) -> bool | None:
+    if not ev.any:
+        return None
+    if any(k in ev.spec for k in ("memory_map", "sram", "storage_bits",
+                                  "sram_budget", "memories")):
+        return True
+    if ev.hit("memory_map", "sram", "register file", "register_file",
+              "regfile", "scratchpad", "line buffer", "line_buffer",
+              "frame buffer", "framebuffer", "lookup table", "buffer",
+              "memory", "storage"):
+        return True
+    if ev.word("rom", "ram", "lut", "fifo", "cache", "mem", "dram", "cs_sram"):
+        return True
+    if ev.signal_hit("addr", "waddr", "raddr", "wdata", "rdata", "wmask",
+                     "write_enable", "read_enable"):
+        return True
+    return False
+
+
+def _rule_axi(ev: _Evidence) -> bool | None:
+    # Judged on LABELS (protocol/channel names) + signal names, never on the
+    # contract's free prose.
+    if ev.label_hit("tvalid", "tready", "tdata", "tlast", "tuser",
+                    "axi_stream", "axi-stream", "axis_", "_axis"):
+        return True
+    # "stream" as a WORD only: `encrypt_stream` is a golden-model function
+    # name, not an interface label.
+    if ev.label_word("axi", "beat", "beats", "stream", "streams", "streaming"):
+        return True
+    if ev.signal_hit("tvalid", "tready", "tdata", "tlast", "tuser"):
+        return True
+    # The interface labels live in the CONTRACT. Without it we are guessing.
+    return False if ev.has_contracts else None
+
+
+def _rule_srdy(ev: _Evidence) -> bool | None:
+    if ev.label_hit("srdy", "drdy", "backpressure", "back-pressure",
+                    "valid/ready", "ready/valid", "valid_ready", "ready_valid",
+                    "elastic", "req_ack", "req/ack", "handshak"):
+        return True
+    if ev.label_word("credit"):
+        return True
+    if ev.signal_hit("srdy", "drdy", "valid", "ready", "_vld", "_rdy"):
+        return True
+    return False if ev.has_contracts else None
+
+
+def _rule_serialization(ev: _Evidence) -> bool | None:
+    if not ev.any:
+        return None
+    if ev.hit("serializ", "serialis", "bitstream", "bit stream", "bit-stream",
+              "packing", "bitpack", "bit-pack", "unpack", "entropy",
+              "huffman", "varint", "framing", "marshal", "encoder", "decoder",
+              "codeword"):
+        return True
+    if ev.hit("packed bit", "bit-packed", "packed record of", "pack into"):
+        return True
+    if ev.word("container", "payload", "tlv", "emit", "encode", "decode",
+               "escape"):
+        return True
+    if ev.signal_hit("bitstream", "bit_len", "bitlen", "nbits", "packed",
+                     "byte_out", "flush", "eob"):
+        return True
+    return False
+
+
+def _rule_buffer_stride(ev: _Evidence) -> bool | None:
+    # Same evidence class as serialization (a packed buffer is read back by
+    # slot/stride), plus explicit stride/geometry language.
+    if not ev.any:
+        return None
+    if _rule_serialization(ev):
+        return True
+    if ev.hit("stride", "raster", "sub-block", "subblock", "sub_block",
+              "row_offset", "slot index", "slot_index", "byte offset"):
+        return True
+    if ev.word("tile", "tiles"):
+        return True
+    return False
+
+
+def _rule_pipeline(ev: _Evidence) -> bool | None:
+    if not ev.any:
+        return None
+    if any(k in ev.spec for k in ("stages", "pipeline_depth", "stage_budget",
+                                  "latency_cycles")):
+        return True
+    if ev.hit("pipeline", "multi-cycle", "multicycle", "state machine",
+              "iterat", "sequential", "latency", "throughput"):
+        return True
+    if ev.word("stage", "stages", "fsm", "round", "rounds", "cycles"):
+        return True
+    return False
+
+
+def _rule_throughput(ev: _Evidence) -> bool | None:
+    if not ev.any:
+        return None
+    if any(k in ev.spec for k in ("perf", "throughput", "cycles_per_op",
+                                  "cyc_per_op", "initiation_interval",
+                                  "target_throughput")):
+        return True
+    if ev.hit("throughput", "cycles/op", "cycles per op", "cyc/op",
+              "initiation interval", "ii=", "samples per", "bandwidth",
+              "per second", "mbps", "gbps", "fps", "frames/s", "throughput_"):
+        return True
+    return False
+
+
+def _rule_control_pulse(ev: _Evidence) -> bool | None:
+    if not ev.any:
+        return None
+    if ev.hit("control pulse", "single-cycle pulse", "start/done",
+              "interrupt", "trigger"):
+        return True
+    if ev.word("irq", "event", "events", "pulse", "abort"):
+        return True
+    if ev.signal_hit("start", "done", "busy", "kick", "go_", "_go", "trigger",
+                     "pulse", "irq", "abort", "cmd_valid", "soft_reset",
+                     "launch", "complete"):
+        return True
+    return False
+
+
+def _rule_arithmetic(ev: _Evidence) -> bool | None:
+    if ev.hit("arithmetic", "fixed-point", "fixed point", "q-format",
+              "quantiz", "saturat", "truncat", "multiply", "multiplier",
+              "accumulat", "dot product", "filter", "transform", "galois",
+              "overflow", "underflow", "rounding"):
+        return True
+    if ev.word("round", "mac", "fft", "dct", "idct", "gf", "add", "sum",
+               "scale", "divide", "sqrt"):
+        return True
+    if not ev.has_model:
+        # No model source supplied -> we cannot see the datapath math. Include.
+        return None
+    if re.search(r"[*/%]|<<|>>|\bmath\.|\bround\b|\bint\(|\bfloat\(",
+                 ev.model_source):
+        return True
+    return False
+
+
+_RULES = {
+    "axi_stream": _rule_axi,
+    "srdy_drdy": _rule_srdy,
+    "arithmetic_precision": _rule_arithmetic,
+    "memory_macro_vs_flops": _rule_memory,
+    "serialization_contract": _rule_serialization,
+    "buffer_stride_contract": _rule_buffer_stride,
+    "pipeline_contract": _rule_pipeline,
+    "throughput_budget_contract": _rule_throughput,
+    "control_pulse_handshake": _rule_control_pulse,
+}
+
+
+def select_skills(
+    block_spec: Any = None,
+    contracts: Any = None,
+    block_diagram: Any = None,
+    candidates: tuple[str, ...] | list[str] = UARCH_SKILL_CANDIDATES,
+) -> list[str]:
+    """Deterministically pick the skills this block's evidence implicates.
+
+    ``block_spec`` is anything dict-ish describing the block (``name``,
+    ``description``, ``model_source``/``python_source``, budgets...);
+    ``contracts`` is the block's contract slice in any of the shapes callers
+    hold; ``block_diagram`` is the diagram (or this block's slice of it).
+
+    Returns a list ordered by ``candidates`` (stable -> prompt-cacheable).
+
+    CONSERVATIVE: with no evidence at all, every candidate is returned. A rule
+    whose evidence channel was not supplied votes include.
+    """
+    ev = _Evidence(block_spec, contracts, block_diagram)
+    if not ev.any:
+        return list(candidates)
+    out: list[str] = []
+    for sid in candidates:
+        rule = _RULES.get(sid)
+        if rule is None:
+            out.append(sid)          # unknown skill -> cannot judge -> include
+            continue
+        verdict = rule(ev)
+        if verdict is None or verdict:
+            out.append(sid)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+_MANIFEST_HEADER = (
+    "# Reference skills NOT inlined (READ THE FILE before authoring in that "
+    "domain)\n\n"
+    "These reference documents were not inlined because this block's spec, "
+    "contract and diagram show no evidence they apply. They are NOT optional "
+    "if you turn out to need them: you have filesystem read access on this "
+    "machine, so if your design touches one of these domains you MUST read "
+    "the file at the path given before writing anything in that domain.\n"
+)
+
+
+def skill_manifest(skill_ids) -> str:
+    """One compact line per NOT-inlined skill: name, purpose, absolute path."""
+    ids = [s for s in skill_ids]
+    if not ids:
+        return ""
+    lines = [_MANIFEST_HEADER]
+    for sid in ids:
+        purpose = SKILL_PURPOSES.get(sid)
+        if not purpose:
+            raise MissingSkillError(
+                f"skill '{sid}' has no SKILL_PURPOSES entry; add one so the "
+                "manifest can describe it"
+            )
+        lines.append(f"- `{sid}` -- {purpose}. READ: {skill_path(sid)}")
+    return "\n".join(lines)
+
+
+def build_skill_section(
+    selected,
+    candidates: tuple[str, ...] | list[str] = UARCH_SKILL_CANDIDATES,
+    always: tuple[str, ...] | list[str] = ALWAYS_INLINE,
+    heading: str = "# Reference Skills (use when authoring interfaces)",
+    separator: str = "\n\n---\n\n",
+) -> str:
+    """Inline the selected (+ always) skill bodies; manifest the rest.
+
+    Inlined skills are loaded STRICTLY -- a missing file raises
+    :class:`MissingSkillError` at first use rather than silently shrinking the
+    prompt.
+    """
+    sel = list(dict.fromkeys(list(always) + [s for s in selected]))
+    bodies = [load_skill_strict(sid) for sid in sel]
+    excluded = [c for c in candidates if c not in sel]
+    parts: list[str] = []
+    if bodies:
+        parts.append(heading + "\n\n" + separator.join(bodies))
+    manifest = skill_manifest(excluded)
+    if manifest:
+        parts.append(manifest)
+    return "\n\n".join(parts)
+
+
+__all__ = [
+    "ALWAYS_INLINE",
+    "MissingSkillError",
+    "SKILL_PURPOSES",
+    "UARCH_SKILL_CANDIDATES",
+    "build_skill_section",
+    "load_skill",
+    "load_skill_strict",
+    "load_skills",
+    "select_skills",
+    "skill_manifest",
+    "skill_path",
+]

--- a/orchestrator/langchain/prompts/skills/latched_control_decisions.md
+++ b/orchestrator/langchain/prompts/skills/latched_control_decisions.md
@@ -1,0 +1,25 @@
+# Latched control decisions (FSM correctness — MANDATORY)
+
+**Any decoded control value that is consumed outside the cycle that produced
+it MUST be latched into a register. An FSM may never re-derive a decision from
+a live bus or datapath signal in a later state.**
+
+The recurring silicon bug this rule kills (three independent generations of it
+have shipped past block DV): a combinational expression is only VALID during
+one narrow window — e.g. `assign cmd = {hi_nibble_q, live_bus_nibble}` is the
+command byte exactly on the second command-nibble cycle — but a later FSM
+state (address phase, data phase, drain) re-reads the same expression, whose
+live component now carries UNRELATED data. The decode silently changes:
+a write opcode re-evaluated during the address phase becomes whatever the
+address nibble makes it.
+
+Rules:
+1. At the cycle a multi-cycle decision completes (opcode assembled, length
+   field finished, mode decoded), latch it: `decision_q <= decision_w;`.
+   Every later state reads `decision_q`, never the combinational form.
+2. Grep your own RTL before finishing: any `assign X_w = {..._q, live_input}`
+   consumed in more than one FSM state is a defect unless X is re-derived
+   fresh each cycle BY DESIGN (and then say so in a comment).
+3. Block-level DV is structurally weak against this class (the model often
+   shares the bug, and a TB can mask it by accident of address choice), so do
+   not rely on a green block sim — apply the rule at WRITE time.

--- a/orchestrator/langchain/prompts/skills/port_naming.md
+++ b/orchestrator/langchain/prompts/skills/port_naming.md
@@ -1,0 +1,56 @@
+# Skill: canonical port naming (`<channel>_<field>`)
+
+The interface contract is the SOLE naming authority for a block's ports.
+
+## The rule
+
+For every edge that touches this block, the contract names a channel (the
+block's `producer_port` / `consumer_port`) and lists the signals on it
+(`fields[]` + `sideband_signals[]` -- their UNION is the port set). The
+canonical flattened RTL port name is:
+
+    <channel>_<field>
+
+A signal the contract lists with no channel (a bare sideband such as `clk`,
+`rst_n`, or an externally mandated pad name) keeps its bare name.
+
+## NEVER shorten a doubled token
+
+When the channel suffix and the field prefix share a token, the token appears
+TWICE. That is correct and required:
+
+    channel: data_write        field: write_enable
+    canonical port name:  data_write_write_enable      <-- CORRECT
+    WRONG:                data_write_enable            <-- collapsed token
+    WRONG:                write_enable                 <-- dropped channel
+
+The doubled token is not a typo and not redundant. The deterministic
+integration assembler resolves contract edges BY NAME: `data_write_enable`
+does not resolve, the edge is unwireable, and the block is rejected by the
+pre-simulation conformance gate. Two channels on one block routinely carry
+the same field name (`read_enable`, `req_addr`, `valid`), and the channel
+prefix is the only thing that tells them apart.
+
+Same rule for a dropped or substituted prefix: `host_read_enable` is not an
+acceptable spelling of `framebuffer_read_read_enable`.
+
+## Precedence
+
+1. **The contract's port table wins.** It is the frozen, authoritative naming
+   source.
+2. A golden / reference model's port identifiers are NOT authoritative. Models
+   are written for simulation and routinely collapse or abbreviate names.
+   Transcribe the model's BEHAVIOR byte-exact; take every port NAME from the
+   contract table.
+3. Accumulated per-block constraints, prior attempts' RTL, testbench code, and
+   the uArch spec's prose are all subordinate to the contract table on naming.
+   If any of them names a port differently, the contract wins -- silently and
+   without asking.
+
+## Checklist before emitting a module header
+
+- [ ] Every contract signal on every edge touching this block has a port.
+- [ ] Each port is spelled `<channel>_<field>` exactly, character for
+      character, including any doubled token.
+- [ ] No port wears a channel prefix that the contract does not declare.
+- [ ] No signal is exposed twice (both `<channel>_<field>` and bare `<field>`).

--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -2459,6 +2459,16 @@ async def ask_human_node(state: BackendState) -> dict:
             _r["waived"] = True
             _r["waiver"] = _waiver
             out["lvs_result"] = _r
+        else:
+            # signoff-phase accept: the park can land after downstream stages
+            # already ran (diagnose picks up the earlier LVS failure). Waive
+            # the failed LVS here too, or advance_block re-fails on it.
+            _lr = state.get("lvs_result") or {}
+            if _lr.get("match") is False and not _lr.get("waived"):
+                _r = dict(_lr)
+                _r["waived"] = True
+                _r["waiver"] = _waiver
+                out["lvs_result"] = _r
         log(f"  [WAIVER] operator ACCEPTED failed {_phase} check -- "
             "recorded, proceeding to the next signoff stage. A waived check "
             "is reported as waived, never as clean.", YELLOW)
@@ -2957,7 +2967,7 @@ def route_after_human(state: BackendState) -> str:
         _phase = state.get("phase", "")
         if _phase == "drc":
             return "lvs"
-        if _phase == "lvs":
+        if _phase in ("lvs", "signoff"):
             return "timing_signoff"
         return "advance_block"
     mapping = {

--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -1734,7 +1734,7 @@ async def lvs_node(state: BackendState) -> dict:
     block_name = block["name"]
 
     drc_result = state.get("drc_result") or {}
-    if not drc_result.get("clean"):
+    if not (drc_result.get("clean") or drc_result.get("waived")):
         error_msg = drc_result.get("errors", "DRC not clean")
         return {"lvs_result": {"match": False, "errors": error_msg}, "phase": "lvs", "previous_error": error_msg}
 

--- a/orchestrator/langgraph/backend_graph.py
+++ b/orchestrator/langgraph/backend_graph.py
@@ -2425,6 +2425,11 @@ async def ask_human_node(state: BackendState) -> dict:
         "step_log_paths": state.get("step_log_paths", {}),
         "supported_actions": [
             "retry", "skip", "abort",
+            # accept: waive the CURRENT failed check (operator rationale
+            # recorded) and proceed to the NEXT signoff stage -- distinct
+            # from skip, which abandons the block and makes every later
+            # stage unreachable.
+            "accept",
         ],
     }
 
@@ -2435,7 +2440,29 @@ async def ask_human_node(state: BackendState) -> dict:
         "graph": "backend",
     })
 
-    return {"human_response": response}
+    out: dict = {"human_response": response}
+    if response.get("action") == "accept":
+        _phase = state.get("phase", "")
+        _waiver = {
+            "phase": _phase,
+            "rationale": response.get("constraint", "")
+            or response.get("feedback", ""),
+            "recorded_by": "operator_accept",
+        }
+        if _phase == "drc":
+            _r = dict(state.get("drc_result") or {})
+            _r["waived"] = True
+            _r["waiver"] = _waiver
+            out["drc_result"] = _r
+        elif _phase == "lvs":
+            _r = dict(state.get("lvs_result") or {})
+            _r["waived"] = True
+            _r["waiver"] = _waiver
+            out["lvs_result"] = _r
+        log(f"  [WAIVER] operator ACCEPTED failed {_phase} check -- "
+            "recorded, proceeding to the next signoff stage. A waived check "
+            "is reported as waived, never as clean.", YELLOW)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -2482,12 +2509,18 @@ async def advance_block_node(state: BackendState) -> dict:
     block_name = block["name"]
     attempt = state["attempt"]
 
-    drc_clean = (state.get("drc_result") or {}).get("clean", False)
-    lvs_match = (state.get("lvs_result") or {}).get("match", False)
+    _drc = state.get("drc_result") or {}
+    _lvs = state.get("lvs_result") or {}
+    drc_clean = _drc.get("clean", False) or _drc.get("waived", False)
+    lvs_match = _lvs.get("match", False) or _lvs.get("waived", False)
     timing_met = (state.get("timing_result") or {}).get("met", False)
     precheck = state.get("precheck_result") or {}
     precheck_ok = precheck.get("pass", False)
     all_pass = drc_clean and lvs_match and timing_met and precheck_ok
+    # A waived check satisfies the gate but is NEVER silent: the waivers ride
+    # in the block result and every report downstream.
+    waivers = [r["waiver"] for r in (_drc, _lvs)
+               if r.get("waived") and r.get("waiver")]
 
     power = state.get("power_result") or {}
     step_logs = dict(state.get("step_log_paths") or {})
@@ -2499,6 +2532,7 @@ async def advance_block_node(state: BackendState) -> dict:
         result = {
             "name": block_name,
             "success": True,
+            "waivers": waivers,
             "attempts": attempt,
             "total_power_mw": power.get("total_power_mw", 0),
             "dynamic_power_mw": power.get("dynamic_power_mw", 0),
@@ -2919,6 +2953,13 @@ route_decision.__edge_labels__ = {
 def route_after_human(state: BackendState) -> str:
     """Route based on the human's resume action."""
     action = (state.get("human_response") or {}).get("action", "retry")
+    if action == "accept":
+        _phase = state.get("phase", "")
+        if _phase == "drc":
+            return "lvs"
+        if _phase == "lvs":
+            return "timing_signoff"
+        return "advance_block"
     mapping = {
         "retry": "increment_attempt",
         "skip": "advance_block",
@@ -2931,6 +2972,8 @@ route_after_human.__edge_labels__ = {
     "increment_attempt": "RETRY",
     "advance_block": "SKIP",
     "backend_complete": "ABORT",
+    "lvs": "ACCEPT (waive DRC)",
+    "timing_signoff": "ACCEPT (waive LVS)",
 }
 
 

--- a/orchestrator/langgraph/bfm_lib/qspi_contract.py
+++ b/orchestrator/langgraph/bfm_lib/qspi_contract.py
@@ -56,6 +56,15 @@ class QSPIContract:
     # a narrow register (false-fail). Set 4 only when CFG1 is a full 32-bit
     # scalar and the wider probe is wanted.
     cfg1_width_bytes: int = 1
+    # Width (bytes) of the CTRL write issued by ``start()``/soft-reset. Default
+    # 1: a byte-wide access is universally legal on the byte-addressed map and
+    # CTRL bits live in byte 0 by convention, whereas the historical 4-byte
+    # write sprays addresses 1-3 -- deliberately reserved on exact-decode
+    # fail-closed designs, which flag them as malformed accesses (and a design
+    # fast enough to retire before the burst completes takes the hit while
+    # idle: sticky ERROR, false-failed run). Set wider only when CTRL is a
+    # genuine multi-byte scalar.
+    ctrl_width_bytes: int = 1
     in_addr: int = 0x001000          # W input window (auto-inc)
     out_addr: int = 0x002000         # R output window (auto-inc)
 

--- a/orchestrator/langgraph/bfm_lib/qspi_master_bfm.py
+++ b/orchestrator/langgraph/bfm_lib/qspi_master_bfm.py
@@ -169,9 +169,18 @@ class QSPIMasterBFM:
         await self.write(addr, bytes((value >> (8 * i)) & 0xFF for i in range(width_bytes)))
 
     async def start(self):
-        """Pulse CTRL.START."""
+        """Pulse CTRL.START.
+
+        Write width comes from the contract (``ctrl_width_bytes``), floored at
+        the byte that actually holds the START bit -- never the historical
+        blanket 4 bytes, which sprays reserved CTRL addresses on exact-decode
+        designs."""
+        _w = max(
+            int(getattr(self.c, "ctrl_width_bytes", 1) or 1),
+            (self.c.ctrl_start_bit // 8) + 1,
+        )
         await self.write_reg(
-            self.c.ctrl_addr, 1 << self.c.ctrl_start_bit, 4
+            self.c.ctrl_addr, 1 << self.c.ctrl_start_bit, _w
         )
 
     async def wait_done(self, timeout_wbclks: int = 5_000_000) -> bool:

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -49,8 +49,10 @@ and the park.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -58,6 +60,188 @@ from pathlib import Path
 #: MANDATED port names (io_in/io_out/io_oeb[37:0] are fixed by the shuttle), so
 #: the <channel>_<field> convention cannot apply to it.
 _LOCKED_BOUNDARY_PORTS = ("io_in", "io_out", "io_oeb")
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Deriving a canonical port name from contract text
+# ---------------------------------------------------------------------------
+#
+# The contract's channel and signal strings are NOT always bare identifiers.
+# The schema template the interface-definition agent is handed literally reads
+#
+#     "producer_port": "<m_axis_<name> or m_<name>_srdy/m_<name>_data>"
+#
+# so a real contract carries either a bare channel or a SLASH-SEPARATED
+# ENUMERATION of the concrete ports on that channel -- and a sideband is
+# sometimes declared under two names ("srdy/in_valid" = the generic protocol
+# role plus the spelling mandated on that edge). Concatenating those strings
+# verbatim into `<channel>_<field>` emitted port names containing `/`. No legal
+# UNESCAPED Verilog identifier can contain one, so the repair pass rewrote six
+# blocks' RTL to names nothing downstream can parse and the loop could never
+# converge. Everything below exists so a `/` can never reach an identifier.
+
+#: A legal, unescaped Verilog identifier. `\s_read_req/addr ` is legal only as
+#: an ESCAPED identifier, which no stitcher / cocotb handle lookup / netlist
+#: reader in this flow handles -- so it is not an acceptable port name here.
+_LEGAL_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+
+
+def is_legal_identifier(name) -> bool:
+    """Whether ``name`` may be emitted as an unescaped Verilog identifier."""
+    return bool(_LEGAL_IDENT_RE.match(str(name or "")))
+
+
+#: Illegal derivations already reported, so a 25-edge contract logs each defect
+#: once instead of once per block that touches it.
+_ILLEGAL_REPORTED: set = set()
+
+
+def _report_illegal(edge: dict, chan_raw, signal, derived: str) -> None:
+    """Loudly refuse a derived name that is not an identifier (never emit it).
+
+    Skipping is the only safe action: the alternative is rewriting a block's
+    RTL -- and its testbench -- to a name that cannot be declared, which is
+    what corrupted six blocks. It is logged at ERROR *and* on stderr because
+    the caller of this module owns logging and would otherwise swallow it.
+    """
+    key = (str(chan_raw), str(signal), derived)
+    if key in _ILLEGAL_REPORTED:
+        return
+    _ILLEGAL_REPORTED.add(key)
+    msg = (
+        "contract signal DROPPED from the port set -- the derived name is not "
+        f"a legal Verilog identifier. edge={edge.get('edge_id')!r} "
+        f"channel={chan_raw!r} signal={signal!r} derived={derived!r}. Fix the "
+        "CONTRACT (a channel/signal must reduce to an identifier); the RTL is "
+        "not at fault and must not be rewritten to this name."
+    )
+    _logger.error(msg)
+    print(f"[contract-conformance] {msg}", file=sys.stderr)
+
+
+def channel_base(raw) -> str:
+    """The channel PREFIX named by ``producer_port`` / ``consumer_port``.
+
+    A bare value is the channel. A slash-separated value ENUMERATES the
+    concrete ports on the channel; all three shapes occur in one 12-block
+    design::
+
+        m_coeff_out_srdy/m_coeff_out_data   -> m_coeff_out   (both qualified)
+        m_transform_read_req/addr           -> m_transform_read  (tail bare)
+        in_valid/in_data/in_last            -> in            (short prefix)
+
+    So the channel is the segments' longest common ``_``-token prefix. When no
+    later segment shares a leading token with the first (the ``.../addr``
+    shape), the segments are suffixes of one base and the first segment's
+    trailing token is its own signal, so the channel is everything before it.
+    """
+    segs = [s.strip() for s in str(raw or "").strip().split("/") if s.strip()]
+    if not segs:
+        return ""
+    if len(segs) == 1:
+        return segs[0]
+    head = segs[0].split("_")
+    common = None
+    for seg in segs[1:]:
+        toks = seg.split("_")
+        n = 0
+        while n < min(len(head), len(toks)) and head[n] == toks[n]:
+            n += 1
+        if n:
+            common = n if common is None else min(common, n)
+    if common:
+        return "_".join(head[:common])
+    return "_".join(head[:-1]) or segs[0]
+
+
+def signal_name(raw, chan: str = "") -> str:
+    """One concrete signal name from a (possibly slash-aliased) declaration.
+
+    ``srdy/in_valid`` declares ONE wire under two names -- the generic
+    handshake role and the spelling this edge mandates -- and only one of them
+    can be a port. Prefer the segment that already carries the channel prefix
+    (that is this end's fully-qualified spelling: on channel ``in`` the
+    contract's own port list says ``in_valid``, on channel ``s_source`` it says
+    ``s_source_srdy``), otherwise the first.
+    """
+    segs = [s.strip() for s in str(raw or "").split("/") if s.strip()]
+    if not segs:
+        return ""
+    if chan:
+        for seg in segs:
+            if seg == chan or seg.startswith(chan + "_"):
+                return seg
+    return segs[0]
+
+
+def canonical_port(chan: str, signal) -> tuple[str, str]:
+    """``(port, bare)`` -- the canonical flattened name for one channel signal.
+
+    ``<channel>_<signal>``, IDEMPOTENT in the channel prefix: a signal the
+    contract already spells with the channel on it (``in_last`` on channel
+    ``in``) is not prefixed a second time. Without that the derivation emitted
+    ``s_chan_s_chan_addr`` and then demanded the RTL rename to it.
+
+    The doubled-TOKEN rule is untouched, because it is a different thing:
+    channel ``data_write`` + signal ``write_enable`` is still
+    ``data_write_write_enable`` -- ``write_enable`` does not start with
+    ``data_write_``. Only a whole-prefix repeat is idempotent.
+
+    ``bare`` is the unprefixed spelling a block may legitimately use instead;
+    it equals ``port`` when the signal already carries the prefix (there is
+    then only ONE acceptable name, not two).
+    """
+    sig = signal_name(signal, chan)
+    if not sig:
+        return "", ""
+    if not chan or sig == chan or sig.startswith(chan + "_"):
+        return sig, sig
+    return f"{chan}_{sig}", sig
+
+
+def channel_signals(edge: dict, chan_raw) -> list[dict]:
+    """Canonical port rows for ONE END of a contract edge.
+
+    THE single derivation: :func:`check_block` (the gate) and
+    :func:`contract_port_rows` (what the RTL generator is shown) both go
+    through it, so the gate can never demand a spelling the prompt did not
+    advertise -- and a slash-alias cannot be fixed in one and not the other.
+
+    Returns ``[{channel, signal, port, bare, width, dir, kind,
+    doubled_token}]``, de-duplicated by port. A row whose derived name is not a
+    legal identifier is DROPPED and reported; nothing downstream ever sees it.
+    """
+    chan = channel_base(chan_raw)
+    if chan and not is_legal_identifier(chan):
+        _report_illegal(edge, chan_raw, "<channel>", chan)
+        return []
+    rows: list[dict] = []
+    seen: set = set()
+    for spec in signal_specs(edge):
+        port, bare = canonical_port(chan, spec["name"])
+        if not port:
+            continue
+        if not is_legal_identifier(port):
+            _report_illegal(edge, chan_raw, spec["name"], port)
+            continue
+        if port in seen:
+            continue
+        seen.add(port)
+        chan_tail = chan.rsplit("_", 1)[-1]
+        sig_head = bare.split("_", 1)[0]
+        rows.append({
+            "channel": chan,
+            "signal": bare,
+            "port": port,
+            "bare": bare,
+            "width": spec["width"],
+            "dir": spec["dir"],
+            "kind": spec["kind"],
+            "doubled_token": bool(chan_tail) and chan_tail == sig_head,
+        })
+    return rows
 
 
 @dataclass
@@ -209,25 +393,12 @@ def contract_port_rows(project_root, block_name: str) -> list[dict]:
             role_key = "producer_block" if role == "producer" else "consumer_block"
             if edge.get(role_key) != block_name:
                 continue
-            chan = str(edge.get(key) or "")
-            if not chan:
+            chan_raw = str(edge.get(key) or "")
+            if not chan_raw:
                 continue
-            for spec in signal_specs(edge):
-                name = spec["name"]
-                port = f"{chan}_{name}"
-                chan_tail = chan.rsplit("_", 1)[-1]
-                sig_head = name.split("_", 1)[0]
-                rows.append({
-                    "channel": chan,
-                    "role": role,
-                    "signal": name,
-                    "port": port,
-                    "width": spec["width"],
-                    "dir": spec["dir"],
-                    "kind": spec["kind"],
-                    "peer": str(edge.get(peer_key) or ""),
-                    "doubled_token": bool(chan_tail) and chan_tail == sig_head,
-                })
+            for row in channel_signals(edge, chan_raw):
+                rows.append(dict(
+                    row, role=role, peer=str(edge.get(peer_key) or "")))
     return rows
 
 
@@ -388,13 +559,22 @@ def check_block(project_root, block_name: str, rtl_path,
                           ("consumer_block", "consumer_port")):
             if edge.get(role) != block_name:
                 continue
-            chan = str(edge.get(key) or "")
-            if not chan:
+            chan_raw = str(edge.get(key) or "")
+            if not chan_raw:
                 continue
             res.checked_edges += 1
-            for n in _signal_names(edge):
-                prefixed, bare = f"{chan}_{n}", n
-                has_p, has_b = prefixed in ports, bare in ports
+            # ONE derivation, shared with the prompt's port table: a channel
+            # or signal spelled as a slash enumeration/alias is reduced here,
+            # never concatenated into an unparseable name.
+            chan = channel_base(chan_raw)
+            for row in channel_signals(edge, chan_raw):
+                prefixed, bare = row["port"], row["bare"]
+                has_p = prefixed in ports
+                # When the contract's signal already carries the channel
+                # prefix there is only ONE acceptable spelling, so the bare
+                # form is not a second candidate (and cannot be "ambiguous"
+                # with itself).
+                has_b = bare != prefixed and bare in ports
                 if has_p and has_b:
                     # Two candidate ports for one declared signal: the stitcher
                     # would have to pick, and picking is how channels get
@@ -429,7 +609,9 @@ def check_block(project_root, block_name: str, rtl_path,
         for role, key in (("producer_block", "producer_port"),
                           ("consumer_block", "consumer_port")):
             if edge.get(role) == block_name and edge.get(key):
-                channels.add(str(edge[key]))
+                base = channel_base(edge[key])
+                if base:
+                    channels.add(base)
     for port in sorted(ports):
         if port in accepted or port in _LOCKED_BOUNDARY_PORTS:
             continue
@@ -496,7 +678,23 @@ def plan_port_repairs(result: "ConformanceResult") -> dict:
             pairs.setdefault(free[0], []).append(want)
 
     # A source port wanted by two declared names is ambiguous -- drop it.
-    return {have: wants[0] for have, wants in pairs.items() if len(wants) == 1}
+    plan = {have: wants[0] for have, wants in pairs.items() if len(wants) == 1}
+
+    # Last line of defence before RTL is rewritten: never rename a port to
+    # something that is not an identifier. `check_block` already refuses to
+    # derive one, so reaching here means a new derivation path was added --
+    # and a rename is the step that turns a bad name into corrupted source.
+    safe = {}
+    for have, want in plan.items():
+        if is_legal_identifier(want) and is_legal_identifier(have):
+            safe[have] = want
+        else:
+            _logger.error(
+                "REFUSING port repair %r -> %r: not a legal Verilog "
+                "identifier. The RTL is left untouched.", have, want)
+            print(f"[contract-conformance] REFUSING port repair {have!r} -> "
+                  f"{want!r}: not a legal Verilog identifier", file=sys.stderr)
+    return safe
 
 
 def repair_block_ports(project_root, block_name: str, rtl_path,

--- a/orchestrator/langgraph/contract_conformance.py
+++ b/orchestrator/langgraph/contract_conformance.py
@@ -136,27 +136,171 @@ def _load_contracts(project_root) -> list[dict]:
     return c if isinstance(c, list) else []
 
 
-def _signal_names(edge: dict) -> list[str]:
-    """Every signal on a channel: the payload fields plus the sideband.
+def signal_specs(edge: dict) -> list[dict]:
+    """Every signal on a channel, with what the contract says about it.
 
-    Split across two keys in the schema, which is precisely why several readers
-    concluded the contract did not record them at all.
+    The payload fields plus the sideband -- split across two keys in the
+    schema, which is precisely why several readers concluded the contract did
+    not record them at all. Their UNION is the port set.
+
+    Returns ``[{"name", "width", "dir", "kind"}]`` in contract order,
+    de-duplicated by name. ``width``/``dir`` are ``""`` when the contract does
+    not state them. This is the single union implementation: both the
+    conformance checker and the prompt-side port table read it, so the
+    generator can never be shown a port set the gate does not check.
     """
-    out: list[str] = []
-    for f in edge.get("fields") or []:
-        n = f.get("name") if isinstance(f, dict) else f
-        if n:
-            out.append(str(n))
-    for s in edge.get("sideband_signals") or []:
-        n = s.get("name") if isinstance(s, dict) else s
-        if n:
-            out.append(str(n))
+    out: list[dict] = []
+    for kind, key in (("field", "fields"), ("sideband", "sideband_signals")):
+        for f in edge.get(key) or []:
+            if isinstance(f, dict):
+                name = f.get("name")
+                width = f.get("width")
+                if width is None:
+                    msb, lsb = f.get("msb"), f.get("lsb")
+                    if isinstance(msb, int) and isinstance(lsb, int):
+                        width = abs(msb - lsb) + 1
+                direction = (
+                    f.get("dir") or f.get("direction") or f.get("towards") or ""
+                )
+            else:
+                name, width, direction = f, None, ""
+            if not name:
+                continue
+            out.append({
+                "name": str(name),
+                "width": "" if width is None else str(width),
+                "dir": str(direction),
+                "kind": kind,
+            })
     seen, uniq = set(), []
-    for n in out:
-        if n not in seen:
-            seen.add(n)
-            uniq.append(n)
+    for spec in out:
+        if spec["name"] not in seen:
+            seen.add(spec["name"])
+            uniq.append(spec)
     return uniq
+
+
+def _signal_names(edge: dict) -> list[str]:
+    """Every signal name on a channel (payload fields plus sideband)."""
+    return [s["name"] for s in signal_specs(edge)]
+
+
+def contract_port_rows(project_root, block_name: str) -> list[dict]:
+    """The ports the contract DECLARES for one block, as canonical rows.
+
+    Walks exactly the edges :func:`check_block` walks, in the same order, and
+    builds the same ``f"{chan}_{n}"`` expectation -- so what the generator is
+    shown and what the gate demands are derived from one place. Returns::
+
+        [{"channel", "role", "signal", "port", "width", "dir", "kind",
+          "peer", "doubled_token"}]
+
+    ``port`` is the canonical flattened name. ``doubled_token`` marks the rows
+    whose channel suffix and signal prefix share a token (``data_write`` +
+    ``write_enable`` -> ``data_write_write_enable``), i.e. exactly the rows a
+    generator "tidies up" into an unwireable name.
+    """
+    rows: list[dict] = []
+    for edge in _load_contracts(project_root):
+        for role, key, peer_key in (
+            ("producer", "producer_port", "consumer_block"),
+            ("consumer", "consumer_port", "producer_block"),
+        ):
+            role_key = "producer_block" if role == "producer" else "consumer_block"
+            if edge.get(role_key) != block_name:
+                continue
+            chan = str(edge.get(key) or "")
+            if not chan:
+                continue
+            for spec in signal_specs(edge):
+                name = spec["name"]
+                port = f"{chan}_{name}"
+                chan_tail = chan.rsplit("_", 1)[-1]
+                sig_head = name.split("_", 1)[0]
+                rows.append({
+                    "channel": chan,
+                    "role": role,
+                    "signal": name,
+                    "port": port,
+                    "width": spec["width"],
+                    "dir": spec["dir"],
+                    "kind": spec["kind"],
+                    "peer": str(edge.get(peer_key) or ""),
+                    "doubled_token": bool(chan_tail) and chan_tail == sig_head,
+                })
+    return rows
+
+
+#: Prepended wherever a block's ACCUMULATED constraints (constraints.json) are
+#: put in front of a generator. Learned constraints are written by a debug
+#: agent looking at one failure; the contract is frozen design intent. When
+#: they disagree about a NAME, the contract wins -- silently, without asking.
+CONSTRAINT_PRECEDENCE_LINE = (
+    "PRECEDENCE: these accumulated constraints are subordinate to the "
+    "interface contract's port table on anything to do with NAMING. If a "
+    "constraint (or a previous attempt's RTL, or the golden model, or the "
+    "uArch spec's prose) spells a port differently from the contract's "
+    "AUTHORITATIVE PORT NAMES table, the contract wins -- use the contract's "
+    "spelling and ignore the constraint's. Constraints remain authoritative "
+    "for everything that is not a port name."
+)
+
+_PORT_TABLE_HEADER = (
+    "## AUTHORITATIVE PORT NAMES (from the frozen interface contract)\n"
+    "The golden model's port identifiers may be collapsed or abbreviated; "
+    "transcribe the model's BEHAVIOR byte-exact but take every port NAME from "
+    "this table. Each row is a port your module MUST declare, spelled exactly "
+    "as shown. A deterministic pre-simulation gate checks this list against "
+    "your module header and FAILS the block on any deviation -- there is no "
+    "sim to reach if a name is wrong.\n"
+)
+
+
+def format_contract_port_table(project_root, block_name: str) -> str:
+    """Render :func:`contract_port_rows` as a prompt fragment ('' when empty).
+
+    Grouped by channel so the ``<channel>_<field>`` construction is visible,
+    with the doubled-token rows called out by name (the exact class the
+    conformance gate keeps catching).
+    """
+    rows = contract_port_rows(project_root, block_name)
+    if not rows:
+        return ""
+    lines = ["", _PORT_TABLE_HEADER]
+    seen_channels: list[tuple[str, str, str]] = []
+    for r in rows:
+        keyed = (r["channel"], r["role"], r["peer"])
+        if keyed not in seen_channels:
+            seen_channels.append(keyed)
+    for chan, role, peer in seen_channels:
+        peer_txt = f" <-> {peer}" if peer else ""
+        lines.append(f"\n**channel `{chan}`** (this block is the {role}{peer_txt})")
+        for r in rows:
+            if (r["channel"], r["role"], r["peer"]) != (chan, role, peer):
+                continue
+            bits = []
+            if r["width"]:
+                bits.append(f"width {r['width']}")
+            if r["dir"]:
+                bits.append(f"dir {r['dir']}")
+            bits.append(r["kind"])
+            note = ""
+            if r["doubled_token"]:
+                note = (
+                    "   <-- DOUBLED TOKEN IS CORRECT: channel "
+                    f"`{chan}` + signal `{r['signal']}`. Do NOT collapse it."
+                )
+            lines.append(
+                f"- `{r['port']}`  ({', '.join(bits)}; signal "
+                f"`{r['signal']}`){note}"
+            )
+    lines.append(
+        "\nRules: the canonical port name is `<channel>_<signal>`; never "
+        "shorten a repeated token, never drop the channel prefix, never "
+        "expose the same signal twice (both prefixed and bare), and never "
+        "invent a port that wears a channel prefix but is not in this table."
+    )
+    return "\n".join(lines)
 
 
 _PORT_RE = re.compile(r"\b(?:input|output|inout)\b([^;)]*)", re.MULTILINE)

--- a/orchestrator/langgraph/integration_helpers.py
+++ b/orchestrator/langgraph/integration_helpers.py
@@ -20,6 +20,10 @@ import subprocess
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from orchestrator.langgraph.contract_conformance import (
+    canonical_port,
+    channel_base,
+)
 from orchestrator.langgraph.pipeline_helpers import (
     PROJECT_ROOT,
     RED,
@@ -900,20 +904,29 @@ def _resolve_by_contract(edge, pb, cb, port_exact, modules):
     if pb not in modules or cb not in modules:
         return None
 
+    # ONE canonical derivation, shared with the per-block conformance gate: a
+    # `producer_port` spelled as a slash ENUMERATION of the channel's concrete
+    # ports (`m_x_srdy/m_x_data`, `m_read_req/addr`) is reduced to its channel
+    # base, and a slash-ALIASED signal (`srdy/in_valid`) to one name -- so the
+    # assembler looks up ports that can actually exist. Concatenating the raw
+    # strings produced `m_x_srdy/m_x_data_valid`, which matches nothing, so
+    # EVERY signal on such an edge became a hazard and the deterministic top
+    # fell back to an LLM-authored integration.
     def _one(block: str, chan: str, sig: str):
-        pref = port_exact(block, f"{chan}_{sig}")
-        bare = port_exact(block, sig)
+        want, bare_name = canonical_port(chan, sig)
+        pref = port_exact(block, want)
+        bare = port_exact(block, bare_name) if bare_name != want else None
         if pref is not None and bare is not None:
-            return None, (f"{block}.{chan}_{sig} and {block}.{sig} both exist "
+            return None, (f"{block}.{want} and {block}.{bare_name} both exist "
                           f"-- ambiguous which implements '{sig}'")
         got = pref or bare
         if got is None:
             return None, (f"{block} implements no port for declared signal "
-                          f"'{sig}' (expected '{chan}_{sig}' or '{sig}')")
+                          f"'{sig}' (expected '{want}' or '{bare_name}')")
         return got, None
 
-    pchan = str(edge.get("producer_port") or "")
-    cchan = str(edge.get("consumer_port") or "")
+    pchan = channel_base(edge.get("producer_port"))
+    cchan = channel_base(edge.get("consumer_port"))
     eid = edge.get("edge_id")
     paired, hazards = [], []
     for sig in signals:

--- a/orchestrator/langgraph/microarch_exp.py
+++ b/orchestrator/langgraph/microarch_exp.py
@@ -1401,6 +1401,13 @@ def build_build_models_prompt(
             "  (no constraints accumulated yet -- but you MUST still read the "
             "files above; they will fill up on retries.)"
         )
+    try:
+        from orchestrator.langgraph.contract_conformance import (
+            CONSTRAINT_PRECEDENCE_LINE as _PRECEDENCE,
+        )
+        constr_lines.append("\n" + _PRECEDENCE)
+    except Exception:  # noqa: BLE001 - prompt garnish, never blocks a build
+        pass
     lines += constr_lines
     if feedback.strip():
         lines += [

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -2570,8 +2570,13 @@ async def generate_testbench_node(state: BlockState) -> dict:
                                   "reason": "contract_port_mismatch",
                                   "errors": _port_errors[:8],
                               })
+            # PHASE = "conformance", NOT "sim": this gate FAILS BEFORE any
+            # testbench is generated, so there is no simulation, no VCD and no
+            # WaveKit audit. Labelling it "sim" sent 3/3 diagnosis agents
+            # hunting for waveforms that cannot exist -- they then blamed the
+            # engine for the missing artifacts.
             return {"tb_path": str(tb_path_obj), "sim_passed": False,
-                    "phase": "sim", "force_regen_tb": False,
+                    "phase": "conformance", "force_regen_tb": False,
                     "step_log_paths": existing_logs}
 
     # --- CONTRACT-CONFORMANCE stage: check + repair the block's PORT NAMES ---
@@ -2685,8 +2690,10 @@ async def generate_testbench_node(state: BlockState) -> dict:
                 _park_conformance_unrepairable(state, block_name, _conform,
                                                _cf_n)
                 _reset_conformance_failures(_pr(state), block_name)
+            # PHASE = "conformance" (see the width gate above): pre-TB,
+            # pre-sim, no waveform exists.
             return {"tb_path": str(tb_path_obj), "sim_passed": False,
-                    "phase": "sim", "force_regen_tb": False,
+                    "phase": "conformance", "force_regen_tb": False,
                     "conformance_renames": _renames,
                     "step_log_paths": existing_logs}
         _reset_conformance_failures(_pr(state), block_name)
@@ -4920,6 +4927,11 @@ def _route_decision(debug_result: dict, attempt_history: list[dict],
         return "retry_tb"
 
     # Rule 6: Route based on failed phase
+    if phase == "conformance":
+        # Deterministic pre-sim contract gate (port names / widths). The fix is
+        # always in the RTL, and the exact expected names are already in
+        # previous_error.txt.
+        return "retry_rtl"
     if phase == "sim":
         return "retry_rtl"  # sim failure -> regenerate RTL
     if phase == "synth":

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -10910,9 +10910,47 @@ async def validation_dv_node(state: OrchestratorState) -> dict:
         # -- otherwise a geometry-dependent index/address-width truncation ships
         # verified. Flip to failed -> existing failure interrupt. Operator-reused
         # TBs are trusted.
-        if passed and not reuse_existing_tb:
-            _mg = _maxgeo_gate_verdict(pr, tb_path)
-            if _mg is not None:
+        # run3-followups: same contract as integration_dv -- the gate runs on
+        # EVERY passing cycle (operator-reused TBs get MORE scrutiny) and every
+        # evaluated outcome logs a verdict; a pass returns a dict, never None.
+        if passed:
+            _mg = _maxgeo_gate_verdict(pr, tb_path, tb_result)
+            if reuse_existing_tb and _mg is not None:
+                log("  [VALIDATION-DV] MAX-GEOMETRY gate: evaluating an "
+                    "OPERATOR-REUSED testbench (fix_tb/fix_rtl) -- operator "
+                    "edits get more scrutiny, not less.", YELLOW)
+            if _mg is not None and _mg.get("verdict") == "pass":
+                log("  [VALIDATION-DV] MAX-GEOMETRY gate PASS -- every "
+                    f"declared maximum appears in the TB markers: "
+                    f"{_mg.get('marker_pairs', {})}", GREEN)
+                write_graph_event(pr, "Validation DV", "maxgeo_gate_pass", {
+                    "gate": "maxgeo",
+                    "marker_pairs": _mg.get("marker_pairs", {}),
+                })
+            elif _mg is not None and _mg.get("advisory"):
+                _mg_scope = _mg.get("scope", "bus-contract-only")
+                log("  [VALIDATION-DV] MAX-GEOMETRY gate ADVISORY "
+                    f"(scope={_mg_scope}) -- NOT full max-geometry coverage. "
+                    f"NOT COVERED: {_mg['uncovered_dims']}", RED)
+                write_graph_event(pr, "Validation DV", "maxgeo_gate_scoped", {
+                    "gate": "maxgeo",
+                    "scope": _mg_scope,
+                    "uncovered_dims": _mg.get("uncovered_dims", {}),
+                })
+                record_carried_forward_defect(pr, {
+                    "gate": "maxgeo",
+                    "kind": "max_geometry_not_covered",
+                    "advisory": True,
+                    "unmodeled": (
+                        "dimensional maxima never individually driven at "
+                        f"maximum extent: {_mg.get('uncovered_dims', {})} "
+                        f"(scope={_mg_scope})"
+                    ),
+                    "first_divergence_block": "",
+                    "note": _mg["reason"],
+                })
+                sim_log = ((sim_log + "\n\n") if sim_log else "") + _mg["reason"]
+            elif _mg is not None:
                 passed = False
                 sim_log = ((sim_log + "\n\n") if sim_log else "") + _mg["reason"]
                 span.set_attribute("maxgeo_gate_failed", True)

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -2975,8 +2975,23 @@ def synthesize_block(
     # Generic SRAM wrapper: read its synth (black-box) view first so every
     # `cs_sram_*` instance is an opaque macro (0 storage flops) -- the backend
     # streams in the real SRAM collateral. Only when the block instantiates it.
+    #
+    # Then MIRROR the flat/backend synth's Part-B directive: `chparam -set
+    # MEM_IMPL "MACRO"` before `hierarchy`, so a macro-eligible wrapped memory
+    # (a cs_rom_1r mask ROM, a cs_mem_*) elaborates to its empty macro shell
+    # instead of a behavioral flop array. The blackbox above only covers
+    # cs_sram_1rw/1rw1r, so without the chparam a wrapped ROM became a
+    # thousands-deep combinational read mux at block synth and STA timed it --
+    # while the backend's flat synth, on the SAME RTL, bound it to a macro.
+    # Pinning MEM_IMPL in the RTL instead is not available: it makes the memory
+    # read zero in DV. The directive, its env gate, its module set and the
+    # macro-eligibility threshold all come from sram_wrapper, so the two synth
+    # paths cannot drift apart.
     _wrapper_read = ""
     try:
+        from orchestrator.langgraph.sram_wrapper import (
+            block_sram_macro_directive as _bsmd,
+        )
         from orchestrator.langgraph.sram_wrapper import (
             uses_wrapper as _uw,
         )
@@ -2985,9 +3000,11 @@ def synthesize_block(
         )
         _rtl_src = Path(rtl_path).read_text() if Path(rtl_path).exists() else ""
         if _uw(_rtl_src):
+            _chparam = _bsmd(_rtl_src)
             _wrapper_read = (
                 f"read_verilog -DCORESMITH_SRAM_SYNTH -sv {_wlp()}\n"
-                "blackbox cs_sram_1rw cs_sram_1rw1r\n"
+                + (f"{_chparam}\n" if _chparam else "")
+                + "blackbox cs_sram_1rw cs_sram_1rw1r\n"
             )
     except Exception:
         _wrapper_read = ""

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -3043,8 +3043,17 @@ write_verilog -noattr {netlist_path}
     # cloud) blows this -> success=False -> route_after_synth -> diagnose.
     _synth_timeout = scaled(600, env="CORESMITH_SYNTH_TIMEOUT_S")
     try:
+        # cwd=PROJECT_ROOT so a PROJECT-RELATIVE artifact path inside the RTL
+        # resolves exactly as it does in simulation. Block RTL legitimately
+        # carries `$readmemh("inputs/rom_images/<image>.memh", ...)` (and the
+        # cs_rom_1r wrapper's INIT_FILE parameter is the same relative path);
+        # yosys resolves those against ITS OWN cwd, which was whatever the
+        # daemon happened to be started in -- so the image was unreadable at
+        # block synth even though the identical path worked in DV. Both flat
+        # synth and the memory-flop probe already run rooted at the project.
         result = subprocess.run(
             ["yosys", "-s", str(script_path)],
+            cwd=str(PROJECT_ROOT.resolve()),
             capture_output=True,
             text=True,
             timeout=_synth_timeout,

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -3142,7 +3142,8 @@ async def fix_lint_errors(
         f"## Working Files\n"
         f"- RTL file: {rtl_path}\n"
         f"- Lint log: {lint_log_path}\n"
-        f"- Constraints: .coresmith/blocks/{block_name}/constraints.json\n\n"
+        f"- Constraints: .coresmith/blocks/{block_name}/constraints.json\n"
+        f"  ({_naming_precedence_line()})\n\n"
         f"Read the lint errors, then use the Edit tool to fix the RTL file "
         f"in-place. Do NOT rewrite the entire file -- make targeted fixes."
     )
@@ -3230,7 +3231,8 @@ async def fix_synth_errors(
         f"- Diagnosis / prior error context (READ THIS FIRST -- when a prior "
         f"diagnose ran it names the specific root cause + the fix): "
         f".coresmith/blocks/{block_name}/previous_error.txt\n"
-        f"- Constraints: .coresmith/blocks/{block_name}/constraints.json\n\n"
+        f"- Constraints: .coresmith/blocks/{block_name}/constraints.json\n"
+        f"  ({_naming_precedence_line()})\n\n"
         f"Read previous_error.txt and the synthesis errors, then fix the RTL. "
         f"{edit_instr}"
     )
@@ -3337,6 +3339,23 @@ async def fix_testbench_errors(
     except Exception as e:
         log(f"  [TB-FIX] LLM error: {e}", RED)
         return None
+
+
+def _naming_precedence_line() -> str:
+    """Naming precedence for a block's ACCUMULATED constraints ('' on error).
+
+    A learned constraint is one debug agent's read of one failure; the frozen
+    interface contract is design intent. When they disagree about a port NAME,
+    the contract wins -- otherwise a constraint that memorialised a collapsed
+    name keeps re-introducing it on every fixer pass.
+    """
+    try:
+        from orchestrator.langgraph.contract_conformance import (
+            CONSTRAINT_PRECEDENCE_LINE,
+        )
+        return CONSTRAINT_PRECEDENCE_LINE
+    except Exception:  # noqa: BLE001 - prompt garnish, never blocks a fix
+        return ""
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/langgraph/sram_wrapper.py
+++ b/orchestrator/langgraph/sram_wrapper.py
@@ -220,12 +220,18 @@ def detect_unwrapped_memories(
 def uses_wrapper(rtl_text: str) -> bool:
     """True if the RTL instantiates any CoreSmith memory primitive.
 
-    Covers the macro-backed wrappers (cs_sram_1rw/1rw1r), the reference
+    Covers the macro-backed wrappers (cs_sram_1rw/1rw1r), the UNIFIED memory
+    primitive they pass through to (cs_mem_1rw/1rw1r), the reference
     flop-memory primitives (cs_fpmem_1rw/1rw1r), and the mask-ROM primitive
     (cs_rom_1r) -- all live in the shared rtl_lib/cs_sram.v, so any one of them
     means that lib must be read in lint/sim/synth.
+
+    cs_mem_* was missing: every caller uses this to decide whether to READ the
+    wrapper library, so a block instantiating the unified primitive directly
+    (which the memory skill's macro menu offers) got no library anywhere and an
+    unresolved module at `hierarchy -check`.
     """
-    pat = r"\bcs_(?:sram_1rw(?:1r)?|fpmem_1rw(?:1r)?|rom_1r)\b"
+    pat = r"\bcs_(?:sram_1rw(?:1r)?|mem_1rw(?:1r)?|fpmem_1rw(?:1r)?|rom_1r)\b"
     return bool(re.search(pat + r"\s*#?\s*\(", rtl_text)) or \
         bool(re.search(pat + r"\s+\w+\s*\(", rtl_text))
 
@@ -517,6 +523,85 @@ def backend_sram_macro_directive(*, force: bool = False) -> str:
     return 'chparam -set MEM_IMPL "MACRO" ' + " ".join(SRAM_MACRO_CHPARAM_MODULES)
 
 
+#: Instances of the MACRO-BACKED wrappers -- the same module set the Part-B
+#: chparam re-derives. cs_fpmem_* is deliberately absent for the same reason it
+#: is absent from SRAM_MACRO_CHPARAM_MODULES: it is the blessed FLOP tier.
+_CSMEM_RE = re.compile(r"\bcs_mem_1rw(?:1r)?\b")
+
+
+def _mem_instances(rtl_text: str) -> list[tuple[int, int]]:
+    """[(width, depth), ...] for each direct cs_mem_1rw/1rw1r INSTANTIATION
+    (mirrors :func:`sram_instances`; skips the module definitions)."""
+    out: list[tuple[int, int]] = []
+    for m in _CSMEM_RE.finditer(rtl_text):
+        if _MODULE_DECL_RE.search(rtl_text[max(0, m.start() - 12):m.start()]):
+            continue
+        end = rtl_text.find(";", m.end())
+        window = rtl_text[m.end(): end if end != -1 else m.end() + 400]
+        w = _W_RE.search(window)
+        d = _D_RE.search(window)
+        if not (w or d):
+            continue
+        out.append((int(w.group(1)) if w else _DEFAULT_W,
+                    int(d.group(1)) if d else _DEFAULT_D))
+    return out
+
+
+def macro_wrapper_instances(rtl_text: str) -> list[tuple[int, int]]:
+    """[(width, depth), ...] for every MACRO-BACKED memory wrapper instance.
+
+    The union of the wrapper families the Part-B chparam covers
+    (:data:`SRAM_MACRO_CHPARAM_MODULES`): cs_sram_1rw/1rw1r, cs_rom_1r and a
+    direct cs_mem_1rw/1rw1r. cs_fpmem_* is excluded -- it hard-passes
+    MEM_IMPL("FLOP") and the chparam cannot (and must not) move it.
+    """
+    return (sram_instances(rtl_text) + rom_instances(rtl_text)
+            + _mem_instances(rtl_text))
+
+
+def macro_impl_eligible(
+    width: int, depth: int, *,
+    threshold_bits: int | None = None,
+    macro_words: int | None = None,
+) -> bool:
+    """Whether a memory of this geometry BELONGS in a macro rather than flops.
+
+    THE threshold predicate, in one place: at/above the SRAM-macro size by
+    total bits, or deep enough on its own that the read mux is the problem.
+    :func:`gate_memory_as_flops` (the post-synth backstop, which fails a block
+    for realizing such a memory as flops) and the block-level synth directive
+    (which stops it happening) must agree by construction -- a block-synth
+    threshold that drifted from the gate's would flop a memory the gate then
+    rejects.
+    """
+    if width <= 0 or depth <= 0:
+        return False
+    thr = threshold_bits if threshold_bits is not None else min_bits()
+    md = macro_words if macro_words is not None else macro_depth()
+    return (width * depth >= thr) or (depth >= md)
+
+
+def block_sram_macro_directive(rtl_text: str, *, force: bool = False) -> str:
+    """The Part-B chparam for a BLOCK-level synth script, or "".
+
+    Same directive, same env gate and same module set as
+    :func:`backend_sram_macro_directive` -- flat synth applies it to the whole
+    design; this applies it to ONE block, and only when that block instantiates
+    a macro-backed wrapper whose geometry is macro-eligible.
+
+    Without it the block-level script read the wrapper library and then
+    elaborated the wrapper BEHAVIORALLY, so a wrapped mask ROM became a
+    thousands-deep combinational read mux that STA duly timed -- while the flat
+    synth the backend runs on the same RTL bound it to a macro. The two paths
+    disagreed about the same source. Pinning MEM_IMPL in the RTL instead is not
+    an option: it makes the memory read zero in DV.
+    """
+    if not any(macro_impl_eligible(w, d)
+               for w, d in macro_wrapper_instances(rtl_text)):
+        return ""
+    return backend_sram_macro_directive(force=force)
+
+
 # --- Part D: post-synth memory-as-flops hard-block gate -----------------------
 #
 # The backstop that turns a silently-shipped flop-array memory into an early,
@@ -594,9 +679,11 @@ def gate_memory_as_flops(
         if _fpmem_exempt(width, depth, fpg):
             continue
         bits = width * depth
-        big = (bits >= thr)      # large by total bits
-        deep = (depth >= md)     # deep enough on its own (read-mux fanout)
-        if not (big or deep):
+        # ONE threshold predicate, shared with the block-synth chparam so the
+        # synth that AVOIDS the flop array and the gate that REJECTS it can
+        # never disagree about which geometries are macro-eligible.
+        if not macro_impl_eligible(width, depth,
+                                   threshold_bits=thr, macro_words=md):
             continue
         reasons.append(
             f"memory [{width}b x {depth}] = {bits:,} bits synthesized to a "

--- a/orchestrator/mcp_server.py
+++ b/orchestrator/mcp_server.py
@@ -3278,7 +3278,7 @@ async def resume_backend(
         action: One of 'retry', 'skip', 'abort'.
         constraint: Optional constraint text.
     """
-    valid_actions = {"retry", "skip", "abort"}
+    valid_actions = {"retry", "skip", "abort", "accept"}
     if action not in valid_actions:
         return json.dumps({
             "error": f"Invalid action: {action}. Must be one of: {sorted(valid_actions)}",

--- a/orchestrator/tests/test_autonomy_gap_fixes.py
+++ b/orchestrator/tests/test_autonomy_gap_fixes.py
@@ -172,14 +172,25 @@ def test_present_golden_says_nothing(monkeypatch):
     assert called == []
 
 
-def test_promised_hardware_golden_that_cannot_be_read_fails_rtl_generation():
-    import inspect
+def test_promised_hardware_golden_that_cannot_be_read_fails_rtl_generation(tmp_path):
+    """An unreadable hardware golden must RAISE, not silently ask for a
+    byte-exact lowering of nothing. Asserted on the behaviour of the
+    production prompt constructor (``build_user_message``, which
+    ``RTLGeneratorAgent.generate`` calls), not on its source text."""
+    import pytest
 
     from orchestrator.langchain.agents import rtl_generator as rg
 
-    src = inspect.getsource(rg.RTLGeneratorAgent.generate)
-    assert "if not _hw_src.strip():" in src
-    assert "CORESMITH_RTL_FROM_HW_GOLDEN" in src
+    with pytest.raises(RuntimeError) as exc:
+        rg.build_user_message(
+            block_name="blk",
+            rtl_target="rtl/blk.v",
+            python_source_path="arch/block_models/blk.py",   # does not exist
+            reference_is_hw_golden=True,
+            project_root=str(tmp_path),
+        )
+    assert "CORESMITH_RTL_FROM_HW_GOLDEN" in str(exc.value)
+    assert "byte-exact" in str(exc.value)
 
 
 # ===========================================================================

--- a/orchestrator/tests/test_block_synth_invocation.py
+++ b/orchestrator/tests/test_block_synth_invocation.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""How the per-block yosys synth is INVOKED (cwd + script preamble).
+
+Block-level synthesis is not a toy check -- it is the synthesizability gate and
+the input to the block PPA/area numbers -- but it was launched differently from
+every other yosys site in the flow, and each difference showed up as a bogus
+block-level failure or a bogus block-level timing number:
+
+* it ran in whatever directory the daemon was started in, so a PROJECT-RELATIVE
+  ``$readmemh`` / ``INIT_FILE`` path in the RTL (the same path DV resolves
+  happily) was unreadable;
+"""
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from orchestrator.langgraph import pipeline_helpers as ph
+
+_HAS_YOSYS = shutil.which("yosys") is not None
+
+
+class _StopBeforeYosys(Exception):
+    """Raised by the fake subprocess so the call is observed, not executed."""
+
+
+def _project(tmp_path):
+    """A project root with an `inputs/` artifact the RTL reads by relative path."""
+    (tmp_path / "inputs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "inputs" / "table.memh").write_text(
+        "\n".join(f"{i:02x}" for i in range(16)) + "\n")
+    rtl = tmp_path / "rtl"
+    rtl.mkdir(parents=True, exist_ok=True)
+    f = rtl / "table_reader.v"
+    f.write_text(
+        "module table_reader(input clk, input [3:0] a, output reg [7:0] q);\n"
+        "  reg [7:0] rom [0:15];\n"
+        '  initial $readmemh("inputs/table.memh", rom);\n'
+        "  always @(posedge clk) q <= rom[a];\n"
+        "endmodule\n")
+    return f
+
+
+class TestSynthRunsAtTheProjectRoot:
+    """A relative artifact path in the RTL must mean the same thing in synth as
+    it does in simulation."""
+
+    def test_yosys_is_launched_with_cwd_at_the_project_root(
+            self, tmp_path, monkeypatch):
+        monkeypatch.setattr(ph, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setenv("CORESMITH_SYNTH_GENERIC", "1")
+        rtl = _project(tmp_path)
+        seen = {}
+
+        def _fake_run(cmd, **kw):
+            seen["cwd"] = kw.get("cwd")
+            raise _StopBeforeYosys()
+
+        monkeypatch.setattr(ph.subprocess, "run", _fake_run)
+        with pytest.raises(_StopBeforeYosys):
+            ph.synthesize_block({"name": "table_reader"}, str(rtl))
+        assert seen["cwd"] == str(tmp_path.resolve())
+
+    @pytest.mark.skipif(not _HAS_YOSYS, reason="yosys not installed")
+    def test_a_relative_readmemh_resolves(self, tmp_path, monkeypatch):
+        """The real thing: yosys must find `inputs/table.memh` from the project
+        root. Before the fix it looked in the daemon's cwd and the block failed
+        synth with 'Can not open file' while DV read the identical path."""
+        monkeypatch.setattr(ph, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setenv("CORESMITH_SYNTH_GENERIC", "1")
+        rtl = _project(tmp_path)
+        out = ph.synthesize_block({"name": "table_reader"}, str(rtl))
+        assert out["success"], out.get("log", "")[-2000:]
+
+    @pytest.mark.skipif(not _HAS_YOSYS, reason="yosys not installed")
+    def test_a_missing_artifact_still_fails(self, tmp_path, monkeypatch):
+        """The fix must not paper over a genuinely absent image -- rooting the
+        run is what makes 'not found' mean 'not in the project'."""
+        monkeypatch.setattr(ph, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setenv("CORESMITH_SYNTH_GENERIC", "1")
+        rtl = _project(tmp_path)
+        (tmp_path / "inputs" / "table.memh").unlink()
+        out = ph.synthesize_block({"name": "table_reader"}, str(rtl))
+        assert not out["success"]

--- a/orchestrator/tests/test_block_synth_invocation.py
+++ b/orchestrator/tests/test_block_synth_invocation.py
@@ -12,6 +12,9 @@ block-level failure or a bogus block-level timing number:
 * it ran in whatever directory the daemon was started in, so a PROJECT-RELATIVE
   ``$readmemh`` / ``INIT_FILE`` path in the RTL (the same path DV resolves
   happily) was unreadable;
+* it omitted the ``chparam -set MEM_IMPL "MACRO"`` the flat/backend synth
+  applies, so a wrapped memory elaborated BEHAVIORALLY and STA timed a
+  thousands-deep read mux -- on the same RTL the backend bound to a macro.
 """
 from __future__ import annotations
 
@@ -86,3 +89,134 @@ class TestSynthRunsAtTheProjectRoot:
         (tmp_path / "inputs" / "table.memh").unlink()
         out = ph.synthesize_block({"name": "table_reader"}, str(rtl))
         assert not out["success"]
+
+
+# ---------------------------------------------------------------------------
+# The block-synth script must select the MACRO impl, exactly as flat synth does
+# ---------------------------------------------------------------------------
+
+def _mem_block(tmp_path, name, inst):
+    """A block whose only interesting content is one memory-wrapper instance."""
+    rtl = tmp_path / "rtl"
+    rtl.mkdir(parents=True, exist_ok=True)
+    f = rtl / f"{name}.v"
+    f.write_text(
+        f"module {name}(input clk, input [15:0] a, output [7:0] q);\n"
+        f"{inst}\n"
+        "endmodule\n")
+    return f
+
+
+def _script_for(tmp_path, monkeypatch, name, inst):
+    """The .ys the block-synth builder emits (yosys itself is never run)."""
+    monkeypatch.setattr(ph, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setenv("CORESMITH_SYNTH_GENERIC", "1")
+    f = _mem_block(tmp_path, name, inst)
+
+    def _fake_run(cmd, **kw):
+        raise _StopBeforeYosys()
+
+    monkeypatch.setattr(ph.subprocess, "run", _fake_run)
+    with pytest.raises(_StopBeforeYosys):
+        ph.synthesize_block({"name": name}, str(f))
+    return (tmp_path / "syn" / "output" / name / f"synth_{name}.ys").read_text()
+
+
+_BIG_ROM = ('  cs_rom_1r #(.WIDTH(8), .DEPTH(3309), '
+            '.INIT_FILE("inputs/rom_images/table.memh"))\n'
+            '    u_rom (.clk(clk), .ce(1\'b1), .addr(a[11:0]), .rdata(q));')
+_SMALL_MEM = ('  cs_mem_1rw #(.WIDTH(8), .DEPTH(16))\n'
+              '    u_mem (.clk(clk), .ce(1\'b1), .we(1\'b0), .addr(a[3:0]),\n'
+              '           .wdata(8\'d0), .rdata(q));')
+_BIG_MEM = ('  cs_mem_1rw1r #(.WIDTH(32), .DEPTH(1024))\n'
+            '    u_mem (.clk(clk), .ce0(1\'b1), .we0(1\'b0), .addr0(a[9:0]),\n'
+            '           .wdata0(32\'d0), .rdata0(), .ce1(1\'b1),\n'
+            '           .addr1(a[9:0]), .rdata1(q));')
+_FLOP_TIER = ('  cs_fpmem_1rw #(.WIDTH(8), .DEPTH(4096))\n'
+              '    u_fp (.clk(clk), .ce(1\'b1), .we(1\'b0), .addr(a[11:0]),\n'
+              '          .wdata(8\'d0), .rdata(q));')
+
+
+class TestBlockSynthSelectsTheMacroImpl:
+    def test_a_macro_eligible_rom_gets_the_chparam(self, tmp_path, monkeypatch):
+        script = _script_for(tmp_path, monkeypatch, "rom_block", _BIG_ROM)
+        assert 'chparam -set MEM_IMPL "MACRO"' in script
+        assert "cs_rom_1r" in script.split("hierarchy")[0]
+
+    def test_a_macro_eligible_cs_mem_gets_the_chparam(self, tmp_path, monkeypatch):
+        script = _script_for(tmp_path, monkeypatch, "mem_block", _BIG_MEM)
+        assert 'chparam -set MEM_IMPL "MACRO"' in script
+
+    def test_the_unified_primitive_pulls_in_the_wrapper_library(
+            self, tmp_path, monkeypatch):
+        """A block instantiating cs_mem_* DIRECTLY got no wrapper library read
+        at all (uses_wrapper did not know the family), so the module was
+        unresolved at `hierarchy -check` -- in synth, lint and sim alike."""
+        from orchestrator.langgraph import sram_wrapper as sw
+        assert sw.uses_wrapper("cs_mem_1rw1r #(.WIDTH(32), .DEPTH(1024)) u (")
+        assert sw.uses_wrapper("cs_mem_1rw u_m (.clk(clk));")
+        script = _script_for(tmp_path, monkeypatch, "mem_block", _BIG_MEM)
+        assert "cs_sram.v" in script
+
+    def test_a_sub_threshold_memory_does_not(self, tmp_path, monkeypatch):
+        """16 words / 128 bits is below both triggers -- flops are correct
+        there, and forcing a shell would hide a real (small) memory."""
+        script = _script_for(tmp_path, monkeypatch, "small_block", _SMALL_MEM)
+        assert "chparam" not in script
+
+    def test_the_blessed_flop_tier_is_never_forced_to_a_macro(
+            self, tmp_path, monkeypatch):
+        """cs_fpmem_* hard-passes MEM_IMPL("FLOP"); it is excluded from the
+        chparam module set, so it must not even trigger the directive."""
+        script = _script_for(tmp_path, monkeypatch, "fp_block", _FLOP_TIER)
+        assert "chparam" not in script
+
+    def test_the_chparam_runs_before_hierarchy(self, tmp_path, monkeypatch):
+        """Setting the parameter after `hierarchy` derives the modules is a
+        no-op on the already-baked $paramod copies."""
+        script = _script_for(tmp_path, monkeypatch, "rom_block", _BIG_ROM)
+        assert script.index("chparam") < script.index("hierarchy -top")
+
+    def test_the_env_gate_turns_it_off(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CORESMITH_SRAM_MACRO", "0")
+        script = _script_for(tmp_path, monkeypatch, "rom_block", _BIG_ROM)
+        assert "chparam" not in script
+
+    def test_a_block_with_no_memory_is_unchanged(self, tmp_path, monkeypatch):
+        script = _script_for(tmp_path, monkeypatch, "plain",
+                             "  assign q = a[7:0];")
+        assert "chparam" not in script
+        assert "cs_sram" not in script
+
+
+class TestTheThresholdHasOneSource:
+    """The synth that AVOIDS a flop memory and the post-synth gate that
+    REJECTS one must not be able to disagree about which geometries qualify."""
+
+    def test_the_block_directive_uses_the_gate_s_predicate(self):
+        from orchestrator.langgraph import sram_wrapper as sw
+        assert sw.macro_impl_eligible(8, 3309)     # deep
+        assert sw.macro_impl_eligible(32, 128)     # 4096 bits
+        assert not sw.macro_impl_eligible(8, 16)
+        assert not sw.macro_impl_eligible(0, 4096)
+
+    def test_the_gate_and_the_directive_agree_geometry_by_geometry(self):
+        from orchestrator.langgraph import sram_wrapper as sw
+        for w, d in [(8, 16), (8, 255), (8, 256), (32, 62), (32, 63),
+                     (8, 3309), (64, 1024)]:
+            gate_flags = not sw.gate_memory_as_flops([(w, d)])[0]
+            assert gate_flags is sw.macro_impl_eligible(w, d), (w, d)
+
+    def test_an_env_override_moves_both_together(self, monkeypatch):
+        from orchestrator.langgraph import sram_wrapper as sw
+        monkeypatch.setenv("CORESMITH_SRAM_MIN_BITS", "64")
+        monkeypatch.setenv("CORESMITH_SRAM_MACRO_DEPTH", "8192")
+        assert sw.macro_impl_eligible(8, 16)                 # 128 bits >= 64
+        assert not sw.gate_memory_as_flops([(8, 16)])[0]
+
+    def test_only_the_macro_backed_families_are_counted(self):
+        from orchestrator.langgraph import sram_wrapper as sw
+        text = ("cs_fpmem_1rw #(.WIDTH(8), .DEPTH(4096)) u_a (.clk(c));\n"
+                "cs_rom_1r #(.WIDTH(8), .DEPTH(3309)) u_b (.clk(c));\n"
+                "cs_mem_1rw1r #(.WIDTH(32), .DEPTH(1024)) u_c (.clk(c));\n")
+        assert sorted(sw.macro_wrapper_instances(text)) == [(8, 3309), (32, 1024)]

--- a/orchestrator/tests/test_contract_conformance.py
+++ b/orchestrator/tests/test_contract_conformance.py
@@ -570,3 +570,241 @@ class TestWiredIntoTheBlockFlow:
         # fresh pair of tries rather than parking on every entry
         assert not (root / ".coresmith" / "blocks" / "ap"
                     / "_conformance_failures.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Slash-bearing contract text -> a legal identifier, never a `/` in a port name
+# ---------------------------------------------------------------------------
+#
+# The schema template the interface-definition agent is handed literally offers
+# the slash form:
+#
+#     "producer_port": "<m_axis_<name> or m_<name>_srdy/m_<name>_data>"
+#
+# so real contracts carry it. Every fixture below is the SHAPE of a real edge
+# from a 12-block codec whose contract used all three enumeration styles plus a
+# two-name sideband alias; only the design-specific words are renamed. The
+# derivation concatenated these verbatim, produced port names containing `/`
+# (illegal unescaped Verilog), rewrote six blocks' RTL to them, and could never
+# converge -- and it double-prefixed a signal that already carried the channel
+# (`s_chan_s_chan_addr`).
+
+def _edge2(producer, consumer, pport, cport, fields=(), sideband=()):
+    """An edge whose two ends spell the channel differently (the real case)."""
+    return {
+        "edge_id": f"{producer}__to__{consumer}",
+        "producer_block": producer, "producer_port": pport,
+        "consumer_block": consumer, "consumer_port": cport,
+        "fields": [{"name": f} for f in fields],
+        "sideband_signals": [{"name": s} for s in sideband],
+    }
+
+
+#: The addressed-read edge: first segment fully qualified, the rest bare.
+_READ_EDGE = _edge2(
+    "transform_engine", "sample_memory",
+    "m_store_read_req/addr", "s_store_read_req/addr",
+    fields=["sample_u8"], sideband=["req", "address", "rvalid", "fault"])
+
+#: The elastic payload edge: both segments fully qualified.
+_ELASTIC_EDGE = _edge2(
+    "transform_engine", "quantizer",
+    "m_result_out_srdy/m_result_out_data",
+    "s_result_out_drdy/s_result_out_data",
+    fields=["idx", "value_s16"], sideband=["srdy", "drdy"])
+
+#: The control edge: qualified head, bare tail.
+_CONTROL_EDGE = _edge2(
+    "control_wrapper", "transform_engine",
+    "m_job_control_valid/data", "s_job_control_valid/data",
+    fields=["job_index", "job_start"], sideband=["valid"])
+
+#: The chip-boundary stream: a SHORT common prefix, plus two sidebands each
+#: declared under TWO names (generic role / mandated spelling) and one that
+#: already carries the producer's channel prefix.
+_STREAM_EDGE = _edge2(
+    "control_wrapper", "ingest_addressor",
+    "in_valid/in_data/in_last",
+    "s_source_srdy/s_source_data/s_source_last",
+    fields=["required_zero", "payload_byte"],
+    sideband=["srdy/in_valid", "drdy/in_ready", "in_last"])
+
+_SLASH_EDGES = [_READ_EDGE, _ELASTIC_EDGE, _CONTROL_EDGE, _STREAM_EDGE]
+
+
+class TestChannelBaseParsesTheEnumeration:
+    @pytest.mark.parametrize("raw,expect", [
+        ("m_store_read_req/addr", "m_store_read"),
+        ("s_store_read_req/addr", "s_store_read"),
+        ("m_result_out_srdy/m_result_out_data", "m_result_out"),
+        ("s_result_out_drdy/s_result_out_data", "s_result_out"),
+        ("m_job_control_valid/data", "m_job_control"),
+        ("in_valid/in_data/in_last", "in"),
+        ("s_source_srdy/s_source_data/s_source_last", "s_source"),
+        ("m_axis_frame", "m_axis_frame"),          # the bare form is untouched
+        ("", ""),
+    ])
+    def test_the_channel_is_the_common_token_prefix(self, raw, expect):
+        from orchestrator.langgraph.contract_conformance import channel_base
+        assert channel_base(raw) == expect
+
+
+class TestNoDerivedPortEverContainsASlash:
+    """The blocking defect: `s_store_read_req/addr_rvalid` is not an
+    identifier, so the repair pass rewrote RTL to a name no tool can parse and
+    the loop could not converge."""
+
+    def test_every_row_of_every_real_shape_is_a_legal_identifier(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import (
+            contract_port_rows,
+            is_legal_identifier,
+        )
+        root = _project(tmp_path, _SLASH_EDGES)
+        blocks = {b for e in _SLASH_EDGES
+                  for b in (e["producer_block"], e["consumer_block"])}
+        seen = 0
+        for block in blocks:
+            for r in contract_port_rows(str(root), block):
+                seen += 1
+                assert "/" not in r["port"], r
+                assert is_legal_identifier(r["port"]), r
+                assert "/" not in r["channel"], r
+        assert seen >= 20, "the fixture must actually exercise the derivation"
+
+    def test_the_gate_never_demands_a_name_with_a_slash(self, tmp_path):
+        root = _project(tmp_path, _SLASH_EDGES)
+        r = check_block(root, "sample_memory",
+                        _rtl(tmp_path, "sample_memory", ["clk"]))
+        assert r.missing
+        for _chan, port in r.missing:
+            assert "/" not in port, port
+
+    def test_the_expected_names_are_the_contract_s_own_port_list(self, tmp_path):
+        """`s_store_read_req/addr` enumerates two of the channel's real ports,
+        so the derived set must contain exactly those spellings."""
+        root = _project(tmp_path, [_READ_EDGE])
+        want = {p for _c, p in
+                check_block(root, "sample_memory",
+                            _rtl(tmp_path, "sample_memory", ["clk"])).missing}
+        assert want == {
+            "s_store_read_sample_u8", "s_store_read_req",
+            "s_store_read_address", "s_store_read_rvalid",
+            "s_store_read_fault",
+        }
+
+    def test_rtl_spelled_the_contract_s_way_conforms(self, tmp_path):
+        root = _project(tmp_path, [_ELASTIC_EDGE])
+        ports = ["m_result_out_idx", "m_result_out_value_s16",
+                 "m_result_out_srdy", "m_result_out_drdy"]
+        r = check_block(root, "transform_engine",
+                        _rtl(tmp_path, "transform_engine", ports))
+        assert r.ok, (r.missing, r.undeclared, r.ambiguous)
+
+
+class TestTheChannelPrefixIsIdempotent:
+    """`s_chan_s_chan_addr_field`: a signal that already carries the channel
+    was prefixed a second time. The port_naming skill's rule is
+    `<channel>_<field>`, and applying it twice must be the same as once."""
+
+    def test_a_signal_already_carrying_the_channel_is_not_prefixed_again(self):
+        from orchestrator.langgraph.contract_conformance import canonical_port
+        assert canonical_port("in", "in_last") == ("in_last", "in_last")
+        assert canonical_port("s_read_req", "s_read_req_addr") == (
+            "s_read_req_addr", "s_read_req_addr")
+
+    def test_a_doubled_TOKEN_is_still_required(self):
+        """Different thing, and the skill says it is CORRECT: `write_enable`
+        does not start with `data_write_`, so it is still prefixed."""
+        from orchestrator.langgraph.contract_conformance import canonical_port
+        assert canonical_port("data_write", "write_enable")[0] == \
+            "data_write_write_enable"
+
+    def test_no_port_repeats_its_whole_channel(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import contract_port_rows
+        root = _project(tmp_path, _SLASH_EDGES)
+        for block in ("control_wrapper", "ingest_addressor"):
+            for r in contract_port_rows(str(root), block):
+                assert not r["port"].startswith(r["channel"] + "_"
+                                                + r["channel"] + "_"), r
+
+    def test_the_prefixed_form_is_the_only_form_then(self, tmp_path):
+        """`in_last` on channel `in` has ONE acceptable spelling, so a block
+        exposing exactly it is conforming -- not 'ambiguous with itself'."""
+        root = _project(tmp_path, [_STREAM_EDGE])
+        ports = ["in_required_zero", "in_payload_byte", "in_valid",
+                 "in_ready", "in_last"]
+        r = check_block(root, "control_wrapper",
+                        _rtl(tmp_path, "control_wrapper", ports))
+        assert r.ok, (r.missing, r.undeclared, r.ambiguous)
+
+
+class TestATwoNameSidebandResolvesToOneName:
+    """`srdy/in_valid` declares ONE wire under the generic handshake role and
+    the spelling this edge mandates. Only one of them can be a port."""
+
+    def test_the_end_that_already_spells_it_keeps_its_spelling(self):
+        from orchestrator.langgraph.contract_conformance import canonical_port
+        # producer channel `in`: the contract's own port list says `in_valid`
+        assert canonical_port("in", "srdy/in_valid")[0] == "in_valid"
+        assert canonical_port("in", "drdy/in_ready")[0] == "in_ready"
+
+    def test_the_other_end_takes_the_generic_role(self):
+        from orchestrator.langgraph.contract_conformance import canonical_port
+        # consumer channel `s_source`: its port list says `s_source_srdy`
+        assert canonical_port("s_source", "srdy/in_valid")[0] == "s_source_srdy"
+        assert canonical_port("s_source", "drdy/in_ready")[0] == "s_source_drdy"
+
+    def test_both_ends_of_the_real_edge_derive_their_own_spelling(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import contract_port_rows
+        root = _project(tmp_path, [_STREAM_EDGE])
+        prod = {r["port"] for r in contract_port_rows(str(root), "control_wrapper")}
+        cons = {r["port"] for r in contract_port_rows(str(root), "ingest_addressor")}
+        assert {"in_valid", "in_ready", "in_last"} <= prod
+        assert {"s_source_srdy", "s_source_drdy"} <= cons
+        assert not any("/" in p for p in prod | cons)
+
+
+class TestAnUnreducibleNameIsDroppedLoudly:
+    """A contract that cannot be reduced to an identifier is a CONTRACT defect.
+    Emitting the name anyway rewrites the RTL to garbage; the only safe action
+    is to drop the signal and say so."""
+
+    def test_an_illegal_channel_drops_the_edge_and_logs(self, tmp_path, caplog):
+        import logging as _logging
+
+        from orchestrator.langgraph.contract_conformance import (
+            _ILLEGAL_REPORTED,
+            contract_port_rows,
+        )
+        _ILLEGAL_REPORTED.clear()
+        root = _project(tmp_path, [
+            _edge2("a", "b", "m bad-chan!", "m bad-chan!", fields=["data"])])
+        with caplog.at_level(_logging.ERROR):
+            rows = contract_port_rows(str(root), "b")
+        assert rows == []
+        assert "not a legal Verilog identifier" in caplog.text
+
+    def test_an_illegal_signal_drops_only_that_signal(self, tmp_path, caplog):
+        import logging as _logging
+
+        from orchestrator.langgraph.contract_conformance import (
+            _ILLEGAL_REPORTED,
+            contract_port_rows,
+        )
+        _ILLEGAL_REPORTED.clear()
+        root = _project(tmp_path, [
+            _edge2("a", "b", "m_ch", "s_ch", fields=["data", "addr[3:0]"])])
+        with caplog.at_level(_logging.ERROR):
+            ports = {r["port"] for r in contract_port_rows(str(root), "b")}
+        assert ports == {"s_ch_data"}
+        assert "addr[3:0]" in caplog.text
+
+    def test_a_repair_to_an_illegal_name_is_refused(self):
+        from orchestrator.langgraph.contract_conformance import (
+            ConformanceResult,
+            plan_port_repairs,
+        )
+        res = ConformanceResult(block="b")
+        res.missing = [("s_ch", "s_ch_req/addr")]
+        res.undeclared = ["s_ch_reqaddr"]
+        assert plan_port_repairs(res) == {}

--- a/orchestrator/tests/test_prompt_authority.py
+++ b/orchestrator/tests/test_prompt_authority.py
@@ -45,7 +45,7 @@ class TestSelectSkillsEvidenceClasses:
     def test_memory_shaped_block_selects_memory_macro(self):
         sel = select_skills(
             {"name": "pixel_line_buffer",
-             "description": "1024x32 line buffer for the raster stage"},
+             "description": "1024x32 line buffer for the scan stage"},
             None, None,
         )
         assert "memory_macro_vs_flops" in sel
@@ -275,8 +275,8 @@ _DOUBLED_TOKEN_CONTRACTS = {
     "contracts": [
         {
             "edge_id": "e1",
-            "producer_block": "qspi_slave_frontend",
-            "consumer_block": "regmap_buffers",
+            "producer_block": "bus_frontend",
+            "consumer_block": "register_map",
             "producer_port": "host_write",
             "consumer_port": "host_write",
             "handshake_protocol": "static",
@@ -305,22 +305,22 @@ class TestContractPortTable:
             contract_port_rows,
         )
         root = _project(tmp_path)
-        rows = contract_port_rows(str(root), "regmap_buffers")
+        rows = contract_port_rows(str(root), "register_map")
         names = {r["port"] for r in rows}
         assert "host_write_write_enable" in names
         assert "host_write_abort" in names, "sideband is part of the port set"
 
         # The gate must demand EXACTLY the names the table advertises.
-        rtl = tmp_path / "regmap_buffers.v"
-        rtl.write_text("module regmap_buffers(input wire clk);\nendmodule\n")
+        rtl = tmp_path / "register_map.v"
+        rtl.write_text("module register_map(input wire clk);\nendmodule\n")
         missing = {port for _chan, port in
-                   check_block(str(root), "regmap_buffers", rtl).missing}
+                   check_block(str(root), "register_map", rtl).missing}
         assert missing == names
 
     def test_doubled_token_row_is_flagged(self, tmp_path):
         from orchestrator.langgraph.contract_conformance import contract_port_rows
         root = _project(tmp_path)
-        rows = {r["port"]: r for r in contract_port_rows(str(root), "regmap_buffers")}
+        rows = {r["port"]: r for r in contract_port_rows(str(root), "register_map")}
         assert rows["host_write_write_enable"]["doubled_token"] is True
         assert rows["host_write_addr"]["doubled_token"] is False
 
@@ -328,10 +328,10 @@ class TestContractPortTable:
         from orchestrator.langchain.agents.rtl_generator import build_user_message
         root = _project(tmp_path)
         prompt = build_user_message(
-            block_name="regmap_buffers",
+            block_name="register_map",
             description="register map + buffers",
             attempt=1,
-            rtl_target="rtl/regmap_buffers.v",
+            rtl_target="rtl/register_map.v",
             python_source_path="inputs/golden.py",
             project_root=str(root),
         )
@@ -346,7 +346,7 @@ class TestContractPortTable:
         from orchestrator.langchain.agents.rtl_generator import build_user_message
         root = _project(tmp_path)
         prompt = build_user_message(
-            block_name="regmap_buffers", rtl_target="rtl/x.v",
+            block_name="register_map", rtl_target="rtl/x.v",
             project_root=str(root),
         )
         assert "PRECEDENCE" in prompt

--- a/orchestrator/tests/test_prompt_authority.py
+++ b/orchestrator/tests/test_prompt_authority.py
@@ -1,0 +1,469 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The contract is the naming authority; skills are selected, not dumped.
+
+Three engine changes, tested through the production prompt constructors:
+
+* **Task A** -- `port_naming` is inline in every authoring agent, and the RTL
+  prompt carries the block's AUTHORITATIVE PORT NAMES table derived from the
+  frozen contract by the SAME machinery the conformance gate uses.
+* **Task B** -- reference skills are chosen per call from the block's evidence;
+  what is not inlined is manifested with an absolute path to read.
+* **Task C** -- a pre-simulation gate failure is diagnosed as `conformance`,
+  with no waveform hunt.
+"""
+from __future__ import annotations
+
+import json
+
+from orchestrator.langchain.prompts.skills import (
+    UARCH_SKILL_CANDIDATES,
+    MissingSkillError,
+    build_skill_section,
+    load_skill,
+    select_skills,
+    skill_manifest,
+    skill_path,
+)
+
+
+def _anchor(skill_id: str, n: int = 300) -> str:
+    """A distinctive slice of a skill's BODY, to prove presence/absence."""
+    body = load_skill(skill_id)
+    assert body, f"{skill_id}.md must exist on disk"
+    # Skip the title line; take a run of real prose.
+    return body[len(body.splitlines()[0]):][:n].strip()
+
+
+# ---------------------------------------------------------------------------
+# Task B1 -- the deterministic classifier
+# ---------------------------------------------------------------------------
+
+class TestSelectSkillsEvidenceClasses:
+    def test_memory_shaped_block_selects_memory_macro(self):
+        sel = select_skills(
+            {"name": "pixel_line_buffer",
+             "description": "1024x32 line buffer for the raster stage"},
+            None, None,
+        )
+        assert "memory_macro_vs_flops" in sel
+
+    def test_memory_map_artifact_selects_memory_macro(self):
+        sel = select_skills({"name": "b"}, None, {"memory_map": {"peripherals": []}})
+        assert "memory_macro_vs_flops" in sel
+
+    def test_axi_labels_in_contract_select_axi_stream(self):
+        contracts = {"edges": [{
+            "producer_block": "a", "consumer_block": "b",
+            "producer_port": "out_stream", "consumer_port": "in_stream",
+            "handshake_protocol": "axi_stream",
+            "fields": [{"name": "tdata", "width": 32}],
+        }]}
+        sel = select_skills({"name": "a"}, contracts, None)
+        assert "axi_stream" in sel
+
+    def test_srdy_drdy_labels_select_srdy_skill(self):
+        contracts = {"edges": [{
+            "producer_block": "a", "consumer_block": "b",
+            "producer_port": "coeff", "consumer_port": "coeff",
+            "handshake_protocol": "srdy_drdy",
+            "fields": [{"name": "data", "width": 8}],
+        }]}
+        assert "srdy_drdy" in select_skills({"name": "a"}, contracts, None)
+
+    def test_serialization_evidence_selects_both_packing_skills(self):
+        sel = select_skills(
+            {"name": "stream_packer",
+             "description": "packs symbols into the output bitstream"},
+            None, None,
+        )
+        assert "serialization_contract" in sel
+        assert "buffer_stride_contract" in sel, (
+            "a packed buffer is read back by slot/stride -- the two travel "
+            "together"
+        )
+
+    def test_pipeline_hint_selects_pipeline_contract(self):
+        sel = select_skills(
+            {"name": "b", "description": "four-stage pipelined datapath"},
+            None, None)
+        assert "pipeline_contract" in sel
+
+    def test_throughput_budget_selects_throughput_contract(self):
+        sel = select_skills({"name": "b", "perf": {"cycles_per_op": 4}}, None, None)
+        assert "throughput_budget_contract" in sel
+
+    def test_control_pulse_fields_select_control_pulse_skill(self):
+        contracts = {"edges": [{
+            "producer_block": "ctl", "consumer_block": "core",
+            "producer_port": "job", "consumer_port": "job",
+            "fields": [{"name": "start", "width": 1},
+                       {"name": "done", "width": 1}],
+        }]}
+        assert "control_pulse_handshake" in select_skills(
+            {"name": "ctl"}, contracts, None)
+
+    def test_arithmetic_ops_in_model_select_arithmetic_precision(self):
+        sel = select_skills(
+            {"name": "b", "description": "widget",
+             "model_source": "def f(a, b):\n    return (a * b) >> 8\n"},
+            {"edges": []}, None,
+        )
+        assert "arithmetic_precision" in sel
+
+    def test_plain_model_without_math_excludes_arithmetic_precision(self):
+        sel = select_skills(
+            {"name": "regfile", "description": "eight entry register file",
+             "model_source": "def f(mem, addr):\n    return mem[addr]\n"},
+            {"edges": [{"producer_block": "regfile", "producer_port": "rd",
+                        "fields": [{"name": "data", "width": 8}]}]},
+            None,
+        )
+        assert "arithmetic_precision" not in sel
+
+
+class TestSelectSkillsConservative:
+    def test_no_evidence_includes_everything(self):
+        assert select_skills(None, None, None) == list(UARCH_SKILL_CANDIDATES)
+        assert select_skills({}, {}, {}) == list(UARCH_SKILL_CANDIDATES)
+
+    def test_missing_evidence_channel_votes_include(self):
+        # Contracts are where the interface labels live. With none supplied we
+        # cannot judge the handshake skills -- so they are INCLUDED.
+        sel = select_skills({"name": "b", "description": "a widget"}, None, None)
+        assert "axi_stream" in sel and "srdy_drdy" in sel
+        # ...and with contracts present that say neither, they are excluded.
+        contracts = {"edges": [{
+            "producer_block": "b", "consumer_block": "c",
+            "producer_port": "pins", "consumer_port": "pins",
+            "handshake_protocol": "static",
+            "fields": [{"name": "level", "width": 1}],
+        }]}
+        sel2 = select_skills({"name": "b", "description": "a widget"},
+                             contracts, None)
+        assert "axi_stream" not in sel2
+
+    def test_no_model_source_votes_include_arithmetic(self):
+        sel = select_skills(
+            {"name": "b", "description": "a widget"}, {"edges": []}, None)
+        assert "arithmetic_precision" in sel
+
+    def test_selection_is_deterministic_and_ordered(self):
+        spec = {"name": "pixel_line_buffer", "description": "1024x32 buffer"}
+        first = select_skills(spec, None, None)
+        assert first == select_skills(spec, None, None)
+        assert first == [s for s in UARCH_SKILL_CANDIDATES if s in first]
+
+
+class TestManifestAndAssembly:
+    def test_manifest_line_carries_purpose_and_absolute_path(self):
+        out = skill_manifest(["serialization_contract"])
+        assert "`serialization_contract`" in out
+        assert str(skill_path("serialization_contract")) in out
+        assert skill_path("serialization_contract").is_absolute()
+        assert "READ" in out
+
+    def test_manifest_rejects_undescribed_skill(self):
+        try:
+            skill_manifest(["not_a_real_skill_xyz"])
+        except MissingSkillError:
+            return
+        raise AssertionError("an undescribed skill must fail loudly")
+
+    def test_missing_selected_skill_raises_loudly(self):
+        try:
+            build_skill_section(["not_a_real_skill_xyz"], candidates=())
+        except MissingSkillError as exc:
+            assert "not_a_real_skill_xyz" in str(exc)
+            return
+        raise AssertionError("a missing skill file must raise at first use")
+
+    def test_port_naming_always_inline(self):
+        section = build_skill_section([], candidates=UARCH_SKILL_CANDIDATES)
+        assert "data_write_write_enable" in section
+        # ...and every unselected skill is still reachable by path.
+        for sid in UARCH_SKILL_CANDIDATES:
+            assert str(skill_path(sid)) in section
+
+
+# ---------------------------------------------------------------------------
+# Task B1 -- the assembled uArch system prompt for a register-file block
+# ---------------------------------------------------------------------------
+
+_REGFILE_SPEC = {
+    "name": "config_register_file",
+    "description": "16-entry x 32-bit configuration register file with one "
+                   "write port and one read port",
+    "model_source": "def read(mem, addr):\n    return mem[addr]\n",
+}
+
+_REGFILE_CONTRACTS = {
+    "edges": [
+        {
+            "edge_id": "e_w", "role": "consumer",
+            "producer_block": "host_if", "consumer_block": "config_register_file",
+            "producer_port": "data_write", "consumer_port": "data_write",
+            "handshake_protocol": "static",
+            "fields": [
+                {"name": "addr", "width": 5},
+                {"name": "wdata", "width": 32},
+                {"name": "write_enable", "width": 1},
+            ],
+            "sideband_signals": [],
+        },
+        {
+            "edge_id": "e_r", "role": "producer",
+            "producer_block": "config_register_file", "consumer_block": "core",
+            "producer_port": "data_read", "consumer_port": "data_read",
+            "handshake_protocol": "static",
+            "fields": [
+                {"name": "req_addr", "width": 5},
+                {"name": "rdata", "width": 32},
+            ],
+            "sideband_signals": [],
+        },
+    ]
+}
+
+
+class TestUarchSystemPromptForRegisterFile:
+    def _prompt(self):
+        from orchestrator.langchain.agents import uarch_spec_generator as u
+        return u.build_system_prompt(
+            block_spec=_REGFILE_SPEC,
+            contracts=_REGFILE_CONTRACTS,
+            block_diagram={"blocks": [{"name": "config_register_file"}]},
+        )
+
+    def test_serialization_body_is_not_inlined(self):
+        prompt = self._prompt()
+        assert _anchor("serialization_contract") not in prompt, (
+            "a register file must not carry the 18 KB bitstream-serialization "
+            "skill body"
+        )
+
+    def test_serialization_is_manifested_with_its_path(self):
+        prompt = self._prompt()
+        assert "`serialization_contract`" in prompt
+        assert str(skill_path("serialization_contract")) in prompt
+
+    def test_port_naming_body_is_inlined(self):
+        prompt = self._prompt()
+        assert "data_write_write_enable" in prompt
+        assert _anchor("port_naming") in prompt
+
+    def test_memory_skill_is_inlined_for_a_register_file(self):
+        assert _anchor("memory_macro_vs_flops") in self._prompt()
+
+    def test_smaller_than_the_unconditional_concatenation(self):
+        from orchestrator.langchain.agents import uarch_spec_generator as u
+        from orchestrator.langchain.prompts.skills import load_skills
+
+        old_size = len(u.SYSTEM_PROMPT) + len(
+            load_skills(*UARCH_SKILL_CANDIDATES))
+        new_size = len(self._prompt())
+        assert new_size < old_size, (old_size, new_size)
+
+
+# ---------------------------------------------------------------------------
+# Task A -- the contract port table in the production RTL prompt
+# ---------------------------------------------------------------------------
+
+_DOUBLED_TOKEN_CONTRACTS = {
+    "contracts": [
+        {
+            "edge_id": "e1",
+            "producer_block": "qspi_slave_frontend",
+            "consumer_block": "regmap_buffers",
+            "producer_port": "host_write",
+            "consumer_port": "host_write",
+            "handshake_protocol": "static",
+            "fields": [
+                {"name": "addr", "width": 24},
+                {"name": "wdata", "width": 8},
+                {"name": "write_enable", "width": 1},
+            ],
+            "sideband_signals": [{"name": "abort", "width": 1}],
+        },
+    ]
+}
+
+
+def _project(tmp_path):
+    (tmp_path / ".coresmith").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".coresmith" / "interface_contracts.json").write_text(
+        json.dumps(_DOUBLED_TOKEN_CONTRACTS), encoding="utf-8")
+    return tmp_path
+
+
+class TestContractPortTable:
+    def test_rows_are_derived_from_the_conformance_machinery(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import (
+            check_block,
+            contract_port_rows,
+        )
+        root = _project(tmp_path)
+        rows = contract_port_rows(str(root), "regmap_buffers")
+        names = {r["port"] for r in rows}
+        assert "host_write_write_enable" in names
+        assert "host_write_abort" in names, "sideband is part of the port set"
+
+        # The gate must demand EXACTLY the names the table advertises.
+        rtl = tmp_path / "regmap_buffers.v"
+        rtl.write_text("module regmap_buffers(input wire clk);\nendmodule\n")
+        missing = {port for _chan, port in
+                   check_block(str(root), "regmap_buffers", rtl).missing}
+        assert missing == names
+
+    def test_doubled_token_row_is_flagged(self, tmp_path):
+        from orchestrator.langgraph.contract_conformance import contract_port_rows
+        root = _project(tmp_path)
+        rows = {r["port"]: r for r in contract_port_rows(str(root), "regmap_buffers")}
+        assert rows["host_write_write_enable"]["doubled_token"] is True
+        assert rows["host_write_addr"]["doubled_token"] is False
+
+    def test_rtl_prompt_carries_the_table_and_the_label(self, tmp_path):
+        from orchestrator.langchain.agents.rtl_generator import build_user_message
+        root = _project(tmp_path)
+        prompt = build_user_message(
+            block_name="regmap_buffers",
+            description="register map + buffers",
+            attempt=1,
+            rtl_target="rtl/regmap_buffers.v",
+            python_source_path="inputs/golden.py",
+            project_root=str(root),
+        )
+        assert "AUTHORITATIVE PORT NAMES" in prompt
+        assert "host_write_write_enable" in prompt
+        assert "host_write_wdata" in prompt
+        assert "DOUBLED TOKEN IS CORRECT" in prompt
+        # The golden model must be demoted as a naming source.
+        assert "take every port NAME from" in prompt
+
+    def test_rtl_prompt_states_constraint_precedence(self, tmp_path):
+        from orchestrator.langchain.agents.rtl_generator import build_user_message
+        root = _project(tmp_path)
+        prompt = build_user_message(
+            block_name="regmap_buffers", rtl_target="rtl/x.v",
+            project_root=str(root),
+        )
+        assert "PRECEDENCE" in prompt
+        assert "constraints" in prompt.lower()
+
+    def test_no_contract_edge_means_no_table(self, tmp_path):
+        from orchestrator.langchain.agents.rtl_generator import build_user_message
+        root = _project(tmp_path)
+        prompt = build_user_message(
+            block_name="unrelated_block", rtl_target="rtl/x.v",
+            project_root=str(root),
+        )
+        assert "AUTHORITATIVE PORT NAMES" not in prompt
+
+    def test_rtl_system_prompt_has_port_naming_skill(self):
+        from orchestrator.langchain.agents import rtl_generator as rg
+        assert "data_write_write_enable" in rg.SYSTEM_PROMPT
+
+    def test_block_model_system_prompt_has_port_naming_skill(self):
+        from orchestrator.langchain.agents import block_golden_generator as bgg
+        prompt = bgg.build_system_prompt(
+            block_spec=_REGFILE_SPEC, contracts=_REGFILE_CONTRACTS)
+        assert "data_write_write_enable" in prompt
+        # anti-cheat stays unconditional too
+        assert _anchor("no_stimulus_keyed_memorization") in prompt
+
+
+# ---------------------------------------------------------------------------
+# Task C -- phase truthfulness
+# ---------------------------------------------------------------------------
+
+class TestDiagnosisPhaseLabelling:
+    def test_conformance_prompt_has_no_waveform_hunt(self):
+        from orchestrator.langchain.agents.debug_agent import (
+            build_debug_user_message,
+        )
+        msg = build_debug_user_message("blk", "conformance")
+        assert "Failed phase: conformance" in msg
+        # No artifact PATH that a simulation would have produced is offered...
+        for artifact in ("dump.vcd", "wavekit_audit.json", "sim_build/",
+                         "tb/cocotb/"):
+            assert artifact not in msg, artifact
+        # ...and the agent is told, in as many words, not to go looking.
+        assert "NO VCD" in msg and "NO WaveKit" in msg
+        assert "do not look for them" in msg.lower()
+        assert "contract_conformance.json" in msg
+        assert "interface_contracts.json" in msg
+        assert "no sim" in msg.lower()
+
+    def test_sim_prompt_still_points_at_the_waveform(self):
+        from orchestrator.langchain.agents.debug_agent import (
+            build_debug_user_message,
+        )
+        msg = build_debug_user_message("blk", "sim")
+        assert "Failed phase: sim" in msg
+        assert "dump.vcd" in msg and "wavekit_audit.json" in msg
+
+    def test_debug_system_prompt_carves_out_pre_sim_phases(self):
+        from orchestrator.langchain.agents.debug_agent import (
+            DEBUG_SYSTEM_PROMPT,
+        )
+        assert "Failed phase:" in DEBUG_SYSTEM_PROMPT
+        assert "pre-simulation" in DEBUG_SYSTEM_PROMPT.lower()
+
+    def test_conformance_gates_report_the_conformance_phase(self):
+        import inspect
+
+        from orchestrator.langgraph import pipeline_graph as pg
+        src = inspect.getsource(pg.generate_testbench_node)
+        assert '"phase": "conformance"' in src
+        assert src.count('"phase": "conformance"') >= 2, (
+            "both pre-TB contract gates (port widths + port names) must "
+            "report the pre-sim phase"
+        )
+
+    def test_conformance_phase_routes_to_rtl_retry(self):
+        from orchestrator.langgraph.pipeline_graph import _route_decision
+        action = _route_decision(
+            debug_result={"category": "INTERFACE_MISMATCH", "confidence": 0.9},
+            attempt_history=[], attempt=1, max_attempts=5,
+            phase="conformance",
+        )
+        assert action == "retry_rtl"
+
+
+# ---------------------------------------------------------------------------
+# Task B2 -- cache-friendly constraint fan-out
+# ---------------------------------------------------------------------------
+
+class TestConstraintSubagentPrefix:
+    def _prompts(self):
+        from orchestrator.architecture.constraints import build_subagent_prompt
+        bundle = "## block_diagram.json\n" + ("x" * 5000)
+        return [
+            build_subagent_prompt({"id": f"c{i}", "description": f"rule {i}"},
+                                  bundle)
+            for i in range(8)
+        ], bundle
+
+    def test_shared_bundle_is_a_byte_identical_prefix(self):
+        prompts, bundle = self._prompts()
+        prefix_len = len("## Artifact bundle\n") + len(bundle)
+        prefixes = {p[:prefix_len] for p in prompts}
+        assert len(prefixes) == 1, "all subagents must share one exact prefix"
+        assert prompts[0].startswith("## Artifact bundle\n")
+
+    def test_charter_comes_last_and_still_names_the_constraint(self):
+        prompts, bundle = self._prompts()
+        for i, p in enumerate(prompts):
+            assert p.index(f"`c{i}`") > p.index(bundle[:50])
+            assert f"rule {i}" in p
+            assert "JSON only" in p
+
+    def test_fanout_warms_the_cache_with_one_call_first(self):
+        import inspect
+
+        from orchestrator.architecture import constraints as c
+        src = inspect.getsource(c.check_constraints)
+        assert "applicable[0]" in src, "one subagent must be issued first"
+        assert "applicable[1:]" in src, "the rest fan out in parallel"

--- a/orchestrator/tests/test_prompt_authority.py
+++ b/orchestrator/tests/test_prompt_authority.py
@@ -361,6 +361,51 @@ class TestContractPortTable:
         )
         assert "AUTHORITATIVE PORT NAMES" not in prompt
 
+    def test_a_slash_alias_contract_keeps_prompt_and_gate_in_step(self, tmp_path):
+        """The generate side and the gate share ONE derivation, so a contract
+        whose channel is a slash ENUMERATION of the channel's concrete ports
+        (`m_read_req/addr`, the schema template's own second form) and whose
+        sideband is a two-name alias (`srdy/in_valid`) must produce the same
+        legal names on both sides -- never a `/` in a port the prompt shows or
+        the gate demands."""
+        from orchestrator.langgraph.contract_conformance import (
+            check_block,
+            contract_port_rows,
+            format_contract_port_table,
+        )
+        (tmp_path / ".coresmith").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".coresmith" / "interface_contracts.json").write_text(
+            json.dumps({"contracts": [{
+                "edge_id": "e1",
+                "producer_block": "engine",
+                "consumer_block": "sample_memory",
+                "producer_port": "m_store_read_req/addr",
+                "consumer_port": "s_store_read_req/addr",
+                "fields": [{"name": "sample_u8", "width": 8}],
+                "sideband_signals": [
+                    {"name": "req"}, {"name": "address", "width": 13},
+                    {"name": "srdy/in_valid"},
+                ],
+            }]}), encoding="utf-8")
+
+        rows = contract_port_rows(str(tmp_path), "sample_memory")
+        names = {r["port"] for r in rows}
+        assert names == {"s_store_read_sample_u8", "s_store_read_req",
+                         "s_store_read_address", "s_store_read_srdy"}
+
+        rtl = tmp_path / "sample_memory.v"
+        rtl.write_text("module sample_memory(input wire clk);\nendmodule\n")
+        missing = {port for _chan, port in
+                   check_block(str(tmp_path), "sample_memory", rtl).missing}
+        assert missing == names, "prompt table and gate must not diverge"
+
+        table = format_contract_port_table(str(tmp_path), "sample_memory")
+        for n in names:
+            assert f"`{n}`" in table
+        for line in table.splitlines():
+            if line.startswith("- `"):
+                assert "/" not in line, line
+
     def test_rtl_system_prompt_has_port_naming_skill(self):
         from orchestrator.langchain.agents import rtl_generator as rg
         assert "data_write_write_enable" in rg.SYSTEM_PROMPT

--- a/orchestrator/tests/test_skills.py
+++ b/orchestrator/tests/test_skills.py
@@ -132,16 +132,40 @@ class TestSkillsWiredIntoAgents:
     wiring so a refactor that drops the load can't go unnoticed."""
 
     def test_uarch_spec_generator_loads_arithmetic_precision(self):
+        # Skills are now selected PER CALL (see build_system_prompt): the
+        # wiring test asserts the skill reaches a block whose evidence calls
+        # for it, not that it is concatenated at import time onto every block.
         from orchestrator.langchain.agents import uarch_spec_generator
-        assert "Bit-width derivation" in uarch_spec_generator.SYSTEM_PROMPT
+        prompt = uarch_spec_generator.build_system_prompt(
+            block_spec={"name": "mac_lane",
+                        "description": "multiply-accumulate lane",
+                        "model_source": "def f(a, b):\n    return (a * b) >> 8\n"},
+        )
+        assert "Bit-width derivation" in prompt
 
     def test_uarch_spec_generator_loads_memory_macro_vs_flops(self):
         # The SRAM-macro-vs-flops skill must reach the uArch agent so
         # every spec author chooses storage type explicitly.
         from orchestrator.langchain.agents import uarch_spec_generator
-        prompt = uarch_spec_generator.SYSTEM_PROMPT
+        prompt = uarch_spec_generator.build_system_prompt(
+            block_spec={"name": "frame_store",
+                        "description": "1024x32 SRAM-backed frame buffer"},
+        )
         assert "sky130_sram_1kbyte_1rw1r_32x256_8" in prompt
         assert "SRAM macro" in prompt
+
+    def test_uarch_spec_generator_no_evidence_inlines_every_skill(self):
+        # Conservative default: with nothing to classify on, the per-call
+        # prompt is exactly as complete as the old unconditional one.
+        from orchestrator.langchain.agents import uarch_spec_generator
+        from orchestrator.langchain.prompts.skills import (
+            UARCH_SKILL_CANDIDATES,
+            load_skill,
+        )
+        prompt = uarch_spec_generator.build_system_prompt()
+        for sid in UARCH_SKILL_CANDIDATES:
+            body = load_skill(sid)
+            assert body[-400:] in prompt, sid
 
     def test_ers_doc_loads_memory_macro_vs_flops(self):
         # The ERS specialist binds memory implementation for the whole


### PR DESCRIPTION
## What

The engine fixes accumulated on the raster speed-run campaign (branch also carries the run's provenance — it is main + #83 + #84 content at its base):

- **`latched_control_decisions` skill, always-inline**: the three-generation opcode-latch class ("any decoded control value consumed outside the cycle that produced it must be latched; never re-derive from a live bus signal in a later state"). Validated live: generation 3 of the raster QSPI core contains the hazardous idiom and correctly latches it.
- **`POST /backend/resume`**: backend interrupts (DRC/LVS/signoff parks) were unanswerable over HTTP — the MCP-only path silently loses resumes from short-lived callers, making a parked backend terminal from the outside (blocked two campaigns). Delegates to the MCP implementation; the daemon loop hosts the task.
- **`accept` action at signoff parks — waive-and-proceed, never silent**: `skip` at a DRC park abandons the block, making LVS/timing/report structurally unreachable for ANY dirty DRC including classified library artifacts. `accept` waives the current failed check with the operator rationale recorded, routes to the next stage, and carries the waiver visibly in the block result. Threaded through all four enforcement layers (interrupt action list, MCP validator, router, node preconditions). Proven live: LVS executed on a DRC-waived design for the first time.
- **PnR prompt corrections**: `-max_columns` belongs on `add_pdn_connect` (not `define_pdn_grid` — rejected STA-0562 on OpenROAD v2.0-17598, proven by controlled keyword probe); generated TCL may not wrap PDN in catch-and-fall-back (it masked a hard ERROR and silently shipped the unmitigated grid); top-level PDN pins on met5; TCL braces escaped for format-template parity.

## Known follow-ups (ledgered, not in this PR)

The `escalate` decision path bypasses `ask_human`, so an adjudicated-benign failure can record `success:false` without the waiver ever being offered; daemon restart severs a parked backend thread's in-memory continuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBWgL9qExhCeRdRMAXv7yX
