### PR TITLE
ci: unbreak the container build (libstdc++ ABI pick, awk, runner disk, GHA cache, preflight, opencode libc)

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -30,9 +30,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # ubuntu-latest gives ~14 GB free; the openlane2 base (~4 GB extracted)
+      # + nix-channel update + Sky130 PDK (~2 GB) already push past that, and
+      # `load: true` materialises the whole ~15 GB image a *second* time when
+      # the docker daemon imports the buildx tarball. Without this the export
+      # dies with
+      #   #28 importing to docker
+      #   ERROR: write /blobs/sha256/...: no space left on device
+      # publish-image.yml and test-mcu3.yml already carry this step; it was
+      # simply never added here. Frees ~25 GB up front.
+      - name: Free runner disk
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /opt/hostedtoolcache/CodeQL || true
+          sudo docker system prune -af || true
+          df -h /
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # No `cache-from`/`cache-to: type=gha` here, deliberately:
+      #   1. Nothing has ever populated that cache -- the build has failed
+      #      before the export step on every scheduled run -- so every
+      #      `cache-from` was already a cold miss.
+      #   2. This job exists to catch *upstream* rot (base image, nix
+      #      channels, PyPI, Sky130 PDK URLs -- see the header comment). A
+      #      warm layer cache would replay yesterday's layers and hide
+      #      exactly the breakage the nightly is supposed to find.
+      #   3. `mode=max` on a ~15 GB image cannot fit GitHub's 10 GB per-repo
+      #      cache budget anyway; it would thrash and evict.
+      # A cold build measures ~6 min, so there is nothing to buy back.
       - name: Build coresmith image
         uses: docker/build-push-action@v5
         with:
@@ -40,12 +68,22 @@ jobs:
           file: Dockerfile
           tags: coresmith:nightly
           load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
+      # CORESMITH_ALLOW_NO_OPENRAM=1 is the documented opt-out from the
+      # "no OpenRAM, no greenlight" preflight gate in
+      # orchestrator/langgraph/pipeline_helpers.py, and it is legitimate
+      # here: the only design this workflow drives is adder8, an 8-bit
+      # combinational adder with provably no memories, so no generated SRAM
+      # macro can ever be required. The image does not ship OpenRAM, so
+      # without this the toolchain smoke test can never pass -- it would
+      # fail on a capability the nightly does not exercise. Everything the
+      # nightly *does* care about (yosys, OpenROAD, magic, netgen,
+      # verilator, cocotb, the Sky130 PDK) is still checked, and the gate
+      # still fires for every real design.
       - name: Preflight check inside container
         run: |
-          docker run --rm coresmith:nightly bash -lc 'cd /coresmith && make preflight'
+          docker run --rm -e CORESMITH_ALLOW_NO_OPENRAM=1 \
+              coresmith:nightly bash -lc 'cd /coresmith && make preflight'
 
   stage-fixtures:
     name: Stage fixtures (strict)
@@ -91,17 +129,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Same headroom problem as docker-build: `load: true` needs room for
+      # the image twice over. See the comment on that job's copy of this step.
+      - name: Free runner disk
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /opt/hostedtoolcache/CodeQL || true
+          sudo docker system prune -af || true
+          df -h /
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Restore coresmith image
+      # `cache-from: type=gha` is gone for the same reason as in
+      # docker-build: nothing populates that cache, so this was already a
+      # cold rebuild in practice -- the step name now says so.
+      - name: Rebuild coresmith image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
           tags: coresmith:nightly
           load: true
-          cache-from: type=gha
 
       - name: Check secret presence
         id: have_token
@@ -126,6 +176,7 @@ jobs:
               -e CLAUDE_CODE_OAUTH_TOKEN \
               -e CORESMITH_MODEL=sonnet-5 \
               -e CORESMITH_PROFILE=strict \
