### PR TITLE
feat(llm): add OpenCode Muse Spark endpoint (Meta Model API)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -109,6 +109,10 @@ claude auth login   # default provider, interactive
 # Hosted Kimi K3 alternative:
 # opencode auth login   # select OpenRouter
 # export CORESMITH_LLM_PROVIDER=opencode
+# Meta Muse Spark 1.1 alternative (no opencode auth login needed):
+# export CORESMITH_LLM_PROVIDER=opencode
+# export CORESMITH_OPENCODE_ENDPOINT=muse-spark
+# export META_MODEL_API_KEY=LLM_...
 
 # 3. Python venv + orchestrator
 python3.11 -m venv venv
@@ -145,7 +149,7 @@ otherwise the latest of each works for most blocks.
 | Python | 3.11.x | `python3.11 -m venv venv` |
 | Node.js | 20.20.x | NodeSource repo, *not* apt's 12.x |
 | Claude Code CLI | 2.x | `npm install -g @anthropic-ai/claude-code` |
-| OpenCode CLI | 1.18+ | `npm install -g opencode-ai`; optional OpenRouter/Kimi K3 provider |
+| OpenCode CLI | 1.18+ | `npm install -g opencode-ai`; optional OpenRouter/Kimi K3 or Meta Muse Spark 1.1 endpoint |
 | OSS-CAD-Suite | 2026-04-29 nightly | Bundles Yosys 0.64+, Verilator 5.049, OpenROAD, Magic, netgen, KLayout |
 | Sky130 PDK | volare commit pinned in [`scripts/pdk-version.env`](scripts/pdk-version.env) | `volare ls-remote --pdk sky130` for current pins |
 | Python deps | see `requirements-lock.txt` | `pip install -r requirements-lock.txt` for an exact replay |

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,8 +1,17 @@
 # Authentication
 
