### PR TITLE
Fix five fresh-install and DV-gate blockers (integration/validation DV cannot pass on WaveKit 0.7)

### DIFF
--- a/bin/coresmith
+++ b/bin/coresmith
@@ -275,18 +275,29 @@ def _daemon_start(args):
     # interpreter can find pygpi (a separate package introduced in
     # cocotb 2.0). Without it, every sim invocation fails with
     # ``ModuleNotFoundError: No module named 'pygpi'`` even though the
-    # module is on disk next to cocotb itself. We auto-detect the
-    # required value from the current interpreter's sysconfig prefix
-    # and inject it -- the operator may override by setting
-    # PYTHONHOME explicitly in the environment or in .coresmith/env.
+    # module is on disk next to cocotb itself. We auto-detect the required
+    # value -- from the interpreter we are about to SPAWN, not from the one
+    # running this script, since they are usually different (system python
+    # here, repo venv python there) -- and inject it. The operator may
+    # override by setting PYTHONHOME explicitly in the environment or in
+    # .coresmith/env. resolve_pythonhome() returns None rather than a prefix
+    # with no stdlib: injecting one of those kills the daemon at startup
+    # ("No module named 'encodings'"), which is worse than not setting it.
     if "PYTHONHOME" not in env:
         try:
-            import sysconfig
-            prefix = sysconfig.get_config_var("prefix")
-            if prefix:
-                env["PYTHONHOME"] = prefix
-        except Exception:
-            pass
+            sys.path.insert(0, str(repo_root))
+            from orchestrator.harness.env import resolve_pythonhome
+            pythonhome = resolve_pythonhome(python)
+            if pythonhome:
+                env["PYTHONHOME"] = pythonhome
+            else:
+                print(
+                    "note: PYTHONHOME not injected -- no interpreter prefix with "
+                    "a stdlib found. cocotb sims may fail with 'No module named "
+                    "pygpi'; set PYTHONHOME explicitly if they do."
+                )
+        except Exception as e:  # noqa: BLE001 -- auto-detect is best-effort
+            print(f"note: PYTHONHOME auto-detect skipped: {e}")
 
     with open(log_path, "ab") as logf:
         proc = subprocess.Popen(

--- a/orchestrator/harness/env.py
+++ b/orchestrator/harness/env.py
@@ -13,10 +13,76 @@ on the process cwd (agents run from arbitrary directories).
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _prefix_has_stdlib(prefix: str | Path) -> bool:
+    """Whether ``prefix`` is a directory that actually holds a Python stdlib."""
+    root = Path(prefix)
+    if not root.is_dir():
+        return False
+    # posix: <prefix>/lib/python3.X/encodings ; windows: <prefix>/Lib/encodings
+    return any(next(root.glob(pat), None) is not None
+               for pat in ("lib/python*/encodings", "Lib/encodings"))
+
+
+def _interpreter_base_prefix(python: str | Path) -> str | None:
+    """Ask ``python`` for its own ``sys.base_prefix``; ``None`` on any failure."""
+    try:
+        proc = subprocess.run(
+            [str(python), "-c", "import sys; print(sys.base_prefix)"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except Exception:  # noqa: BLE001 -- probe is best-effort
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def resolve_pythonhome(python: str | Path | None = None) -> str | None:
+    """Return a PYTHONHOME value that can actually bootstrap an interpreter.
+
+    cocotb 2.x needs PYTHONHOME so Verilator's embedded interpreter can find
+    pygpi. The obvious source -- ``sysconfig.get_config_var("prefix")`` -- is
+    the prefix the interpreter was *configured* with, which is not always where
+    it was *installed*: relocated, framework and vendor-repackaged builds
+    report a prefix holding no stdlib. Injecting such a value is strictly worse
+    than injecting nothing, because PYTHONHOME overrides stdlib discovery, so
+    the child dies before running a single line with ``Fatal Python error:
+    init_fs_encoding`` / ``ModuleNotFoundError: No module named 'encodings'``.
+
+    Two corrections over the naive read:
+
+    * When ``python`` names a different interpreter than the current one
+      (``bin/coresmith`` may run under the system python while spawning the
+      venv python), ask *that* interpreter for its ``sys.base_prefix`` -- a
+      prefix derived from the launcher does not necessarily describe the child.
+    * Verify the candidate holds a stdlib, and return ``None`` rather than a
+      value known to be unbootable. ``None`` degrades to a pygpi import error
+      at sim time; a bad value kills the process at startup.
+    """
+    candidates: list[str] = []
+    if python and str(python) != sys.executable:
+        remote = _interpreter_base_prefix(python)
+        if remote:
+            candidates.append(remote)
+    candidates.append(sys.base_prefix)
+    try:
+        import sysconfig
+        configured = sysconfig.get_config_var("prefix")
+        if configured:
+            candidates.append(configured)
+    except Exception:  # noqa: BLE001
+        pass
+    for candidate in candidates:
+        if candidate and _prefix_has_stdlib(candidate):
+            return candidate
+    return None
 
 
 def repo_root() -> Path:
@@ -63,13 +129,9 @@ def harness_child_env(extra: dict | None = None) -> dict:
         env["PATH"] = os.pathsep.join(parts + [env.get("PATH", "/usr/bin:/bin")])
     # Preserve PYTHONHOME for cocotb's Verilator-embedded interpreter (pygpi).
     if "PYTHONHOME" not in env:
-        try:
-            import sysconfig
-            prefix = sysconfig.get_config_var("prefix")
-            if prefix:
-                env["PYTHONHOME"] = prefix
-        except Exception:  # noqa: BLE001
-            pass
+        pythonhome = resolve_pythonhome()
+        if pythonhome:
+            env["PYTHONHOME"] = pythonhome
     if extra:
         env.update({str(k): str(v) for k, v in extra.items()})
     return env

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -2060,6 +2060,81 @@ def _assert_testbench_materialized(tb_path: Path, block_name: str) -> str | None
 # Simulation
 # ---------------------------------------------------------------------------
 
+# Standalone WaveKit VCD-audit program. Runs in a SEPARATE interpreter
+# (see wavekit_python()), which may be a scratch venv rather than this
+# process, so it must not import anything from orchestrator. Module-level
+# so tests can exec it against stub readers for both WaveKit API shapes.
+_WAVEKIT_AUDIT_SCRIPT = r"""
+import json
+import sys
+from pathlib import Path
+
+from wavekit import VcdReader
+
+vcd_path = Path(sys.argv[1])
+clock_hint = sys.argv[2]
+
+with VcdReader(str(vcd_path)) as reader:
+    # WaveKit renamed its tree API between 0.5.x and 0.7.x. wavekit is
+    # unpinned in requirements.txt AND the wavekit_python() fallback below
+    # pip-installs the latest into a scratch venv, so a fresh box gets the new
+    # API no matter what the operator pinned. On the new API the 0.5.x calls
+    # raise AttributeError inside this script, which exits non-zero and is
+    # read as an audit FAILURE -- and the DV gates fail closed on that, so
+    # integration_dv and validation_dv could never pass. Support both shapes:
+    #   0.5.x: reader.top_scope_list()  scope.signal_list  scope.child_scope_list
+    #   0.7.x: reader.top_scopes        scope.children (signals and scopes mixed)
+    # Signal objects expose .full_name and .width in both.
+    _tops = getattr(reader, "top_scope_list", None)
+    top_scopes = _tops() if callable(_tops) else reader.top_scopes
+    signals = []
+    clocks = []
+
+    def _split(scope):
+        # Return (child_signals, child_scopes) for either API shape.
+        if hasattr(scope, "signal_list") or hasattr(scope, "child_scope_list"):
+            return (getattr(scope, "signal_list", []),
+                    getattr(scope, "child_scope_list", []))
+        sigs, scopes = [], []
+        for child in getattr(scope, "children", []):
+            # A signal is a leaf carrying a width; a scope is not.
+            (sigs if hasattr(child, "width") else scopes).append(child)
+        return sigs, scopes
+
+    def walk(scope):
+        child_signals, child_scopes = _split(scope)
+        for sig in child_signals:
+            name = sig.full_name
+            signals.append({"name": name, "width": int(sig.width)})
+            base = name.split(".")[-1].split("[")[0]
+            if base in {clock_hint, "clk", "clock", "i_clk"}:
+                clocks.append(name)
+        for child in child_scopes:
+            walk(child)
+
+    for top in top_scopes:
+        walk(top)
+
+    if not signals:
+        raise RuntimeError("VCD contains no signals")
+    if int(reader.end_time) <= int(reader.begin_time):
+        raise RuntimeError(
+            f"VCD contains no value-change time range: begin={reader.begin_time} end={reader.end_time}"
+        )
+
+    report = {
+        "ok": True,
+        "vcd_path": str(vcd_path),
+        "begin_time": int(reader.begin_time),
+        "end_time": int(reader.end_time),
+        "signal_count": len(signals),
+        "sample_signals": signals[:64],
+        "clock_candidates": clocks[:16],
+    }
+    print(json.dumps(report))
+"""
+
+
 def run_wavekit_vcd_audit(vcd_path: Path, audit_path: Path, clock_hint: str = "clk") -> dict:
     """Inspect a Verilator VCD with WaveKit and persist a small audit report."""
     if not vcd_path.exists() or vcd_path.stat().st_size == 0:
@@ -2104,52 +2179,7 @@ def run_wavekit_vcd_audit(vcd_path: Path, audit_path: Path, clock_hint: str = "c
             )
         return str(python)
 
-    script = r"""
-import json
-import sys
-from pathlib import Path
-
-from wavekit import VcdReader
-
-vcd_path = Path(sys.argv[1])
-clock_hint = sys.argv[2]
-
-with VcdReader(str(vcd_path)) as reader:
-    top_scopes = reader.top_scope_list()
-    signals = []
-    clocks = []
-
-    def walk(scope):
-        for sig in getattr(scope, "signal_list", []):
-            name = sig.full_name
-            signals.append({"name": name, "width": int(sig.width)})
-            base = name.split(".")[-1].split("[")[0]
-            if base in {clock_hint, "clk", "clock", "i_clk"}:
-                clocks.append(name)
-        for child in getattr(scope, "child_scope_list", []):
-            walk(child)
-
-    for top in top_scopes:
-        walk(top)
-
-    if not signals:
-        raise RuntimeError("VCD contains no signals")
-    if int(reader.end_time) <= int(reader.begin_time):
-        raise RuntimeError(
-            f"VCD contains no value-change time range: begin={reader.begin_time} end={reader.end_time}"
-        )
-
-    report = {
-        "ok": True,
-        "vcd_path": str(vcd_path),
-        "begin_time": int(reader.begin_time),
-        "end_time": int(reader.end_time),
-        "signal_count": len(signals),
-        "sample_signals": signals[:64],
-        "clock_candidates": clocks[:16],
-    }
-    print(json.dumps(report))
-"""
+    script = _WAVEKIT_AUDIT_SCRIPT
     try:
         audit_python = wavekit_python()
         proc = subprocess.run(

--- a/orchestrator/langgraph/pipeline_helpers.py
+++ b/orchestrator/langgraph/pipeline_helpers.py
@@ -231,6 +231,30 @@ def preflight_check(phases: list[str] | None = None) -> dict:
         if not Path(NETGEN_BIN).exists():
             errors.append(f"Netgen binary/script not found: {NETGEN_BIN}")
 
+        # The three checks above only assert the configured path EXISTS. By
+        # default they point at scripts/{openroad,magic,netgen}-nix.sh, which
+        # are committed to this repo and therefore always exist -- so backend
+        # preflight reports ok on a box with no EDA tools at all. Those
+        # wrappers are one-liners that `exec nix shell "nixpkgs#<tool>"`, so
+        # without nix on PATH every one of them fails at the first backend
+        # node. Warn (not error): a site may point config.yaml at real
+        # binaries, and turning a passing preflight into a failing one is a
+        # behaviour change this check does not need to make in order to stop
+        # being misleading.
+        _nix_wrapped = sorted({
+            Path(_b).name
+            for _b in (OPENROAD_BIN, MAGIC_BIN, NETGEN_BIN)
+            if Path(_b).name.endswith("-nix.sh")
+        })
+        if _nix_wrapped and not shutil.which("nix"):
+            warnings.append(
+                "backend tools resolve to nix wrappers (" + ", ".join(_nix_wrapped)
+                + ") but `nix` is not on PATH -- these paths exist as files, so "
+                "the checks above pass, but every backend node will fail when it "
+                "invokes them. Install nix (see SETUP.md Option B), use the "
+                "Docker image, or point config.yaml at real binaries."
+            )
+
     return {"ok": len(errors) == 0, "errors": errors, "warnings": warnings}
 
 # ANSI colors for terminal output

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "pydantic>=2.0",
     "pyyaml>=6.0",
     "jinja2>=3.1",
-    "mcp>=1.0.0",
+    # <2: mcp 2.x dropped `mcp.server.fastmcp`, imported by mcp_server.py.
+    "mcp>=1.0.0,<2",
     "gdstk>=0.9.0",
     "pygltflib>=1.16.0",
     "mapbox-earcut>=1.0.0",

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -255,6 +255,61 @@ def fft16_full_docs(isolated_project):
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Architecture-graph LLM containment
+# ═══════════════════════════════════════════════════════════════════════════
+
+def enter_arch_llm_node_patches(stack) -> None:
+    """Shut the architecture-graph nodes that reach a live LLM but are not
+    "specialists", so a test driving the whole graph stays offline.
+
+    Every test module that runs the architecture graph maintains its own list
+    of specialist patches, and both lists independently missed these two: they
+    are graph nodes rather than ``architecture.specialists.*`` modules, so they
+    do not look like something a "patch all specialists" helper should cover.
+    The result was that tests carrying no ``live_llm`` marker made real, billed
+    API calls, and the agents' shell tools ran unbounded commands (one observed
+    run spent 30+ minutes on a filesystem-wide ``find /``). The failure mode is
+    load-bearing on latency, not correctness, so it hid in plain sight -- CI
+    just looked slow.
+
+    Kept here rather than duplicated per module so the containment cannot drift
+    out of sync again. A test that genuinely wants either node's real behaviour
+    should mark itself ``live_llm`` and not call this.
+
+    Args:
+        stack: An ``ExitStack`` the caller already owns; patches are entered
+            into it and unwound with it.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    stack.enter_context(patch(
+        "orchestrator.architecture.specialists.interface_definition"
+        ".analyze_interface_definition",
+        new_callable=AsyncMock,
+        return_value={
+            "result": {
+                "design_summary": "patched by enter_arch_llm_node_patches",
+                "contracts": [],
+                "contract_violations": [],
+                "open_questions": [],
+            },
+            "questions": [],
+        },
+    ))
+    stack.enter_context(patch(
+        "orchestrator.langchain.agents.output_contract_review_agent"
+        ".OutputContractReviewAgent.review",
+        new_callable=AsyncMock,
+        return_value={
+            "passed": True,
+            "orphaned_properties": [],
+            "summary": "patched by enter_arch_llm_node_patches",
+            "feedback_for_redecomposition": "",
+        },
+    ))
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Assertion Helpers
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/orchestrator/tests/test_architecture_graph.py
+++ b/orchestrator/tests/test_architecture_graph.py
@@ -45,6 +45,7 @@ from orchestrator.langgraph.architecture_graph import (
     route_after_prd,
     route_after_prd_escalation,
 )
+from orchestrator.tests.conftest import enter_arch_llm_node_patches
 from orchestrator.tests.fft16_fixtures import (
     FFT16_BLOCK_DIAGRAM,
     FFT16_CLOCK_TREE,
@@ -158,6 +159,10 @@ def _patch_all_specialists(
         new_callable=AsyncMock,
         return_value={"ers": {"title": "FFT16 ERS", "summary": "test"}, "phase": "ers_complete"},
     ))
+    # Interface Definition and Output Contract Review are graph nodes rather
+    # than specialists, so they were missing from the list above and reached a
+    # live LLM on every whole-graph test. See enter_arch_llm_node_patches.
+    enter_arch_llm_node_patches(stack)
 
     return stack
 

--- a/orchestrator/tests/test_architecture_integration.py
+++ b/orchestrator/tests/test_architecture_integration.py
@@ -31,7 +31,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from orchestrator.tests.conftest import wait_for_status
+from orchestrator.tests.conftest import enter_arch_llm_node_patches, wait_for_status
 from orchestrator.tests.fft16_fixtures import (
     FFT16_BLOCK_DIAGRAM,
     FFT16_CLOCK_TREE,
@@ -151,6 +151,12 @@ def _patch_specialists_for_lifecycle(*, constraint_side_effect=None):
             new_callable=AsyncMock,
             return_value=[],
         ))
+
+    # Interface Definition and Output Contract Review are graph nodes rather
+    # than specialists, so they were missing from the list above and reached a
+    # live LLM. Here that showed up as `wait_for_status` timing out at 30s --
+    # the runner was still 'running' because a real API call was in flight.
+    enter_arch_llm_node_patches(stack)
 
     return stack
 

--- a/orchestrator/tests/test_preflight_backend_nix.py
+++ b/orchestrator/tests/test_preflight_backend_nix.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Backend preflight must not report a silent false green without nix.
+
+The OpenROAD/Magic/netgen checks only assert the configured path EXISTS. By
+default those paths are ``scripts/{openroad,magic,netgen}-nix.sh``, committed
+to this repo, so they exist on every checkout -- backend preflight returned
+``ok: true`` on a box with no EDA toolchain at all. Each wrapper is a one-liner
+that ``exec nix shell "nixpkgs#<tool>"``, so without nix every backend node
+fails at its first invocation.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+import orchestrator.langgraph.pipeline_helpers as ph
+
+_NIX_HINT = "nix wrappers"
+
+
+def _warn_blob(result: dict) -> str:
+    return "\n".join(result.get("warnings", []))
+
+
+@pytest.fixture
+def _no_pdk_noise(monkeypatch):
+    """Backend preflight also checks PDK files; those errors are not the point."""
+    monkeypatch.setenv("CORESMITH_SKIP_SYNTH", "1")
+    monkeypatch.setenv("CORESMITH_ALLOW_NO_OPENRAM", "1")
+
+
+def _fake_which(present: set[str]):
+    def _which(name, *a, **kw):
+        return f"/usr/bin/{name}" if name in present else None
+    return _which
+
+
+class TestNixWrapperWarning:
+    def test_warns_when_wrappers_configured_but_nix_absent(
+        self, monkeypatch, _no_pdk_noise,
+    ):
+        monkeypatch.setattr(ph.shutil, "which", _fake_which({"verilator", "yosys"}))
+        result = ph.preflight_check(["backend"])
+        blob = _warn_blob(result)
+        assert _NIX_HINT in blob
+        # names the wrappers so the operator knows which paths are affected
+        assert "openroad-nix.sh" in blob
+
+    def test_no_warning_when_nix_is_on_path(self, monkeypatch, _no_pdk_noise):
+        monkeypatch.setattr(
+            ph.shutil, "which", _fake_which({"verilator", "yosys", "nix"}),
+        )
+        assert _NIX_HINT not in _warn_blob(ph.preflight_check(["backend"]))
+
+    def test_no_warning_when_backend_phase_not_requested(
+        self, monkeypatch, _no_pdk_noise,
+    ):
+        monkeypatch.setattr(ph.shutil, "which", _fake_which({"verilator", "yosys"}))
+        assert _NIX_HINT not in _warn_blob(ph.preflight_check(["pipeline"]))
+
+    def test_no_warning_when_binaries_are_not_nix_wrappers(
+        self, monkeypatch, _no_pdk_noise,
+    ):
+        """A site pointing config.yaml at real binaries must stay quiet."""
+        import orchestrator.langgraph.backend_helpers as bh
+
+        for attr in ("OPENROAD_BIN", "MAGIC_BIN", "NETGEN_BIN"):
+            monkeypatch.setattr(bh, attr, f"/usr/bin/{attr.split('_')[0].lower()}")
+        monkeypatch.setattr(ph.shutil, "which", _fake_which({"verilator", "yosys"}))
+        assert _NIX_HINT not in _warn_blob(ph.preflight_check(["backend"]))
+
+    def test_warning_does_not_flip_ok(self, monkeypatch, _no_pdk_noise):
+        """It is a warning, not an error -- `ok` is decided by errors only."""
+        monkeypatch.setattr(ph.shutil, "which", _fake_which({"verilator", "yosys"}))
+        result = ph.preflight_check(["backend"])
+        assert result["ok"] == (len(result["errors"]) == 0)
+
+
+class TestWrappersReallyNeedNix:
+    """Guard the premise: if the wrappers stop shelling to nix, drop the warning."""
+
+    def test_shipped_wrappers_exec_nix(self):
+        from pathlib import Path
+
+        repo_root = Path(ph.__file__).resolve().parents[2]
+        for name in ("openroad-nix.sh", "magic-nix.sh", "netgen-nix.sh"):
+            script = repo_root / "scripts" / name
+            if not script.exists():
+                continue
+            assert "nix shell" in script.read_text(), f"{name} no longer uses nix"
+
+    def test_shutil_is_the_module_under_patch(self):
+        assert ph.shutil is shutil

--- a/orchestrator/tests/test_pythonhome_resolution.py
+++ b/orchestrator/tests/test_pythonhome_resolution.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for ``orchestrator.harness.env.resolve_pythonhome``.
+
+Regression cover for a daemon-won't-start failure: ``bin/coresmith`` used to
+inject ``PYTHONHOME=sysconfig.get_config_var("prefix")`` unconditionally. That
+is the prefix the interpreter was *configured* with, which relocated /
+framework / vendor-repackaged builds report as a path holding no stdlib. Since
+PYTHONHOME overrides stdlib discovery, the spawned daemon died before running
+any Python with ``ModuleNotFoundError: No module named 'encodings'``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from orchestrator.harness import env as harness_env
+
+
+def _make_fake_prefix(root: Path, version: str = "3.12") -> Path:
+    """Build a directory that looks like a real posix Python install root."""
+    (root / "lib" / f"python{version}" / "encodings").mkdir(parents=True)
+    (root / "lib" / f"python{version}" / "encodings" / "__init__.py").touch()
+    return root
+
+
+class TestPrefixHasStdlib:
+    def test_real_base_prefix_is_accepted(self):
+        assert harness_env._prefix_has_stdlib(sys.base_prefix)
+
+    def test_posix_layout_accepted(self, tmp_path):
+        assert harness_env._prefix_has_stdlib(_make_fake_prefix(tmp_path / "p"))
+
+    def test_windows_layout_accepted(self, tmp_path):
+        (tmp_path / "Lib" / "encodings").mkdir(parents=True)
+        assert harness_env._prefix_has_stdlib(tmp_path)
+
+    def test_directory_without_stdlib_rejected(self, tmp_path):
+        (tmp_path / "lib").mkdir()
+        assert not harness_env._prefix_has_stdlib(tmp_path)
+
+    def test_nonexistent_path_rejected(self, tmp_path):
+        assert not harness_env._prefix_has_stdlib(tmp_path / "nope")
+
+    def test_venv_prefix_rejected_when_it_has_no_stdlib(self, tmp_path):
+        # A venv's own prefix carries site-packages but no stdlib -- exactly
+        # the shape that must never be handed to PYTHONHOME.
+        (tmp_path / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
+        assert not harness_env._prefix_has_stdlib(tmp_path)
+
+
+class TestResolvePythonhome:
+    def test_returns_a_bootable_prefix_for_this_interpreter(self):
+        resolved = harness_env.resolve_pythonhome()
+        assert resolved is not None
+        assert harness_env._prefix_has_stdlib(resolved)
+
+    def test_skips_configured_prefix_that_holds_no_stdlib(self, tmp_path, monkeypatch):
+        """The exact production bug: configured prefix != install prefix."""
+        broken = tmp_path / "Library" / "Frameworks" / "Python.framework"
+        broken.mkdir(parents=True)
+        import sysconfig
+        monkeypatch.setattr(
+            sysconfig, "get_config_var",
+            lambda name: str(broken) if name == "prefix" else None,
+        )
+        resolved = harness_env.resolve_pythonhome()
+        assert resolved != str(broken)
+        assert resolved == sys.base_prefix
+
+    def test_returns_none_when_no_candidate_is_bootable(self, tmp_path, monkeypatch):
+        """Better to inject nothing than a value that kills the child."""
+        broken = tmp_path / "broken"
+        broken.mkdir()
+        monkeypatch.setattr(sys, "base_prefix", str(broken))
+        import sysconfig
+        monkeypatch.setattr(sysconfig, "get_config_var", lambda name: str(broken))
+        assert harness_env.resolve_pythonhome() is None
+
+    def test_prefers_the_prefix_of_the_interpreter_being_spawned(
+        self, tmp_path, monkeypatch,
+    ):
+        """``bin/coresmith`` may run under one interpreter and spawn another;
+        the value must describe the child, not the launcher."""
+        child_prefix = _make_fake_prefix(tmp_path / "child")
+        monkeypatch.setattr(
+            harness_env, "_interpreter_base_prefix", lambda python: str(child_prefix),
+        )
+        assert harness_env.resolve_pythonhome("/some/other/python") == str(child_prefix)
+
+    def test_falls_back_when_the_spawned_interpreter_cannot_be_probed(
+        self, monkeypatch,
+    ):
+        monkeypatch.setattr(
+            harness_env, "_interpreter_base_prefix", lambda python: None,
+        )
+        assert harness_env.resolve_pythonhome("/nonexistent/python") == sys.base_prefix
+
+    def test_same_interpreter_is_not_re_probed(self, monkeypatch):
+        """No subprocess when the target is the interpreter already running."""
+        def _boom(python):  # pragma: no cover -- must not be reached
+            raise AssertionError("should not probe the current interpreter")
+
+        monkeypatch.setattr(harness_env, "_interpreter_base_prefix", _boom)
+        assert harness_env.resolve_pythonhome(sys.executable) == sys.base_prefix
+
+
+class TestInterpreterBasePrefix:
+    def test_probes_a_real_interpreter(self):
+        assert harness_env._interpreter_base_prefix(sys.executable) == sys.base_prefix
+
+    def test_missing_interpreter_returns_none(self):
+        assert harness_env._interpreter_base_prefix("/nonexistent/python") is None
+
+
+class TestHarnessChildEnv:
+    def test_injects_only_a_bootable_pythonhome(self, monkeypatch):
+        monkeypatch.delenv("PYTHONHOME", raising=False)
+        env = harness_env.harness_child_env()
+        if "PYTHONHOME" in env:
+            assert harness_env._prefix_has_stdlib(env["PYTHONHOME"])
+
+    def test_explicit_pythonhome_is_left_alone(self, monkeypatch):
+        monkeypatch.setenv("PYTHONHOME", "/operator/override")
+        assert harness_env.harness_child_env()["PYTHONHOME"] == "/operator/override"

--- a/orchestrator/tests/test_wavekit_audit_api_compat.py
+++ b/orchestrator/tests/test_wavekit_audit_api_compat.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The WaveKit VCD audit must work against both WaveKit tree APIs.
+
+WaveKit renamed its scope-tree API between 0.5.x and 0.7.x. ``wavekit`` is
+unpinned in requirements.txt, and ``run_wavekit_vcd_audit``'s own fallback
+pip-installs the latest into a scratch venv, so a fresh box gets the new API
+regardless of what the operator pinned. The audit program used only the 0.5.x
+names, so on 0.7.x it raised ``AttributeError: 'VcdReader' object has no
+attribute 'top_scope_list'`` -- and because the DV gates fail CLOSED on a
+non-ok audit, ``integration_dv`` and ``validation_dv`` could never pass.
+
+These tests exec the audit program against stub readers of each shape, so both
+branches are covered without needing either WaveKit version installed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from orchestrator.langgraph.pipeline_helpers import _WAVEKIT_AUDIT_SCRIPT
+
+_VCD = """$timescale 1ns $end
+$scope module toy $end
+$var wire 1 ! clk $end
+$var wire 9 " s $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+b0 "
+#10
+1!
+b11 "
+"""
+
+# A stub `wavekit` module. `SHAPE` is substituted with "old" or "new".
+_STUB = '''
+import sys, types
+
+SHAPE = "{shape}"
+
+
+class _Sig:
+    def __init__(self, full_name, width):
+        self.full_name = full_name
+        self.width = width
+
+
+class _Scope:
+    def __init__(self, sigs, subs):
+        self._sigs, self._subs = sigs, subs
+        if SHAPE == "old":
+            self.signal_list = sigs
+            self.child_scope_list = subs
+        else:
+            # 0.7.x: one mixed `children` tuple; only signals carry `width`.
+            self.children = tuple(sigs) + tuple(subs)
+
+
+class VcdReader:
+    def __init__(self, path):
+        self.begin_time, self.end_time = 0, 10
+        inner = _Scope([_Sig("toy.sub.d[3:0]", 4)], [])
+        top = _Scope([_Sig("toy.clk", 1), _Sig("toy.s[8:0]", 9)], [inner])
+        if SHAPE == "old":
+            self.top_scope_list = lambda: [top]
+        else:
+            self.top_scopes = (top,)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+_m = types.ModuleType("wavekit")
+_m.VcdReader = VcdReader
+sys.modules["wavekit"] = _m
+'''
+
+
+def _run_audit(tmp_path: Path, shape: str) -> dict:
+    """Exec the real audit program with a stubbed wavekit of the given shape."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    vcd = tmp_path / "toy.vcd"
+    vcd.write_text(_VCD)
+    program = _STUB.format(shape=shape) + textwrap.dedent(_WAVEKIT_AUDIT_SCRIPT)
+    proc = subprocess.run(
+        [sys.executable, "-c", program, str(vcd), "clk"],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, f"audit exited {proc.returncode}\n{proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+class TestBothWavekitApiShapes:
+    @pytest.mark.parametrize("shape", ["old", "new"])
+    def test_audit_succeeds(self, tmp_path, shape):
+        report = _run_audit(tmp_path, shape)
+        assert report["ok"] is True
+
+    @pytest.mark.parametrize("shape", ["old", "new"])
+    def test_finds_every_signal_including_nested_scopes(self, tmp_path, shape):
+        report = _run_audit(tmp_path, shape)
+        assert report["signal_count"] == 3
+        names = {s["name"] for s in report["sample_signals"]}
+        assert names == {"toy.clk", "toy.s[8:0]", "toy.sub.d[3:0]"}
+
+    @pytest.mark.parametrize("shape", ["old", "new"])
+    def test_widths_preserved(self, tmp_path, shape):
+        widths = {s["name"]: s["width"] for s in _run_audit(tmp_path, shape)["sample_signals"]}
+        assert widths == {"toy.clk": 1, "toy.s[8:0]": 9, "toy.sub.d[3:0]": 4}
+
+    @pytest.mark.parametrize("shape", ["old", "new"])
+    def test_clock_detected_despite_range_suffix(self, tmp_path, shape):
+        assert _run_audit(tmp_path, shape)["clock_candidates"] == ["toy.clk"]
+
+    def test_both_shapes_agree(self, tmp_path):
+        """The shim must not change what the audit reports, only how it walks."""
+        old = _run_audit(tmp_path / "a", "old")
+        new = _run_audit(tmp_path / "b", "new")
+        for key in ("ok", "signal_count", "clock_candidates", "sample_signals"):
+            assert old[key] == new[key], key
+
+
+class TestAgainstInstalledWavekit:
+    def test_real_wavekit_audit_passes(self, tmp_path):
+        """End-to-end against whatever WaveKit is actually installed."""
+        pytest.importorskip("wavekit")
+        from orchestrator.langgraph.pipeline_helpers import run_wavekit_vcd_audit
+
+        vcd = tmp_path / "toy.vcd"
+        vcd.write_text(_VCD)
+        report = run_wavekit_vcd_audit(vcd, tmp_path / "audit.json")
+        # A WaveKit that cannot be set up is reported as skipped-but-ok; that is
+        # a deliberate separate path and not what this test is about.
+        if report.get("skipped"):
+            pytest.skip(f"WaveKit unavailable: {report.get('reason')}")
+        assert report["ok"] is True, report
+        assert report["signal_count"] == 2
+        assert report["clock_candidates"] == ["toy.clk"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,12 @@ jinja2>=3.1.0
 pydantic>=2.0.0
 
 # Orchestrator -- MCP server
-mcp>=1.0.0
+# Capped below 2.0: mcp 2.x removed `mcp.server.fastmcp`, which
+# orchestrator/mcp_server.py imports at module scope, so an unpinned install
+# resolves to a version where the MCP server cannot even be imported (and
+# every test in tests/test_mcp_server.py errors at collection).
+# requirements-lock.txt pins the validated 1.27.0.
+mcp>=1.0.0,<2
 
 # Orchestrator -- coresmithd HTTP daemon (orchestrator/daemon/server.py)
 fastapi>=0.115.0


### PR DESCRIPTION
Five independent bugs found while bringing up a fresh checkout on macOS. Each is
reproducible from a clean `pip install -r requirements.txt`; none is
platform-specific in cause, and the fixes are all generic.

The **WaveKit one is the urgent one** — it makes the documented deliverable
unreachable on any fresh install.

## 1. `dv`: WaveKit VCD audit works on the 0.7 tree API

WaveKit renamed its scope-tree API between 0.5.x and 0.7.x
(`reader.top_scope_list()` → `reader.top_scopes`; `scope.signal_list` /
`scope.child_scope_list` → a mixed `scope.children`). The audit program used only
the 0.5.x names, so on 0.7.x it raised:

```
AttributeError: 'VcdReader' object has no attribute 'top_scope_list'
```

`wavekit` is unpinned in `requirements.txt`, **and** `run_wavekit_vcd_audit`'s own
fallback pip-installs the latest into a scratch venv — so a fresh box gets the new
API regardless of what the operator pinned.

This is not cosmetic. `integration_dv` and `validation_dv` gate `passed` on
`wavekit_audit["ok"] is True` and **fail closed**, so neither could ever pass.
Per CLAUDE.md that is precisely the deliverable.

It also hides well: a WaveKit that cannot be *set up* is caught and reported as
`skipped, ok=True`, but an API *mismatch* falls through to the generic error path
and reads as a genuine DV failure.

Fixed by walking both shapes rather than pinning backwards. The 0.5.x branch is
unchanged from the previous code, so it cannot regress; signal objects expose
`.full_name` and `.width` in both. The audit program is hoisted to a module-level
constant so tests can `exec` it against stub readers of each shape without either
WaveKit version installed.

## 2. `deps`: cap `mcp <2`

`mcp>=1.0.0` resolves to 2.x, which removed `mcp.server.fastmcp` — imported at
module scope by `orchestrator/mcp_server.py`. On a clean install `make mcp` is
dead and every test in `tests/test_mcp_server.py` errors at collection
(34 errors + 13 failures). `requirements-lock.txt` already pins the validated
1.27.0; this stops the unpinned path resolving past the API the code targets.

## 3. `daemon`: PYTHONHOME must describe the spawned interpreter and hold a stdlib

`bin/coresmith daemon start` injected
`PYTHONHOME=sysconfig.get_config_var("prefix")` so cocotb 2.x's Verilator-embedded
interpreter can find pygpi. Two defects:

- That is the prefix the interpreter was **configured** with, not where it was
  **installed**. Relocated / framework / vendor-repackaged builds report a prefix
  holding no stdlib. `PYTHONHOME` overrides stdlib discovery, so the daemon died
  before executing a line — `Fatal Python error: init_fs_encoding` /
  `ModuleNotFoundError: No module named 'encodings'` — with only `daemon.log` to
  explain it.
- The value was derived from the interpreter running the **script** and applied to
  the interpreter it **spawns**. Those are usually different (system python
  launching the repo venv python).

`resolve_pythonhome()` probes the interpreter actually being spawned, verifies the
candidate holds a stdlib, and returns `None` rather than a value known to be
unbootable — no PYTHONHOME degrades to a pygpi import error at sim time, a bad one
is fatal at startup. `harness_child_env()` carried a copy of the same buggy block;
both now share the helper.

## 4. `tests`: architecture-graph tests no longer reach a live LLM

Interface Definition and Output Contract Review are graph *nodes* rather than
`architecture.specialists.*` modules, so neither looked like something a "patch all
specialists" helper should cover — and `test_architecture_graph.py` and
`test_architecture_integration.py` independently missed both. Both reach a live LLM
(`ClaudeLLM.call` / `OutputContractReviewAgent.review`).

Every test driving the whole graph therefore made real, billed API calls despite
carrying no `live_llm` marker, and the agents' shell tools ran unbounded commands —
one observed run spent 30+ minutes on a filesystem-wide `find /`. The failure mode
is load-bearing on latency rather than correctness, so it hid in plain sight; CI
just looked slow. In the integration module it did surface, as `wait_for_status`
timing out at 30s with the runner still `running` because a real API call was in
flight.

| | before | after |
|---|---|---|
| `test_architecture_graph.py` | ~19 min | **5.5s** |
| `test_architecture_integration.py` | 3 failures, ~6 min | **0 failures, 1.4s** |

Containment lives in `conftest` as `enter_arch_llm_node_patches()` rather than
duplicated per module, so the two lists cannot drift apart again.

## 5. `preflight`: warn when backend tools are nix wrappers and nix is absent

The OpenROAD/Magic/netgen checks only assert the configured path *exists*. They
default to `scripts/{openroad,magic,netgen}-nix.sh`, which are committed to this
repo and so exist on every checkout — backend preflight returned `ok: true` on a
box with no EDA toolchain at all. Each wrapper is a one-liner that
`exec nix shell "nixpkgs#<tool>"`, so without nix every backend node fails at its
first invocation, long after preflight said the run was safe to start.

**Reviewer judgment call:** CLAUDE.md says behaviour changes get gated behind an
env var. I made this a *warning* so `ok` stays decided by errors alone and no
behaviour is gated — which I think exempts it — but `warnings` is still observable
output. Happy to gate or drop it if you disagree.

## Testing

- Full suite: **3519 passed**, 4 failed, 25 skipped, 7 xfailed.
- The 4 failures are pre-existing on `main` and unrelated to this branch
  (`test_chip_equiv_wiring`, `test_integration_lead`, 2× `test_qspi_pin_boundary_gate`
  — assertion drift, e.g. `_mock_parse() takes 1 positional argument but 2 were given`).
- 33 new tests across 3 files, both-branch coverage per the
  `TestRouteAfterIntegrationReview` template: both WaveKit API shapes, PYTHONHOME
  present/absent/unbootable, nix present/absent.
- `ruff check` clean on every changed file under the repo config.
- Verified beyond unit tests on a real toolchain: verilator lint, yosys + Sky130
  synthesis mapping to real `sky130_fd_sc_hd__*` cells, a passing cocotb 2.0.1 +
  Verilator simulation, WaveKit audit returning `ok: True` on a real VCD, and a
  daemon start → `/run/state` → stop cycle.

`orchestrator/langgraph/pipeline_helpers.py` carried two unrelated fixes (#1 and
#5); they are split across separate commits by hunk, and the reassembled file was
checksum-verified against the tested state.

## Follow-ups not in this PR

- **`wavekit` is absent from `requirements-lock.txt` entirely** — no version was
  ever validated. Worth adding on the next lock refresh; I left the lock file alone
  since it should be regenerated from a validated run rather than hand-edited.
- **A systemic guard against LLM escapes.** #4 fixes two sites by hand. A `conftest`
  fixture pointing `CLAUDE_CLI_PATH`/`CODEX_CLI_PATH` at a nonexistent path for any
  test not marked `live_llm` would stop this recurring. Measured blast radius: 3
  tests in `test_coresmith_llm.py` that read the ambient env and would need to set
  their own path. That is a test-harness policy change, so I left it out.
- The 4 pre-existing failures above.