+              -e CORESMITH_ALLOW_NO_OPENRAM=1 \
               -v "${{ github.workspace }}/.coresmith:/coresmith/.coresmith" \
               coresmith:nightly bash -lc 'cd /coresmith && \
                 python3 scripts/nightly_canary.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -243,7 +243,7 @@ RUN mkdir -p /opt/npm-global \
         @anthropic-ai/claude-code \
         @anthropic-ai/claude-code-linux-x64-musl \
         opencode-ai \
-        opencode-linux-x64-musl
+        opencode-linux-x64
 
 # `npm install -g`'s postinstall on the wrapper package may have copied
 # the glibc binary over bin/claude.exe (because Nix Node is glibc-
@@ -254,12 +254,31 @@ RUN set -eux \
  && test -x "${MUSL_BIN}" \
  && ln -sf "${MUSL_BIN}" /opt/npm-global/bin/claude
 
-# OpenCode also ships glibc and musl native variants. This image needs the
-# explicit x64-musl binary for the same reason as Claude Code above.
+# OpenCode ships both glibc and musl native variants, and unlike Claude Code
+# this image needs the *glibc* one. Their ELF requirements differ decisively:
+#
+#   opencode-linux-x64-musl: interp /lib/ld-musl-x86_64.so.1
+#                            NEEDED libstdc++.so.6, libc.musl-x86_64.so.1,
+#                                   libgcc_s.so.1
+#   opencode-linux-x64:      interp /lib64/ld-linux-x86-64.so.2
+#                            NEEDED libc.so.6, ld-linux-x86-64.so.2,
+#                                   libpthread.so.0, libdl.so.2, libm.so.6
+#
+# The musl build wants a *musl* libstdc++ and a libgcc_s.so.1. This image has
+# neither: the libstdc++ symlinked above is glibc-built, and no libgcc_s is
+# published at an FHS path at all. So it failed at build time with
+#   Error loading shared library libgcc_s.so.1: No such file or directory
+#   Error relocating /usr/lib/libstdc++.so.6: arc4random: symbol not found
+#   Error relocating /usr/lib/libstdc++.so.6: __libc_single_threaded: ...
+# (arc4random and __libc_single_threaded are glibc symbols musl does not have).
+#
+# The glibc build needs only core glibc, and its interpreter is already
+# symlinked above for the Codespaces agent -- so it just runs. Claude Code
+# still uses its musl variant, which needs no libstdc++/libgcc_s at all.
 RUN set -eux \
- && OPENCODE_MUSL_BIN=/opt/npm-global/lib/node_modules/opencode-linux-x64-musl/bin/opencode \
- && test -x "${OPENCODE_MUSL_BIN}" \
- && ln -sf "${OPENCODE_MUSL_BIN}" /opt/npm-global/bin/opencode
+ && OPENCODE_GLIBC_BIN=/opt/npm-global/lib/node_modules/opencode-linux-x64/bin/opencode \
+ && test -x "${OPENCODE_GLIBC_BIN}" \
+ && ln -sf "${OPENCODE_GLIBC_BIN}" /opt/npm-global/bin/opencode
 
 # Capture the resolved agent CLI paths at build time and bake them so runtime
 # resolution can't drift if PATH changes under us. Fail the build loud if any

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,19 @@ ENV PATH="/root/.nix-profile/bin:${PATH}"
 # symlink it into a path the loader actually searches.
 #   build error this fixes:
 #     ImportError: libstdc++.so.6: cannot open shared object file: No such file or directory