-coresmith supports Claude Code (default), Codex CLI, OpenCode with OpenRouter's
-hosted Kimi K3, and the Kimi Code CLI. Select OpenCode with
-`CORESMITH_LLM_PROVIDER=opencode`, or Kimi Code with `CORESMITH_LLM_PROVIDER=kimi`.
+coresmith supports Claude Code (default), Codex CLI, OpenCode (with OpenRouter's
+hosted Kimi K3 or Meta's Muse Spark 1.1), and the Kimi Code CLI. Select OpenCode
+with `CORESMITH_LLM_PROVIDER=opencode`, or Kimi Code with
+`CORESMITH_LLM_PROVIDER=kimi`.
+
+Under `CORESMITH_LLM_PROVIDER=opencode`, `CORESMITH_OPENCODE_ENDPOINT` picks
+which backend OpenCode talks to:
+
+| `CORESMITH_OPENCODE_ENDPOINT` | Route | Credential |
+|---|---|---|
+| unset / `openrouter` (default) | `openrouter/moonshotai/kimi-k3` | `OPENROUTER_API_KEY` |
+| `muse-spark` | `meta-model-api/muse-spark-1.1` | `META_MODEL_API_KEY` |
 
 ## OpenCode + OpenRouter (Kimi K3)
 
@@ -39,6 +48,53 @@ consumes the NDJSON event stream. Every valid event—including model-exposed
 and usage remain in `.coresmith/llm_calls.jsonl`. The trajectory file can contain
 sensitive prompt, reasoning, and tool content, so protect it like other run
 artifacts. CoreSmith uses `permission: "deny"` when tools are disabled.
+
+## OpenCode + Meta Model API (Muse Spark 1.1)
+
+[Muse Spark 1.1](https://ai.meta.com/blog/introducing-muse-spark-meta-model-api/)
+is served from Meta's Model API at `https://api.meta.ai/v1` over an
+OpenAI-*chat-completions*-compatible surface. Get a key from the Meta Model API
+console, then:
+
+```bash
+npm install -g opencode-ai
+export CORESMITH_LLM_PROVIDER=opencode
+export CORESMITH_OPENCODE_ENDPOINT=muse-spark
+export META_MODEL_API_KEY=LLM_...
+```
+
+That is the whole setup — **no `opencode auth login` and no hand-edited
+`~/.config/opencode/opencode.json`.** OpenCode's built-in registry has no
+chat-completions provider for this endpoint, so CoreSmith registers one inline
+through `OPENCODE_CONFIG_CONTENT` on every call, merging (never clobbering) any
+provider block you already set. The key is referenced as `{env:META_MODEL_API_KEY}`
+and is read from the process environment, so the secret never enters the config
+blob CoreSmith hands to the CLI. If `META_MODEL_API_KEY` is unset the call fails
+fast with a clear error instead of falling back to another model.
+
+Verify the route:
+
+```bash
+curl -s https://api.meta.ai/v1/models -H "Authorization: Bearer $META_MODEL_API_KEY"
+# -> {"object":"list","data":[{"id":"muse-spark-1.1",...}]}
+```
+
+Two behaviours worth knowing:
+
+- **The provider id is `meta-model-api`, not `meta`.** OpenCode's model registry
+  already ships a `meta` provider pinned to the `@ai-sdk/openai` adapter — the
+  *Responses* API. A provider block keyed `meta` merges into that entry, inherits
+  its adapter, and every call dies with `responses is not a function`. CoreSmith
+  registers under an id the registry does not claim so the
+  `@ai-sdk/openai-compatible` adapter actually takes effect. Do not rename it
+  without re-verifying against a live key.
+- **`CORESMITH_OPENCODE_VARIANT` is ignored on this endpoint, so CoreSmith drops
+  it.** Muse Spark returns 200 for *any* `--variant` — `low`, `high`, `max`,
+  `minimal`, even a nonsense value — and the reported reasoning-token count does
+  not move. Rather than put a reasoning cap in the command line and the logs that
+  is not actually in force, CoreSmith omits the flag and warns once. Muse Spark
+  is a reasoning model that spends completion budget on hidden reasoning tokens,
+  so size `max_tokens`/output limits with that in mind.
 
 ## Kimi Code
 

--- a/docs/RUNPOD.md
+++ b/docs/RUNPOD.md
@@ -39,8 +39,10 @@ is fine. There's no GPU dependency.
 |----------|---------|----------|
 | `ANTHROPIC_API_KEY` | API key from console.anthropic.com | one of API key / OAuth required for non-shell modes |
 | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token from `claude setup-token` | alternate to Anthropic API key |
-| `CORESMITH_LLM_PROVIDER` | Set `opencode` for hosted Kimi K3 through OpenRouter | optional; defaults to Claude |
-| `OPENROUTER_API_KEY` | OpenRouter secret consumed by OpenCode | required when provider is `opencode` unless auth store is mounted |
+| `CORESMITH_LLM_PROVIDER` | Set `opencode` for hosted Kimi K3 through OpenRouter, or Muse Spark through the Meta Model API | optional; defaults to Claude |
+| `CORESMITH_OPENCODE_ENDPOINT` | `openrouter` (default) or `muse-spark` | optional; only read when provider is `opencode` |
+| `OPENROUTER_API_KEY` | OpenRouter secret consumed by OpenCode | required for the `openrouter` endpoint unless auth store is mounted |
+| `META_MODEL_API_KEY` | Meta Model API secret consumed by OpenCode | required for the `muse-spark` endpoint |
 | `CORESMITH_MODE` | `shell` (default), `pipeline`, `mcp`, `mcp-http`, `test` | optional |
 | `CORESMITH_MODEL` | Override default model (e.g. `opus-5`, `sonnet-5`, `haiku-4.5`) | optional |
 | `MCP_PORT` | Port for `mcp-http` mode (default `8765`) | optional |

--- a/orchestrator/langchain/agents/coresmith_llm.py
+++ b/orchestrator/langchain/agents/coresmith_llm.py
@@ -737,6 +737,50 @@ _OPENCODE_MODEL_MAP = {
     "haiku-3.5": "openrouter/moonshotai/kimi-k3",
 }
 
+# --- Muse Spark endpoint (Meta Model API) -----------------------------------
+# Meta's Model API serves Muse Spark 1.1 over an OpenAI-*chat-completions*
+# compatible surface (POST {base}/chat/completions), so OpenCode must load the
+# "@ai-sdk/openai-compatible" adapter for it.
+#
+# WHY A NON-OBVIOUS PROVIDER ID: models.dev (OpenCode's built-in registry)
+# already ships a provider called "meta", pinned to npm "@ai-sdk/openai" -- the
+# *Responses* API. A user provider block keyed "meta" merges INTO that registry
+# entry and inherits its npm, so every call dies inside getModel() with
+# "responses is not a function". Registering under an id the registry does not
+# claim is what makes the adapter choice actually stick. Do not rename this to
+# "meta" without re-verifying against a live key.
+MUSE_SPARK_PROVIDER_ID = "meta-model-api"
+MUSE_SPARK_MODEL_ID = "muse-spark-1.1"
+MUSE_SPARK_BASE_URL = "https://api.meta.ai/v1"
+MUSE_SPARK_NPM = "@ai-sdk/openai-compatible"
+# Secret is read from the environment at call time and never persisted by
+# CoreSmith. OPENCODE_CONFIG_CONTENT uses OpenCode's "{env:VAR}" indirection so
+# the key itself is not embedded in the config blob we hand to the CLI.
+MUSE_SPARK_API_KEY_ENV = "META_MODEL_API_KEY"
+# 1M-token context per Meta's model card; output cap is the conservative value
+# CoreSmith asks OpenCode to plan against.
+MUSE_SPARK_CONTEXT_LIMIT = 1_000_000
+MUSE_SPARK_OUTPUT_LIMIT = 65_536
+
+DEFAULT_MUSE_SPARK_MODEL = f"{MUSE_SPARK_PROVIDER_ID}/{MUSE_SPARK_MODEL_ID}"
+
+# Every CoreSmith tier maps onto the single Muse Spark model the Model API
+# currently exposes (GET /v1/models returns exactly muse-spark-1.1).
+_MUSE_SPARK_MODEL_MAP = {
+    tier: DEFAULT_MUSE_SPARK_MODEL for tier in _OPENCODE_MODEL_MAP
+}
+
+
+def _is_muse_spark_model(resolved_model: str) -> bool:
+    """Whether a resolved OpenCode slug points at Muse Spark on the Model API.
+
+    Matches on the model id rather than the provider prefix so an operator who
+    routes Muse Spark through their own gateway (a different provider id, or
+    OpenRouter's ``openrouter/meta/muse-spark-1.1``) still gets the
+    model-specific handling.
+    """
+    return MUSE_SPARK_MODEL_ID in (resolved_model or "").lower()
+
 
 # Default model used by every agent unless overridden. Set the CORESMITH_MODEL
 # environment variable (to either a short name above or a full Claude CLI
@@ -752,6 +796,111 @@ DEFAULT_OPENCODE_MODEL = "openrouter/moonshotai/kimi-k3"
 # fix, tb fix).  Integration and review agents still call DEFAULT_MODEL.
 # Override with CORESMITH_BLOCK_MODEL env var.
 BLOCK_MODEL = "sonnet-5"
+
+# --- OpenCode endpoint selection --------------------------------------------
+# An "endpoint" bundles the model map, the default model and (where the target
+# is not something OpenCode can reach out of the box) the provider registration
+# CoreSmith injects for it.
+#
+# "openrouter" is the pre-existing hosted-Kimi route and remains the DEFAULT, so
+# a run that does not set CORESMITH_OPENCODE_ENDPOINT behaves exactly as before
+# this endpoint was added -- same model, same flags, same provider config.
+OPENCODE_ENDPOINT_OPENROUTER = "openrouter"
+OPENCODE_ENDPOINT_MUSE_SPARK = "muse-spark"
+
+_OPENCODE_ENDPOINT_ALIASES = {
+    "": OPENCODE_ENDPOINT_OPENROUTER,
+    "default": OPENCODE_ENDPOINT_OPENROUTER,
+    "openrouter": OPENCODE_ENDPOINT_OPENROUTER,
+    "kimi": OPENCODE_ENDPOINT_OPENROUTER,
+    "kimi-k3": OPENCODE_ENDPOINT_OPENROUTER,
+    "muse": OPENCODE_ENDPOINT_MUSE_SPARK,
+    "muse-spark": OPENCODE_ENDPOINT_MUSE_SPARK,
+    "muse_spark": OPENCODE_ENDPOINT_MUSE_SPARK,
+    "musespark": OPENCODE_ENDPOINT_MUSE_SPARK,
+    "meta": OPENCODE_ENDPOINT_MUSE_SPARK,
+    "meta-model-api": OPENCODE_ENDPOINT_MUSE_SPARK,
+}
+
+
+def _opencode_endpoint() -> str:
+    """Resolve ``CORESMITH_OPENCODE_ENDPOINT`` to a canonical endpoint name.
+
+    Unset (or any "openrouter" alias) keeps the historical hosted-Kimi route.
+    An unrecognised value raises rather than silently falling back: picking a
+    different model than the operator asked for is the kind of thing that only
+    surfaces hours later in a token bill.
+    """
+    raw = os.environ.get("CORESMITH_OPENCODE_ENDPOINT", "").strip().lower()
+    try:
+        return _OPENCODE_ENDPOINT_ALIASES[raw]
+    except KeyError:
+        raise ValueError(
+            "Unsupported CORESMITH_OPENCODE_ENDPOINT={!r}. Use one of: {}.".format(
+                raw, ", ".join(sorted(set(_OPENCODE_ENDPOINT_ALIASES.values())))
+            )
+        ) from None
+
+
+def _opencode_endpoint_models(endpoint: str) -> tuple[dict, str]:
+    """Return ``(model_map, default_model)`` for a canonical endpoint name."""
+    if endpoint == OPENCODE_ENDPOINT_MUSE_SPARK:
+        return _MUSE_SPARK_MODEL_MAP, DEFAULT_MUSE_SPARK_MODEL
+    return _OPENCODE_MODEL_MAP, DEFAULT_OPENCODE_MODEL
+
+
+def muse_spark_provider_config() -> dict:
+    """The OpenCode provider block that registers the Meta Model API.
+
+    Returned as a plain dict so callers can merge it into an existing
+    ``OPENCODE_CONFIG_CONTENT`` rather than clobbering operator config. The API
+    key is referenced through OpenCode's ``{env:VAR}`` indirection, so the
+    secret stays in the process environment and never lands in the config blob.
+    """
+    return {
+        "npm": MUSE_SPARK_NPM,
+        "name": "Meta Model API",
+        "api": MUSE_SPARK_BASE_URL,
+        "options": {
+            "baseURL": MUSE_SPARK_BASE_URL,
+            "apiKey": "{env:%s}" % MUSE_SPARK_API_KEY_ENV,
+        },
+        "models": {
+            MUSE_SPARK_MODEL_ID: {
+                "name": "Muse Spark 1.1",
+                "limit": {
+                    "context": MUSE_SPARK_CONTEXT_LIMIT,
+                    "output": MUSE_SPARK_OUTPUT_LIMIT,
+                },
+            },
+        },
+    }
+
+
+def _inject_muse_spark_provider(config_content: str) -> str:
+    """Merge the Muse Spark provider block into an OPENCODE_CONFIG_CONTENT blob.
+
+    Operator-supplied keys win: if the blob already registers
+    ``MUSE_SPARK_PROVIDER_ID`` we leave it completely alone, so a site that
+    needs a proxy base URL or a different adapter can override us without
+    editing CoreSmith.
+    """
+    try:
+        config = _json.loads(config_content or "{}") or {}
+    except _json.JSONDecodeError as exc:
+        raise ValueError(
+            "OPENCODE_CONFIG_CONTENT must be valid JSON to use the "
+            "muse-spark endpoint"
+        ) from exc
+    if not isinstance(config, dict):
+        raise ValueError("OPENCODE_CONFIG_CONTENT must contain a JSON object")
+
+    providers = config.setdefault("provider", {})
+    if not isinstance(providers, dict):
+        raise ValueError("OPENCODE_CONFIG_CONTENT 'provider' must be an object")
+    providers.setdefault(MUSE_SPARK_PROVIDER_ID, muse_spark_provider_config())
+    return _json.dumps(config)
+
 
 # --- OpenCode reasoning-effort ("--variant") handling ------------------------
 # OpenRouter's hosted Kimi models (kimi-k3 / kimi-k2-thinking) expose reasoning
@@ -798,6 +947,20 @@ def _normalize_opencode_variant(variant: str, resolved_model: str) -> str:
     """
     v = (variant or "").strip().lower()
     if not v:
+        return ""
+    if _is_muse_spark_model(resolved_model):
+        # Verified against a live Meta Model API key: muse-spark-1.1 accepts
+        # EVERY --variant value -- low/high/max/minimal and even "bogusvalue"
+        # all return 200, and the reported reasoning-token counts do not track
+        # the flag. Shipping it would put a reasoning cap in the command line
+        # and the logs that is not actually in force, which is precisely the
+        # footgun the Kimi normalisation above exists to prevent.
+        logger.warning(
+            "CORESMITH_OPENCODE_VARIANT=%r has no effect on %s: the Meta Model "
+            "API silently ignores --variant. Omitting the flag so it does not "
+            "imply a reasoning cap that is not applied.",
+            variant, resolved_model,
+        )
         return ""
     if "kimi" not in (resolved_model or "").lower():
         return v
@@ -914,15 +1077,18 @@ def _resolve_model(model: str, provider: str = "claude_cli") -> str:
             return DEFAULT_AGY_MODEL
         return _AGY_MODEL_MAP.get(model, model)
     if provider == "opencode_cli":
+        # The endpoint picks which catalogue we resolve against; an explicit
+        # CORESMITH_OPENCODE_MODEL still wins over both.
+        _model_map, _default_model = _opencode_endpoint_models(_opencode_endpoint())
         env_override = (
             os.environ.get("CORESMITH_OPENCODE_MODEL", "").strip()
             or os.environ.get("CORESMITH_MODEL", "").strip()
         )
         if env_override:
-            return _OPENCODE_MODEL_MAP.get(env_override, env_override)
+            return _model_map.get(env_override, env_override)
         if not model:
-            return DEFAULT_OPENCODE_MODEL
-        return _OPENCODE_MODEL_MAP.get(model, model)
+            return _default_model
+        return _model_map.get(model, model)
 
     env_override = os.environ.get("CORESMITH_MODEL", "").strip()
     if env_override:
@@ -2369,6 +2535,23 @@ class ClaudeLLM:
                 raise ValueError("OPENCODE_CONFIG_CONTENT must contain a JSON object")
             inline_config["permission"] = "deny"
             process_env["OPENCODE_CONFIG_CONTENT"] = _json.dumps(inline_config)
+
+        # Muse Spark is not reachable out of the box: OpenCode's built-in
+        # registry has no chat-completions provider for the Meta Model API, so
+        # CoreSmith registers one inline rather than making every operator
+        # hand-edit ~/.config/opencode/opencode.json. Merged (not clobbered) on
+        # top of whatever the disable_tools branch above and the operator set.
+        if _is_muse_spark_model(resolved_model):
+            if not process_env.get(MUSE_SPARK_API_KEY_ENV, "").strip():
+                raise RuntimeError(
+                    f"{MUSE_SPARK_API_KEY_ENV} is not set, so OpenCode cannot "
+                    f"authenticate against the Meta Model API "
+                    f"({MUSE_SPARK_BASE_URL}). Export the key before starting "
+                    f"the daemon."
+                )
+            process_env["OPENCODE_CONFIG_CONTENT"] = _inject_muse_spark_provider(
+                process_env.get("OPENCODE_CONFIG_CONTENT", "")
+            )
 
         logger.info(
             "OpenCode invocation: model=%s prompt_len=%d system_len=%d",

--- a/orchestrator/tests/test_coresmith_llm.py
+++ b/orchestrator/tests/test_coresmith_llm.py
@@ -28,6 +28,7 @@ from orchestrator.langchain.agents.coresmith_llm import (
     _CLI_MODEL_MAP,
     _CODEX_MODEL_MAP,
     _KIMI_MODEL_MAP,
+    _MUSE_SPARK_MODEL_MAP,
     _OPENCODE_LOW_REASONING_STEPS,
     _OPENCODE_MODEL_MAP,
     _RESUME_FLAGS_CACHE,
@@ -35,7 +36,13 @@ from orchestrator.langchain.agents.coresmith_llm import (
     DEFAULT_CODEX_MODEL,
     DEFAULT_KIMI_MODEL,
     DEFAULT_MODEL,
+    DEFAULT_MUSE_SPARK_MODEL,
     DEFAULT_OPENCODE_MODEL,
+    MUSE_SPARK_API_KEY_ENV,
+    MUSE_SPARK_BASE_URL,
+    MUSE_SPARK_MODEL_ID,
+    MUSE_SPARK_NPM,
+    MUSE_SPARK_PROVIDER_ID,
     ClaudeLLM,
     _active_processes,
     _active_processes_lock,
@@ -45,9 +52,12 @@ from orchestrator.langchain.agents.coresmith_llm import (
     _is_transient_opencode_failure,
     _llm_breakers,
     _llm_breakers_lock,
+    _inject_muse_spark_provider,
+    _is_muse_spark_model,
     _log_llm_call,
     _log_opencode_turns,
     _normalize_opencode_variant,
+    _opencode_endpoint,
     _parse_codex_json,
     _parse_kimi_acp_json,
     _parse_opencode_json,
@@ -73,6 +83,8 @@ def _clear_provider_env(monkeypatch):
     monkeypatch.delenv("CORESMITH_OPENCODE_MODEL", raising=False)
     monkeypatch.delenv("CORESMITH_OPENCODE_VARIANT", raising=False)
     monkeypatch.delenv("CORESMITH_OPENCODE_MAX_RETRIES", raising=False)
+    monkeypatch.delenv("CORESMITH_OPENCODE_ENDPOINT", raising=False)
+    monkeypatch.delenv("META_MODEL_API_KEY", raising=False)
     monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
     monkeypatch.delenv("CORESMITH_KIMI_MODEL", raising=False)
     monkeypatch.delenv("KIMI_MODEL_NAME", raising=False)
@@ -1297,3 +1309,215 @@ class TestFailedCallLogging:
         assert "provider boom" in rec["error"]
         assert rec["response"] == ""
         assert rec["run_name"] == "rn"
+
+
+class TestOpenCodeEndpointSelection:
+    """CORESMITH_OPENCODE_ENDPOINT picks which catalogue OpenCode resolves against.
+
+    Both branches are covered per the repo convention: unset must reproduce the
+    historical OpenRouter/Kimi behaviour byte for byte, set must switch.
+    """
+
+    def test_defaults_to_openrouter_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CORESMITH_OPENCODE_ENDPOINT", raising=False)
+        assert _opencode_endpoint() == "openrouter"
+
+    def test_openrouter_endpoint_leaves_model_resolution_unchanged(self, monkeypatch):
+        """Regression guard: adding Muse Spark must not move the default route."""
+        monkeypatch.delenv("CORESMITH_OPENCODE_ENDPOINT", raising=False)
+        assert _resolve_model(DEFAULT_MODEL, "opencode_cli") == DEFAULT_OPENCODE_MODEL
+        assert _resolve_model(BLOCK_MODEL, "opencode_cli") == DEFAULT_OPENCODE_MODEL
+        assert set(_OPENCODE_MODEL_MAP.values()) == {"openrouter/moonshotai/kimi-k3"}
+
+    @pytest.mark.parametrize(
+        "alias", ["muse", "muse-spark", "muse_spark", "musespark", "meta",
+                  "meta-model-api", "MUSE-SPARK", "  Muse-Spark  "],
+    )
+    def test_muse_spark_aliases(self, monkeypatch, alias):
+        monkeypatch.setenv("CORESMITH_OPENCODE_ENDPOINT", alias)
+        assert _opencode_endpoint() == "muse-spark"
+
+    @pytest.mark.parametrize("alias", ["openrouter", "kimi", "kimi-k3", "default", ""])
+    def test_openrouter_aliases(self, monkeypatch, alias):
+        monkeypatch.setenv("CORESMITH_OPENCODE_ENDPOINT", alias)
+        assert _opencode_endpoint() == "openrouter"
+
+    def test_unknown_endpoint_raises(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_OPENCODE_ENDPOINT", "gpt-9")
+        with pytest.raises(ValueError, match="Unsupported CORESMITH_OPENCODE_ENDPOINT"):
+            _opencode_endpoint()
+
+    def test_muse_spark_endpoint_maps_every_tier(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_OPENCODE_ENDPOINT", "muse-spark")
+        expected = "meta-model-api/muse-spark-1.1"
+        assert DEFAULT_MUSE_SPARK_MODEL == expected
+        assert set(_MUSE_SPARK_MODEL_MAP.values()) == {expected}
+        # Every tier the OpenRouter route knows is also routable on Muse Spark:
+        # the Model API currently exposes exactly one model.
+        assert set(_MUSE_SPARK_MODEL_MAP) == set(_OPENCODE_MODEL_MAP)
+        assert _resolve_model(DEFAULT_MODEL, "opencode_cli") == expected
+        assert _resolve_model(BLOCK_MODEL, "opencode_cli") == expected
+
+    def test_explicit_opencode_model_still_wins_on_muse_endpoint(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_OPENCODE_ENDPOINT", "muse-spark")
+        monkeypatch.setenv("CORESMITH_OPENCODE_MODEL", "openrouter/meta/muse-spark-1.1")
+        assert (
+            _resolve_model("opus-5", "opencode_cli") == "openrouter/meta/muse-spark-1.1"
+        )
+
+
+class TestMuseSparkModelDetection:
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "meta-model-api/muse-spark-1.1",
+            "openrouter/meta/muse-spark-1.1",
+            "META-MODEL-API/MUSE-SPARK-1.1",
+        ],
+    )
+    def test_detects_muse_spark_regardless_of_provider_prefix(self, slug):
+        assert _is_muse_spark_model(slug) is True
+
+    @pytest.mark.parametrize(
+        "slug", ["openrouter/moonshotai/kimi-k3", "kimi-code/k3", "", None],
+    )
+    def test_rejects_non_muse_models(self, slug):
+        assert _is_muse_spark_model(slug) is False
+
+
+class TestMuseSparkVariantHandling:
+    """Muse Spark silently accepts any --variant, so CoreSmith must not send one.
+
+    Verified against a live Meta Model API key: low/high/max/minimal and an
+    outright bogus value all return 200 and none of them move the reported
+    reasoning-token count. Emitting the flag would advertise a reasoning cap
+    that is not in force.
+    """
+
+    @pytest.mark.parametrize("variant", ["low", "high", "max", "minimal", "bogusvalue"])
+    def test_variant_is_dropped_for_muse_spark(self, variant):
+        assert _normalize_opencode_variant(variant, DEFAULT_MUSE_SPARK_MODEL) == ""
+
+    def test_kimi_variant_handling_is_untouched(self):
+        # The pre-existing Kimi normalisation must keep working unchanged.
+        assert _normalize_opencode_variant(
+            "minimal", "openrouter/moonshotai/kimi-k3"
+        ) == "low"
+        assert _normalize_opencode_variant(
+            "high", "openrouter/moonshotai/kimi-k3"
+        ) == "high"
+
+
+class TestMuseSparkProviderInjection:
+    def test_registers_chat_completions_adapter_and_base_url(self):
+        cfg = json.loads(_inject_muse_spark_provider(""))
+        provider = cfg["provider"][MUSE_SPARK_PROVIDER_ID]
+        # @ai-sdk/openai-compatible == /v1/chat/completions. The built-in
+        # models.dev "meta" provider pins @ai-sdk/openai (Responses API), which
+        # fails against this endpoint -- hence the distinct provider id.
+        assert provider["npm"] == MUSE_SPARK_NPM == "@ai-sdk/openai-compatible"
+        assert MUSE_SPARK_PROVIDER_ID != "meta"
+        assert provider["options"]["baseURL"] == MUSE_SPARK_BASE_URL
+        assert provider["api"] == "https://api.meta.ai/v1"
+        assert MUSE_SPARK_MODEL_ID in provider["models"]
+
+    def test_api_key_is_referenced_by_env_not_inlined(self, monkeypatch):
+        monkeypatch.setenv(MUSE_SPARK_API_KEY_ENV, "LLM_secret_value")
+        blob = _inject_muse_spark_provider("")
+        assert "{env:META_MODEL_API_KEY}" in blob
+        assert "LLM_secret_value" not in blob
+
+    def test_merges_into_existing_config_without_clobbering(self):
+        existing = json.dumps({"permission": "deny", "provider": {"openrouter": {}}})
+        cfg = json.loads(_inject_muse_spark_provider(existing))
+        assert cfg["permission"] == "deny"
+        assert "openrouter" in cfg["provider"]
+        assert MUSE_SPARK_PROVIDER_ID in cfg["provider"]
+
+    def test_operator_provider_block_wins(self):
+        existing = json.dumps(
+            {"provider": {MUSE_SPARK_PROVIDER_ID: {"npm": "@acme/custom"}}}
+        )
+        cfg = json.loads(_inject_muse_spark_provider(existing))
+        assert cfg["provider"][MUSE_SPARK_PROVIDER_ID] == {"npm": "@acme/custom"}
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="must be valid JSON"):
+            _inject_muse_spark_provider("{not json")
+
+    def test_non_object_raises(self):
+        with pytest.raises(ValueError, match="must contain a JSON object"):
+            _inject_muse_spark_provider("[1, 2, 3]")
+
+
+class TestMuseSparkInvocation:
+    @patch(
+        "orchestrator.langchain.agents.coresmith_llm._find_opencode_binary",
+        return_value="/usr/bin/opencode",
+    )
+    def test_muse_endpoint_sets_model_config_and_omits_variant(
+        self, _mock_find, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setenv("CORESMITH_LLM_PROVIDER", "opencode")
+        monkeypatch.setenv("CORESMITH_OPENCODE_ENDPOINT", "muse-spark")
+        monkeypatch.setenv("META_MODEL_API_KEY", "LLM_test_key")
+        # Even an explicit variant must not reach the CLI for this model.
+        monkeypatch.setenv("CORESMITH_OPENCODE_VARIANT", "max")
+        monkeypatch.setenv("CORESMITH_PROJECT_ROOT", str(tmp_path))
+
+        model = ClaudeLLM(model="opus-5", timeout=10)
+        with patch.object(model, "_run_cli_with_watchdog") as watchdog:
+            watchdog.return_value = ("ready", "", 0, 1.0, False, False, {})
+            model._generate_via_cli("system", "hello")
+
+        cmd = watchdog.call_args.args[0]
+        assert cmd[cmd.index("--model") + 1] == "meta-model-api/muse-spark-1.1"
+        assert "--variant" not in cmd
+
+        env = watchdog.call_args.kwargs["process_env"]
+        cfg = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+        provider = cfg["provider"][MUSE_SPARK_PROVIDER_ID]
+        assert provider["npm"] == "@ai-sdk/openai-compatible"
+        assert provider["options"]["baseURL"] == "https://api.meta.ai/v1"
+        # The secret is passed through the environment, never the config blob.
+        assert "LLM_test_key" not in env["OPENCODE_CONFIG_CONTENT"]
+        assert env["META_MODEL_API_KEY"] == "LLM_test_key"
+
+    @patch(
+        "orchestrator.langchain.agents.coresmith_llm._find_opencode_binary",
+        return_value="/usr/bin/opencode",
+    )
+    def test_missing_api_key_fails_fast(self, _mock_find, monkeypatch, tmp_path):
+        monkeypatch.setenv("CORESMITH_LLM_PROVIDER", "opencode")
+        monkeypatch.setenv("CORESMITH_OPENCODE_ENDPOINT", "muse-spark")
+        monkeypatch.delenv("META_MODEL_API_KEY", raising=False)
+        monkeypatch.setenv("CORESMITH_PROJECT_ROOT", str(tmp_path))
+
+        model = ClaudeLLM(model="opus-5", timeout=10)
+        with patch.object(model, "_run_cli_with_watchdog") as watchdog:
+            with pytest.raises(RuntimeError, match="META_MODEL_API_KEY is not set"):
+                model._generate_via_cli("system", "hello")
+        watchdog.assert_not_called()
+
+    @patch(
+        "orchestrator.langchain.agents.coresmith_llm._find_opencode_binary",
+        return_value="/usr/bin/opencode",
+    )
+    def test_openrouter_endpoint_does_not_register_meta_provider(
+        self, _mock_find, monkeypatch, tmp_path,
+    ):
+        """Default route must not gain a Meta provider block or need its key."""
+        monkeypatch.setenv("CORESMITH_LLM_PROVIDER", "opencode")
+        monkeypatch.delenv("CORESMITH_OPENCODE_ENDPOINT", raising=False)
+        monkeypatch.delenv("META_MODEL_API_KEY", raising=False)
+        monkeypatch.setenv("CORESMITH_PROJECT_ROOT", str(tmp_path))
+
+        model = ClaudeLLM(model="opus-5", timeout=10)
+        with patch.object(model, "_run_cli_with_watchdog") as watchdog:
+            watchdog.return_value = ("ready", "", 0, 1.0, False, False, {})
+            model._generate_via_cli("system", "hello")
+
+        cmd = watchdog.call_args.args[0]
+        assert cmd[cmd.index("--model") + 1] == "openrouter/moonshotai/kimi-k3"
+        env = watchdog.call_args.kwargs["process_env"]
+        assert MUSE_SPARK_PROVIDER_ID not in env.get("OPENCODE_CONFIG_CONTENT", "")


### PR DESCRIPTION
## What

Adds a second OpenCode endpoint so `CORESMITH_LLM_PROVIDER=opencode` can target Meta's **Muse Spark 1.1** via the Meta Model API (`https://api.meta.ai/v1`) instead of the hosted Kimi K3 route.

```bash
export CORESMITH_LLM_PROVIDER=opencode
export CORESMITH_OPENCODE_ENDPOINT=muse-spark
export META_MODEL_API_KEY=LLM_...
```

No `opencode auth login`, no hand-edited `~/.config/opencode/opencode.json` — CoreSmith registers the provider inline.

**The default is unchanged.** Unset (or any `openrouter`/`kimi` alias) resolves the same model, the same flags and the same provider config as before, and never requires the new key. Both branches are covered by tests per the repo convention.

## Three things worth reviewing

**1. The provider id is `meta-model-api`, not `meta`.** This is the non-obvious part. OpenCode's models.dev registry already ships a provider called `meta`, pinned to `npm: @ai-sdk/openai` — the *Responses* API. A user provider block keyed `meta` merges *into* that registry entry and inherits its adapter, so every call dies inside `getModel()` with `responses is not a function`. Meta's endpoint speaks chat-completions and needs `@ai-sdk/openai-compatible`; only a provider id the registry does not claim makes that adapter choice stick. Please don't rename this to `meta` without re-verifying against a live key — there's a comment in the source saying the same.

**2. `--variant` is deliberately dropped for this model.** Verified against a live key: `muse-spark-1.1` returns 200 for *every* variant value tried — `low`, `high`, `max`, `minimal`, and a deliberately bogus one — and the reported reasoning-token counts do not track the flag. Emitting it would put a reasoning cap in the command line and the logs that is not actually in force, which is precisely the footgun the existing Kimi normalisation exists to prevent. We warn once and omit the flag.

**3. Secret handling.** The key is referenced through OpenCode's `{env:META_MODEL_API_KEY}` indirection and read from the process environment, so it never enters the config blob handed to the CLI. There's a test asserting the literal key value does not appear in the serialised config. A missing key fails fast rather than silently falling back to another model.

Muse Spark is a reasoning model that spends completion budget on hidden reasoning tokens — a probe with `max_tokens: 32` burned 29 on reasoning and returned `content: null` with `finish_reason: \"length\"`. The registered model config declares a 64K output limit accordingly.

## Verification

- **Unit:** 151/151 in `test_coresmith_llm.py` (111 pre-existing + 40 new). 394/395 across all ten test files that reference the changed module; the one failure (`test_integration_lead.py::test_calls_integration_lead_agent`) reproduces identically on unmodified `main` at the same commit and is unrelated to this change.
- **Live, end-to-end:** drove a real CoreSmith architecture + frontend run on an 8-core VM with this endpoint. It completed the architecture phase and took a 2-block 32-bit adder design through per-block RTL generation, lint, cocotb DV and Sky130 synthesis — 2/2 blocks passing — with `opencode --model meta-model-api/muse-spark-1.1` running as a child of the daemon throughout.

That run later stopped at `integration_check` when the Meta account behind the test key returned HTTP 402 `billing_not_configured`. That is an account/quota condition, not a code path in this PR; the error propagates cleanly and is not retried (it is correctly classified as non-transient).

## Notes for the reviewer

The full 155-file suite does not complete in my environment — it gets SIGTERM'd partway — but it does so identically on an unmodified checkout at the same commit, so I could not get a clean full-suite number either way. Targeted coverage above is the meaningful signal.

Filed as a draft: the live exercise stopped short of `integration_dv`/`validation_dv` for the billing reason above, so the endpoint has not yet been proven across a *complete* chip run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)