### PR TITLE
ci: get main green again (8 ruff errors + 4 stale test assertions)

### DIFF
--- a/orchestrator/langgraph/bfm_lib/codegen.py
+++ b/orchestrator/langgraph/bfm_lib/codegen.py
@@ -19,7 +19,6 @@ coresmith package being importable inside the sim subprocess.
 from __future__ import annotations
 
 import inspect
-
 import re as _re
 
 from . import qspi_contract as _contract_mod

--- a/orchestrator/langgraph/macro_prebind.py
+++ b/orchestrator/langgraph/macro_prebind.py
@@ -445,7 +445,6 @@ def resolve_prebindings(sources, *, allow_generate: bool = True,
         if key in req_mask:
             nb = req_mask[key]
             macro_has_mask = "wmask0" in macro_ports(macro.verilog)
-            result_lanes = nb
             if macro_has_mask and nb > 1:
                 # The shell routes the mask to the macro's own port, so this
                 # binds -- PROVIDED both sides agree on lane count. OpenRAM

--- a/orchestrator/langgraph/pipeline_graph.py
+++ b/orchestrator/langgraph/pipeline_graph.py
@@ -69,11 +69,11 @@ from opentelemetry import trace
 from orchestrator.langgraph.event_stream import write_graph_event
 from orchestrator.langgraph.integration_helpers import (
     discover_block_rtl,
-    module_for_block,
     generate_integration_testbench,
     generate_validation_testbench,
     lint_top_level,
     load_architecture_connections,
+    module_for_block,
     parse_verilog_ports,
     run_integration_simulation,
 )

--- a/orchestrator/tests/test_backend_helpers.py
+++ b/orchestrator/tests/test_backend_helpers.py
@@ -925,10 +925,11 @@ class TestSynthAttemptHistory:
                              llm_reply=None) == []
 
     def test_persist_merges_into_the_synth_result_artifact(self, tmp_path):
+        import json as _json
+
         from orchestrator.langgraph.backend_helpers import (
             persist_synth_attempt_history,
         )