+#
+# The candidate must be picked by *library version*, not by store path.
+# `find ... | sort -V | tail -1` sorts whole /nix/store paths, and those
+# begin with a random 32-char hash -- so the "newest" library was really
+# whichever hash happened to sort last. That silently selected nixos-24.05's
+# gcc-13 libstdc++.so.6.0.32 (max CXXABI_1.3.14) even though the store also
+# carries a newer one, and every consumer needing a later ABI then died:
+#     node: /usr/lib/libstdc++.so.6: version `CXXABI_1.3.15' not found
+#           (required by .../icu4c-78.3/lib/libicui18n.so.78)
+# which broke `npm install -g` and failed the image build outright.
+# Sorting on the *basename* orders by the real X.Y suffix. Newest is always
+# the correct pick: libstdc++.so.6 and libz.so.1 are backward-compatible,
+# so the highest version satisfies every older consumer too.
 RUN set -eux \
  && mkdir -p /usr/lib /lib /etc/ld.so.conf.d \
  && for spec in \
@@ -91,7 +104,8 @@ RUN set -eux \
         LIBNAME="${spec%%|*}"; PATTERN="${spec##*|}"; \
         LIB="$(find /nix/store -regextype posix-extended \
                 -regex ".*/${PATTERN}$" -type f 2>/dev/null \
-                | sort -V | tail -1)"; \
+                | awk -F/ '{print $NF" "$0}' \
+                | sort -V | tail -1 | cut -d' ' -f2-)"; \
         if [ -z "${LIB}" ] || [ ! -s "${LIB}" ]; then \
             echo "ERROR: could not locate ${LIBNAME} under /nix/store"; \
             exit 1; \
@@ -118,12 +132,20 @@ ENV LD_LIBRARY_PATH="/usr/lib:/lib:${LD_LIBRARY_PATH}"
 # Also verify g++ is reachable -- verilator shells out to it to
 # compile the testbench simulator and the missing-compiler error
 # only surfaces when sim runs, which is too late.
+#
+# `node --version` is checked here too: node is the first consumer of the
+# libstdc++ symlinked above, and when that symlink points at too old a
+# libstdc++ node cannot start at all. Catching it here reports the ABI
+# mismatch directly instead of surfacing 4 layers later as an opaque
+# `npm install` exit code 1.
 RUN set -eux \
  && which verilator \
  && verilator --version \
  && verilator --version | python3 -c "import sys,re; v=sys.stdin.read().strip(); m=re.search(r'(\d+)\.(\d+)', v); maj,min=int(m.group(1)),int(m.group(2)); assert (maj,min) >= (5,36), f'verilator too old: {v}'; print(f'verilator OK: {v}')" \
  && which g++ \
- && g++ --version | head -1
+ && g++ --version | head -1 \
+ && which node \
+ && node --version
 
 # Make the musl ELF interpreter resolvable at the FHS path the binary
 # is hard-linked against. nix's musl ships ld-musl-x86_64.so.1 which is

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,17 +85,27 @@ ENV PATH="/root/.nix-profile/bin:${PATH}"
 #     ImportError: libstdc++.so.6: cannot open shared object file: No such file or directory
 #
 # The candidate must be picked by *library version*, not by store path.
-# `find ... | sort -V | tail -1` sorts whole /nix/store paths, and those
-# begin with a random 32-char hash -- so the "newest" library was really
-# whichever hash happened to sort last. That silently selected nixos-24.05's
-# gcc-13 libstdc++.so.6.0.32 (max CXXABI_1.3.14) even though the store also
-# carries a newer one, and every consumer needing a later ABI then died:
+# `find ... | sort -V | tail -1` sorts whole /nix/store paths, and those begin
+# with a random 32-char hash -- so the "newest" library was really whichever
+# hash happened to sort last, which makes the choice nondeterministic across
+# builds. Measured in this image, the store holds four candidates:
+#     .../gcc-13.2.0-lib/lib/libstdc++.so.6.0.32      -> max CXXABI_1.3.14
+#     .../gcc-13.2.0-lib/lib/libstdc++.so.6.0.32      -> max CXXABI_1.3.14
+#     .../gfortran-13.2.0-lib/lib/libstdc++.so.6.0.32 -> max CXXABI_1.3.14
+#     .../gcc-15.3.0-lib/lib/libstdc++.so.6.0.34      -> max CXXABI_1.3.15
+# Only the last one satisfies node, whose icu4c needs CXXABI_1.3.15. On CI the
+# hash order landed on a gcc-13 copy, so node could not start at all:
 #     node: /usr/lib/libstdc++.so.6: version `CXXABI_1.3.15' not found
 #           (required by .../icu4c-78.3/lib/libicui18n.so.78)
 # which broke `npm install -g` and failed the image build outright.
 # Sorting on the *basename* orders by the real X.Y suffix. Newest is always
 # the correct pick: libstdc++.so.6 and libz.so.1 are backward-compatible,
 # so the highest version satisfies every older consumer too.
+#
+# The re-key to basename is done with a shell `while read` loop and `${p##*/}`
+# rather than the obvious `awk`: this Nix-only base image has no awk on PATH
+# ("/bin/sh: awk: command not found"), which silently empties the pipeline.
+# Only find/sort/tail plus shell builtins are used here -- all present.
 RUN set -eux \
  && mkdir -p /usr/lib /lib /etc/ld.so.conf.d \
  && for spec in \
@@ -104,8 +114,11 @@ RUN set -eux \
         LIBNAME="${spec%%|*}"; PATTERN="${spec##*|}"; \
         LIB="$(find /nix/store -regextype posix-extended \
                 -regex ".*/${PATTERN}$" -type f 2>/dev/null \
-                | awk -F/ '{print $NF" "$0}' \
-                | sort -V | tail -1 | cut -d' ' -f2-)"; \
+                | while IFS= read -r p; do \
+                      printf '%s %s\n' "${p##*/}" "${p}"; \
+                  done \
+                | sort -V | tail -1)"; \
+        LIB="${LIB#* }"; \
         if [ -z "${LIB}" ] || [ ! -s "${LIB}" ]; then \
             echo "ERROR: could not locate ${LIBNAME} under /nix/store"; \
             exit 1; \


### PR DESCRIPTION
Fixes five stacked faults that kept **Nightly E2E → Build container** and **Publish image** red. Both failed for the same underlying reason: the image build itself was broken.

**Both workflows are now green.** `Nightly E2E` ✅ [run 32995866163](https://github.com/facebookexperimental/coresmith/actions/runs/32995866163) — `conclusion=success` across **all three jobs**: `Build container` (9m14s, all 22 layers plus `make preflight`), `Stage fixtures (strict)`, and `Run make demo on adder8`. `Publish image` ✅ [run 32995901955](https://github.com/facebookexperimental/coresmith/actions/runs/32995901955) dispatched on this branch — its first success since 2026-07-28. That job had failed on every scheduled run for 19 consecutive nights (08-08 → 08-26); `Publish image` had failed on every push to `main` since 2026-07-31. `CI` (ci.yml) is unaffected — this PR touches no Python.

## Timeline (from run history, not inference)

| Date | Event |
|---|---|
| ≤ 2026-07-28 | `Publish image` **green** — the image built fine |
| ~2026-07-29/30 | nixos-unstable moves node onto `icu4c-78.3`, needing `CXXABI_1.3.15` → build starts failing at layer 8 |
| 2026-07-30 | PRs #64/#65 add the kimi + opencode CLIs (layers 8–11) |
| 2026-07-31 → 08-26 | **every** `Publish image` run fails (17 in a row); **every** `Nightly E2E` run fails (19 nights) |

Because the CXXABI fault failed *earlier* than the new CLI layers, it masked them the whole time — the opencode layer had **never once executed in CI**.

## #1 — libstdc++ ABI pick (broke *both* workflows)

Identical log line in nightly [32941871127](https://github.com/facebookexperimental/coresmith/actions/runs/32941871127) (`#13 [ 8/22]`) and publish-image [31161376329](https://github.com/facebookexperimental/coresmith/actions/runs/31161376329) (`#14`):

```
/nix/store/…-nodejs-slim-22.23.2/bin/node: /usr/lib/libstdc++.so.6:
  version `CXXABI_1.3.15' not found (required by …/icu4c-78.3/lib/libicui18n.so.78)
```

The Dockerfile picked a libstdc++ with `find … | sort -V | tail -1`, which sorts **whole store paths** — and those start with a random 32-char hash, so the "newest" library was whichever *hash* sorted last. Measured in the real base image, four candidates exist and only one works:

```
…/gcc-13.2.0-lib/lib/libstdc++.so.6.0.32       -> max CXXABI_1.3.14
…/gcc-13.2.0-lib/lib/libstdc++.so.6.0.32       -> max CXXABI_1.3.14
…/gfortran-13.2.0-lib/lib/libstdc++.so.6.0.32  -> max CXXABI_1.3.14
…/gcc-15.3.0-lib/lib/libstdc++.so.6.0.34       -> max CXXABI_1.3.15   ← the one node needs
```

The old picker was **nondeterministic, not merely wrong**: from the identical Dockerfile it chose the gcc-15 copy on a local probe and a gcc-13 copy on the runner. It was never "correct then broken by upstream" — it was always a coin flip that upstream drift finally made fatal.

**Fix:** re-key each candidate to its **basename** before `sort -V`. Newest is always right — `libstdc++.so.6`/`libz.so.1` are backward-compatible.

The re-key deliberately avoids `awk`. The first attempt used it, and run [32990795884](https://github.com/facebookexperimental/coresmith/actions/runs/32990795884) showed why:

```
++ awk -F/ '{print $NF" "$0}'
/bin/sh: line 1: awk: command not found
+ LIB=
ERROR: could not locate libstdc++.so.6 under /nix/store
```

`ghcr.io/efabless/openlane2` is Nix-only and ships no awk. The shipped version uses `while read` + `${p##*/}` — only `find`/`sort`/`tail` and builtins.

Also added `node --version` to the toolchain-sanity layer so this ABI class reports itself directly instead of resurfacing as an opaque `npm` exit 1.

## #2–#4 — nightly-e2e.yml

**Free runner disk** — `load: true` makes buildx serialise the whole image to a tarball and re-import it, so it must fit twice over. Added the step `publish-image.yml` and `test-mcu3.yml` already carry, to **both** `load: true` jobs.

**Dropped `cache-from`/`cache-to: type=gha`** — no run had ever completed a cache export, so every `cache-from` was already a cold miss; `mode=max` on a ~15 GB image cannot fit GitHub's 10 GB per-repo budget; and this workflow exists to catch **upstream** rot, which a warm layer cache would hide. `Restore` → `Rebuild` renamed to match reality.

**`CORESMITH_ALLOW_NO_OPENRAM=1`** on both `docker run`s — the opt-out the gate in `orchestrator/langgraph/pipeline_helpers.py` documents. Legitimate here: the only design the nightly drives is `adder8`, combinational with provably no memories. Everything the nightly *does* exercise (yosys, OpenROAD, magic, netgen, verilator, cocotb, Sky130) is still checked, and the gate still fires for real designs.

## #5 — opencode musl → glibc  *(maintainer decision: option 1)*

With #1 cleared the build reached layer 11/22 for the first time since 07-28 and died there (exit 127):

```
+ opencode --version
Error loading shared library libgcc_s.so.1: No such file or directory
Error relocating /usr/lib/libstdc++.so.6: arc4random: symbol not found
Error relocating /usr/lib/libstdc++.so.6: __libc_single_threaded: symbol not found
```

Reading the two published variants' ELF headers explains it exactly:

```
opencode-linux-x64-musl  interp /lib/ld-musl-x86_64.so.1
                         NEEDED libstdc++.so.6, libc.musl-x86_64.so.1, libgcc_s.so.1
opencode-linux-x64       interp /lib64/ld-linux-x86-64.so.2
                         NEEDED libc.so.6, ld-linux-x86-64.so.2,
                                libpthread.so.0, libdl.so.2, libm.so.6
```

The musl build wants a *musl* libstdc++ and a `libgcc_s.so.1`; the image has neither, so `arc4random` and `__libc_single_threaded` — glibc symbols absent from musl — fail to relocate. **No choice of libstdc++ fixes this**; gcc-13 fails identically, so this was not caused by #1.

The glibc build needs only core glibc, and its interpreter `/lib64/ld-linux-x86-64.so.2` is *already* symlinked earlier in the Dockerfile for the Codespaces agent. **Per the maintainer's decision, this PR ships `opencode-linux-x64` and drops `opencode-linux-x64-musl`.** Claude Code keeps its musl variant (it needs neither libstdc++ nor libgcc_s). `kimi` is untouched — `@moonshot-ai/kimi-code` is pure JS (`bin` → `dist/main.mjs`) run by node.

## Verification — [run 32995866163](https://github.com/facebookexperimental/coresmith/actions/runs/32995866163)

**`Build container` ✅ 9m14s. `Stage fixtures (strict)` ✅ 56s.**

Layer 3/22 picks correctly, and layer 4/22 proves node starts:
```
linking libstdc++.so.6 -> /nix/store/…-gcc-15.3.0-lib/lib/libstdc++.so.6.0.34
verilator OK: Verilator 5.050 2026-07-01 rev v5.050
v22.23.2
```

Layer 11/22 — all three CLIs resolve and run (previously exit 127):
```
+ opencode --version
+ kimi --version
+ printf 'CLAUDE_CLI_PATH=%s\nOPENCODE_CLI_PATH=%s\nKIMI_CLI_PATH=%s\n' \
    /opt/npm-global/bin/claude /opt/npm-global/bin/opencode /opt/npm-global/bin/kimi
#15 DONE 1.9s
```

Free-runner-disk step:
```
/dev/root  145G  58G   87G  41% /
Total reclaimed space: 1.795GB
/dev/root  145G  39G  107G  27% /
```

Export + import completed clean, and a scan of the whole job log finds **zero** occurrences of `no space left`, `error writing layer`, `not_found` or `GitHub Actions Cache`:
```
#27 exporting layers 97.7s done
#28 importing to docker
```

Preflight inside the container — the gate correctly demotes to a warning:
```
=== Running preflight check ===
{
  "ok": true,
  "errors": [],
  "warnings": [
    "CORESMITH_ALLOW_NO_OPENRAM=1 with macro tiling disabled: this design must satisfy
     EVERY store with an exact pre-built macro or an explicitly-accepted flop tier. …"
  ]
}
```

Build-duration progression across the four dispatches, each failing strictly later until green: **2m33s → 3m55s → 6m57s → ✅ 9m14s**.

The `e2e-demo` leg (`Run make demo on adder8`) also passed. That matters beyond the headline: it is the *second* `load: true` build, so it independently exercises the second copy of the Free-runner-disk step, the cache-free rebuild, and the `CORESMITH_ALLOW_NO_OPENRAM=1` opt-out on the canary's own `docker run`. Fixes #2–#4 are therefore confirmed in both jobs, not just `docker-build`.

`Publish image` was dispatched on this branch too and returned **`conclusion=success`** ([32995901955](https://github.com/facebookexperimental/coresmith/actions/runs/32995901955)) — it shares root causes #1 and #5 with the nightly, and this is its first green run since 2026-07-28. Being a non-`main` dispatch it tagged the image with the branch name and short SHA; it did not touch `:latest`.

`ruff check orchestrator/` → `All checks passed!`, and `Lint with ruff` is green in the PR's own CI run. Diff is 2 files, zero Python.

## Scope

CI-only. `Dockerfile` + `.github/workflows/nightly-e2e.yml`. No Python touched, so no env gate per the repo's gating convention (which covers changes to observable pipeline outputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F69UPThv61UrLyEfrRxizL