-        import json as _json
         p = tmp_path / "synth_result.json"
         p.write_text(_json.dumps({"success": True, "gate_count": 42}))
         hist = [{"attempt": 1, "error_summary": "ERROR: boom",

--- a/orchestrator/tests/test_chip_equiv_wiring.py
+++ b/orchestrator/tests/test_chip_equiv_wiring.py
@@ -116,13 +116,19 @@ def _setup_node(monkeypatch, tmp_path, *, sim_passed, equiv_result):
 
 @pytest.mark.asyncio
 async def test_loosened_tb_pass_but_equiv_fail_flips_dv_to_failed(monkeypatch, tmp_path):
-    captured = {}
+    # integration_dv_node deliberately does NOT interrupt (run3-followups): a
+    # tail interrupt() in a node LangGraph re-executes from the top is consumed
+    # one full cycle late, and the intervening default cycle clobbers operator
+    # fix_tb edits. The failure is handed to integration_dv_decision_node as
+    # `interrupt_payload` instead. Assert that invariant rather than
+    # monkeypatching a call that must never happen.
+    def _must_not_interrupt(payload):
+        raise AssertionError(
+            "integration_dv_node must not interrupt; the decision parks in "
+            "integration_dv_decision_node"
+        )
 
-    def fake_interrupt(payload):
-        captured.update(payload)
-        return {"action": "abort"}
-
-    monkeypatch.setattr(pipeline_graph, "interrupt", fake_interrupt)
+    monkeypatch.setattr(pipeline_graph, "interrupt", _must_not_interrupt)
     state = _setup_node(
         monkeypatch, tmp_path,
         sim_passed=True,
@@ -132,12 +138,13 @@ async def test_loosened_tb_pass_but_equiv_fail_flips_dv_to_failed(monkeypatch, t
     result = await pipeline_graph.integration_dv_node(state)
 
     # The sim passed but the equivalence gate failed -> DV is failed and the
-    # existing failure interrupt fired with the equivalence divergence in the log.
-    assert captured.get("type") == "integration_dv_failure"
-    assert "EQUIVALENCE FAILED" in captured.get("sim_log", "")
+    # pending payload carries the equivalence divergence in the log.
     dv = result["integration_dv_result"]
+    payload = dv.get("interrupt_payload") or {}
+    assert payload.get("type") == "integration_dv_failure"
+    assert "EQUIVALENCE FAILED" in payload.get("sim_log", "")
     assert dv["passed"] is False
-    assert dv["aborted"] is True
+    assert dv["pending_decision"] is True
 
 
 @pytest.mark.asyncio

--- a/orchestrator/tests/test_chip_gate_sim_wiring.py
+++ b/orchestrator/tests/test_chip_gate_sim_wiring.py
@@ -31,7 +31,6 @@ from orchestrator.langgraph.backend_graph import (
 )
 from orchestrator.langgraph.integration_helpers import chip_rtl_sources
 
-
 # ---------------------------------------------------------------------------
 # The reference source list
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_integration_lead.py
+++ b/orchestrator/tests/test_integration_lead.py
@@ -596,7 +596,10 @@ class TestIntegrationCheckNode:
             ],
         )
 
-        def _mock_parse(path):
+        # parse_verilog_ports(rtl_path, module=None): the `module` selector was
+        # added so a block whose Verilog module name differs from the block name
+        # still resolves, and the call site passes module_for_block(...).
+        def _mock_parse(path, module=None):
             if "block_a" in path:
                 return mod_a
             return mod_b

--- a/orchestrator/tests/test_macro_prebind.py
+++ b/orchestrator/tests/test_macro_prebind.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-import pytest
-
 from orchestrator.langgraph.macro_prebind import (
     UNBOUND_SENTINEL,
     PrebindResult,
@@ -137,8 +135,8 @@ class TestGeometryDispatch:
 
 def _maskless_env(tmp_path, monkeypatch, width, nb_expected):
     """Wire resolve_prebindings to a maskless macro for the given RTL width."""
-    from orchestrator.langgraph import macro_prebind as mp
     import orchestrator.langgraph.macro_registry as reg
+    from orchestrator.langgraph import macro_prebind as mp
 
     rtl = tmp_path / "blk.v"
     rtl.write_text(

--- a/orchestrator/tests/test_qspi_pin_boundary_gate.py
+++ b/orchestrator/tests/test_qspi_pin_boundary_gate.py
@@ -50,6 +50,22 @@ from orchestrator.langgraph.bfm_lib.classifier import (
 )
 from orchestrator.langgraph.integration_helpers import VerilogModule, VerilogPort
 
+
+def _must_not_interrupt(payload):
+    """integration_dv_node must never interrupt directly (run3-followups).
+
+    A tail ``interrupt()`` in a node LangGraph re-executes from the top is
+    consumed one full cycle late, and the intervening default cycle clobbers
+    operator ``fix_tb`` edits. The failure is returned as
+    ``integration_dv_result["interrupt_payload"]`` and parked by
+    ``integration_dv_decision_node`` instead.
+    """
+    raise AssertionError(
+        "integration_dv_node must not interrupt; the decision parks in "
+        "integration_dv_decision_node"
+    )
+
+
 # ---------------------------------------------------------------------------
 # RTL fixtures (shapes taken from the real raster run)
 # ---------------------------------------------------------------------------
@@ -392,20 +408,18 @@ async def test_off_top_boundary_fails_closed_and_never_reaches_the_llm_bfm(
     monkeypatch.setattr(
         pipeline_graph, "generate_integration_testbench", _must_not_run)
 
-    captured = {}
-
-    def fake_interrupt(payload):
-        captured.update(payload)
-        return {"action": "abort"}
-    monkeypatch.setattr(pipeline_graph, "interrupt", fake_interrupt)
+    # The node hands the failure to integration_dv_decision_node as
+    # `interrupt_payload` instead of interrupting itself (run3-followups).
+    monkeypatch.setattr(pipeline_graph, "interrupt", _must_not_interrupt)
 
     result = await pipeline_graph.integration_dv_node(state)
 
-    assert captured.get("type") == "integration_dv_failure"
-    assert captured.get("phase") == "tb_generation"
-    assert "QSPI pin-boundary gate" in captured.get("sim_log", "")
-    assert "user_project_wrapper.v" in captured.get("sim_log", "")
     dv = result["integration_dv_result"]
+    payload = dv.get("interrupt_payload") or {}
+    assert payload.get("type") == "integration_dv_failure"
+    assert payload.get("phase") == "tb_generation"
+    assert "QSPI pin-boundary gate" in payload.get("sim_log", "")
+    assert "user_project_wrapper.v" in payload.get("sim_log", "")
     assert dv["passed"] is False
     assert result["pipeline_done"] is False
 
@@ -421,14 +435,12 @@ async def test_contradiction_fails_closed(monkeypatch, tmp_path):
         raise AssertionError("LLM BFM must not be generated")
     monkeypatch.setattr(
         pipeline_graph, "generate_integration_testbench", _must_not_run)
-    captured = {}
-    monkeypatch.setattr(
-        pipeline_graph, "interrupt",
-        lambda p: (captured.update(p), {"action": "retry"})[1])
+    monkeypatch.setattr(pipeline_graph, "interrupt", _must_not_interrupt)
 
-    await pipeline_graph.integration_dv_node(state)
-    assert captured.get("type") == "integration_dv_failure"
-    assert "CONTRADICTION" in captured.get("sim_log", "")
+    result = await pipeline_graph.integration_dv_node(state)
+    payload = result["integration_dv_result"].get("interrupt_payload") or {}
+    assert payload.get("type") == "integration_dv_failure"
+    assert "CONTRADICTION" in payload.get("sim_log", "")
 
 
 @pytest.mark.asyncio

--- a/orchestrator/tests/test_qspi_pin_boundary_gate.py
+++ b/orchestrator/tests/test_qspi_pin_boundary_gate.py
@@ -33,8 +33,7 @@ import json
 
 import pytest
 
-from orchestrator.langgraph import pipeline_graph
-from orchestrator.langgraph import bfm_lib
+from orchestrator.langgraph import bfm_lib, pipeline_graph
 from orchestrator.langgraph.bfm_lib import (
     STATUS_BOUNDARY_OFF_TOP,
     STATUS_CONTRADICTION,


### PR DESCRIPTION
`main` CI has been red since at least 2026-08-02 — every run, including README-only commits. Two independent causes, stacked: lint runs **before** tests and fails fast, so **no PR has reached its test results in days.** This fixes both.

## 1. `ci:` the 8 ruff errors

7 are import ordering (I001) plus one unused import (F401), applied with `ruff check --fix` — no semantic change. The `pipeline_graph.py` hunk only alphabetizes names inside a single `from ... import (...)`, so it cannot affect the import-order-dependent behaviour pyproject documents elsewhere.

The one non-mechanical fix is **F841 in `macro_prebind.py`**: `result_lanes = nb` is assigned and never read anywhere in the file (`nb` carries the value into the lane-count comparison directly below), so it is dead and removed rather than silenced.

## 2. `tests:` four stale assertions

All four reproduce on a clean `main`. All four are assertion drift against contracts that moved — **no product bug**.

**`integration_dv_node` deliberately stopped calling `interrupt()`** (run3-followups). A tail `interrupt()` in a node LangGraph re-executes from the top is consumed one full cycle late, and the intervening default cycle regenerates the testbench and destroys operator `fix_tb` edits — the code comment records three consecutive live clobbers and then a false PASS on the clobbered TB. The failure is now returned as `integration_dv_result["interrupt_payload"]` and parked by `integration_dv_decision_node`.

Three tests still monkeypatched `pipeline_graph.interrupt` and asserted on what it captured, so they saw `{}`:

- `test_chip_equiv_wiring::test_loosened_tb_pass_but_equiv_fail_flips_dv_to_failed`
- `test_qspi_pin_boundary_gate::test_off_top_boundary_fails_closed_and_never_reaches_the_llm_bfm`
- `test_qspi_pin_boundary_gate::test_contradiction_fails_closed`

They now read the payload from the return value, and install a `_must_not_interrupt` stub so the no-tail-interrupt invariant is **asserted rather than assumed**. Every payload assertion is preserved, including the load-bearing QSPI ones. The chip-equiv test also swaps `dv["aborted"]` (which only existed because the old fake interrupt returned `{"action": "abort"}`) for `dv["pending_decision"]`, which is what the node actually reports.

**`test_integration_lead::test_calls_integration_lead_agent`** mocked `parse_verilog_ports` with a one-argument function. The real signature grew a `module` selector so a block whose Verilog module name differs from the block name still resolves, and the call site passes `module_for_block(...)` as the second argument — so the mock raised `TypeError`. Production is correct; the mock now accepts the selector.

## Testing

- `ruff check orchestrator/` — clean.
- Full suite: **3487 passed**, 25 skipped, 7 xfailed, **0 real failures**. (The run was executed with `CODEX_CLI_PATH=/nonexistent` to keep offline tests offline, which trips 3 `test_coresmith_llm` codex tests that read the ambient env; they pass unblocked — verified separately, 7/7.)