### PR TITLE
ci: unbreak the test matrix -- 5h54m to 58s (leaked spinning threads)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # The unit suite is minutes of work. It previously ran for 2-6 h because
-    # unmarked tests shelled out to a real provider CLI, and one main run was
-    # cancelled at GitHub's 6 h ceiling. A ceiling of our own turns any repeat
-    # into a fast, legible failure instead of a silent all-day burn.
-    timeout-minutes: 60
+    # main's CI has run 2.5-6 h for months and run 30994350130 was cancelled at
+    # GitHub's 6 h ceiling, which reports as an unexplained red. A ceiling of
+    # our own well under that turns a runaway into a fast, legible failure.
+    # Measured on this branch: 3.11 ~70 min, 3.12 ~95 min end to end, so 120
+    # is a backstop with headroom, not a tripwire. See the PR for the residual
+    # per-test cost that is still CI-only and not yet explained.
+    timeout-minutes: 120
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # The unit suite is minutes of work. It previously ran for 2-6 h because
+    # unmarked tests shelled out to a real provider CLI, and one main run was
+    # cancelled at GitHub's 6 h ceiling. A ceiling of our own turns any repeat
+    # into a fast, legible failure instead of a silent all-day burn.
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -81,6 +81,72 @@ def _reset_profile_state():
     _profile.reset()
 
 
+# ═══════════════════════════════════════════════════════════════════════════
+# Fail-closed: no live provider CLI in the marker-excluded (PR) suite
+# ═══════════════════════════════════════════════════════════════════════════
+# ``_detect_provider()`` defaults to ``claude_cli``, so any node that reaches a
+# real ``ClaudeLLM.call()`` shells out to the actual Claude CLI:
+#
+#   claude -p --output-format stream-json --model opus --max-turns 50 ...
+#
+# Several graph tests did exactly that while carrying no ``live_llm`` marker --
+# test_pipeline_graph's end-to-end walks reach ``uarch_integration_review``,
+# which runs the Integration Review agent for real. CI installs the Claude CLI
+# (the workflow needs it on PATH so import-time ``ClaudeLLM()`` construction
+# does not raise), so those calls actually launch. That is what turned a
+# minutes-long unit suite into a 2-6 hour job that intermittently hit GitHub's
+# 6-hour ceiling, and what starved the wall-clock budget of the fixed-timeout
+# assertions elsewhere in the suite.
+#
+# Every test NOT marked ``live_llm`` gets the five provider CLI path env vars
+# pointed at a stub that exits non-zero immediately. Resolution still succeeds
+# (the path exists and is executable), so import-time construction behaves
+# exactly as before -- only an actual model invocation changes, and it now
+# fails fast and deterministically instead of burning wall-clock.
+#
+# Escape hatch: ``CORESMITH_ALLOW_LIVE_LLM_IN_TESTS=1`` restores the previous
+# behavior for the whole session.
+
+_PROVIDER_CLI_ENV = (
+    "CLAUDE_CLI_PATH",
+    "CODEX_CLI_PATH",
+    "KIMI_CLI_PATH",
+    "AGY_CLI_PATH",
+    "OPENCODE_CLI_PATH",
+)
+
+_LLM_CLI_STUB_SRC = """#!/bin/sh
+echo "coresmith tests: refusing a live provider CLI call." >&2
+echo "This test is not marked 'live_llm'. Mark it, or stub the agent." >&2
+exit 1
+"""
+
+
+def live_llm_calls_allowed() -> bool:
+    """True when the suite is permitted to shell out to a real provider CLI."""
+    return os.environ.get("CORESMITH_ALLOW_LIVE_LLM_IN_TESTS", "") == "1"
+
+
+@pytest.fixture(scope="session")
+def llm_cli_stub(tmp_path_factory) -> str:
+    """Path to an executable stub that stands in for a provider CLI."""
+    stub = tmp_path_factory.mktemp("llm_cli_stub") / "no-live-llm"
+    stub.write_text(_LLM_CLI_STUB_SRC)
+    stub.chmod(0o755)
+    return str(stub)
+
+
+@pytest.fixture(autouse=True)
+def _no_live_llm_cli(request, monkeypatch, llm_cli_stub):
+    """Point every provider CLI at the stub unless the test opts into live LLM."""
+    if live_llm_calls_allowed():
+        return
+    if request.node.get_closest_marker("live_llm"):
+        return
+    for var in _PROVIDER_CLI_ENV:
+        monkeypatch.setenv(var, llm_cli_stub)
+
+
 @pytest.fixture
 def replay_llm(monkeypatch):
     """Route ``ClaudeLLM`` through the record/replay backend (Package C, C4).

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -98,21 +98,29 @@ def _reset_profile_state():
 # 6-hour ceiling, and what starved the wall-clock budget of the fixed-timeout
 # assertions elsewhere in the suite.
 #
-# Every test NOT marked ``live_llm`` gets the five provider CLI path env vars
-# pointed at a stub that exits non-zero immediately. Resolution still succeeds
-# (the path exists and is executable), so import-time construction behaves
-# exactly as before -- only an actual model invocation changes, and it now
-# fails fast and deterministically instead of burning wall-clock.
+# For every test NOT marked ``live_llm``, the five ``_find_*_binary`` resolvers
+# in ``coresmith_llm`` return a stub that exits non-zero immediately. Resolution
+# still succeeds (the stub exists and is executable), so import-time
+# construction behaves exactly as before -- only an actual model invocation
+# changes, and it now fails fast instead of burning wall-clock.
+#
+# Patching the resolvers rather than the ``*_CLI_PATH`` env vars is deliberate.
+# ``ClaudeLLM.__init__`` reads the env var FIRST and only falls back to the
+# resolver, so seeding the env would silently outrank the tests that patch a
+# resolver to pin an expected argv -- and ``pipeline_helpers`` preflight reads
+# two of those vars as presence checks. Patching the resolver leaves both
+# behaviors intact: a test that sets the env var or patches the resolver itself
+# still wins, because its patch is applied after this fixture's.
 #
 # Escape hatch: ``CORESMITH_ALLOW_LIVE_LLM_IN_TESTS=1`` restores the previous
 # behavior for the whole session.
 
-_PROVIDER_CLI_ENV = (
-    "CLAUDE_CLI_PATH",
-    "CODEX_CLI_PATH",
-    "KIMI_CLI_PATH",
-    "AGY_CLI_PATH",
-    "OPENCODE_CLI_PATH",
+_PROVIDER_BINARY_FINDERS = (
+    "_find_claude_binary",
+    "_find_codex_binary",
+    "_find_kimi_binary",
+    "_find_agy_binary",
+    "_find_opencode_binary",
 )
 
 _LLM_CLI_STUB_SRC = """#!/bin/sh
@@ -138,13 +146,15 @@ def llm_cli_stub(tmp_path_factory) -> str:
 
 @pytest.fixture(autouse=True)
 def _no_live_llm_cli(request, monkeypatch, llm_cli_stub):
-    """Point every provider CLI at the stub unless the test opts into live LLM."""
+    """Resolve every provider CLI to the stub unless the test opts into live LLM."""
     if live_llm_calls_allowed():
         return
     if request.node.get_closest_marker("live_llm"):
         return
-    for var in _PROVIDER_CLI_ENV:
-        monkeypatch.setenv(var, llm_cli_stub)
+    from orchestrator.langchain.agents import coresmith_llm as _llm
+
+    for finder in _PROVIDER_BINARY_FINDERS:
+        monkeypatch.setattr(_llm, finder, lambda *_a, **_kw: llm_cli_stub)
 
 
 @pytest.fixture

--- a/orchestrator/tests/test_full_model_dv.py
+++ b/orchestrator/tests/test_full_model_dv.py
@@ -186,11 +186,27 @@ def simulate(stimulus):
 # The probe is static (ast over the composition + a standalone import of each
 # block model), so it costs nothing and works on a run that is already hung.
 
-HANGING_CHIP = '''\
-def simulate(stimulus):
+# A simulate() that hangs on purpose, WITHOUT burning CPU.
+#
+# ``_simulate_with_timeout`` runs simulate() on a daemon thread and abandons it
+# on timeout -- correct for the daemon ("cannot block process exit"), but in a
+# test session the thread outlives the test that started it. A `while True:
+# pass` spin then thrashes the GIL for every remaining test in the process: the
+# two tests below that exercise the timeout used to leak two spinning threads
+# and slow all ~2200 subsequent tests from ~10 ms to ~1-3 s each, which was the
+# bulk of CI's multi-hour runtime (and, because 3.11 and 3.12 schedule threads
+# differently, most of why 3.12 ran 3.4x slower than 3.11 on the same commit).
+#
+# Sleeping honours the same contract -- simulate() does not return within the
+# timeout -- for no CPU.
+_HANG_BODY = """def simulate(stimulus):
+    import time
+
     while True:
-        pass
-'''
+        time.sleep(0.05)
+"""
+
+HANGING_CHIP = _HANG_BODY
 
 # A composition where one block's ports are wired to signals nothing else in the
 # whole chip model touches -- an output no one consumes / an input no one drives.
@@ -214,10 +230,7 @@ class chip_model:
         return m
 
 
-def simulate(stimulus):
-    while True:
-        pass
-'''
+''' + _HANG_BODY
 
 BROKEN_BLOCK = "import a_module_that_does_not_exist_anywhere\n"
 

--- a/orchestrator/tests/test_no_live_llm_guard.py
+++ b/orchestrator/tests/test_no_live_llm_guard.py
@@ -18,32 +18,56 @@ import subprocess
 
 import pytest
 
-from orchestrator.tests.conftest import _PROVIDER_CLI_ENV, live_llm_calls_allowed
+from orchestrator.langchain.agents import coresmith_llm
+from orchestrator.tests.conftest import (
+    _PROVIDER_BINARY_FINDERS,
+    live_llm_calls_allowed,
+)
+
+_STUB_NAME = "no-live-llm"
 
 
 class TestGuardIsOnByDefault:
     """Default branch: CORESMITH_ALLOW_LIVE_LLM_IN_TESTS unset."""
 
-    @pytest.mark.parametrize("var", _PROVIDER_CLI_ENV)
-    def test_every_provider_cli_points_at_the_stub(self, var):
-        path = os.environ.get(var, "")
-        assert path, f"{var} should be pointed at the stub"
+    @pytest.mark.parametrize("finder", _PROVIDER_BINARY_FINDERS)
+    def test_every_resolver_returns_the_stub(self, finder):
+        path = getattr(coresmith_llm, finder)()
+        assert _STUB_NAME in path, f"{finder} should resolve to the stub"
         assert os.path.isfile(path) and os.access(path, os.X_OK), (
-            f"{var}={path!r} must resolve to an executable so import-time "
+            f"{finder} must resolve to an executable so import-time "
             "ClaudeLLM() construction still succeeds"
         )
 
     def test_invoking_the_stub_fails_fast(self):
         """The stub must fail, not silently succeed and look like a real reply."""
         proc = subprocess.run(
-            [os.environ["CLAUDE_CLI_PATH"], "-p", "hello"],
+            [coresmith_llm._find_claude_binary(), "-p", "hello"],
             capture_output=True, text=True, timeout=30,
         )
         assert proc.returncode != 0
         assert "live_llm" in proc.stderr
 
+    def test_a_default_llm_resolves_to_the_stub(self):
+        """The guard has to survive the real construction path, not just the resolver."""
+        llm = coresmith_llm.ClaudeLLM()
+        assert _STUB_NAME in llm.claude_path
+
     def test_helper_reports_guard_active(self):
         assert live_llm_calls_allowed() is False
+
+
+class TestGuardYieldsToTheTest:
+    """The fixture must not outrank a test that pins its own binary."""
+
+    def test_env_var_still_wins(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CLI_PATH", "/usr/bin/claude")
+        assert coresmith_llm.ClaudeLLM().claude_path == "/usr/bin/claude"
+
+    def test_a_test_level_resolver_patch_still_wins(self, monkeypatch):
+        monkeypatch.setattr(
+            coresmith_llm, "_find_claude_binary", lambda: "/usr/bin/claude")
+        assert coresmith_llm.ClaudeLLM().claude_path == "/usr/bin/claude"
 
 
 class TestEscapeHatch:
@@ -62,5 +86,4 @@ class TestEscapeHatch:
 @pytest.mark.live_llm
 def test_live_llm_marked_tests_keep_the_real_cli():
     """A test that opts in is left alone -- the marker is the opt-in."""
-    stub_marker = "no-live-llm"
-    assert stub_marker not in os.environ.get("CLAUDE_CLI_PATH", "")
+    assert _STUB_NAME not in coresmith_llm._find_claude_binary()

--- a/orchestrator/tests/test_no_live_llm_guard.py
+++ b/orchestrator/tests/test_no_live_llm_guard.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""The suite must never shell out to a real provider CLI unless it says so.
+
+``_detect_provider()`` defaults to ``claude_cli``, so any node reaching a real
+``ClaudeLLM.call()`` launches the actual Claude CLI. Graph tests carrying no
+``live_llm`` marker used to do that in PR CI, which is what made the job take
+hours instead of minutes. ``conftest._no_live_llm_cli`` closes that door; these
+tests keep it closed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from orchestrator.tests.conftest import _PROVIDER_CLI_ENV, live_llm_calls_allowed
+
+
+class TestGuardIsOnByDefault:
+    """Default branch: CORESMITH_ALLOW_LIVE_LLM_IN_TESTS unset."""
+
+    @pytest.mark.parametrize("var", _PROVIDER_CLI_ENV)
+    def test_every_provider_cli_points_at_the_stub(self, var):
+        path = os.environ.get(var, "")
+        assert path, f"{var} should be pointed at the stub"
+        assert os.path.isfile(path) and os.access(path, os.X_OK), (
+            f"{var}={path!r} must resolve to an executable so import-time "
+            "ClaudeLLM() construction still succeeds"
+        )
+
+    def test_invoking_the_stub_fails_fast(self):
+        """The stub must fail, not silently succeed and look like a real reply."""
+        proc = subprocess.run(
+            [os.environ["CLAUDE_CLI_PATH"], "-p", "hello"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert proc.returncode != 0
+        assert "live_llm" in proc.stderr
+
+    def test_helper_reports_guard_active(self):
+        assert live_llm_calls_allowed() is False
+
+
+class TestEscapeHatch:
+    """Gated branch: CORESMITH_ALLOW_LIVE_LLM_IN_TESTS=1 restores old behavior."""
+
+    def test_helper_reports_guard_disabled(self, monkeypatch):
+        monkeypatch.setenv("CORESMITH_ALLOW_LIVE_LLM_IN_TESTS", "1")
+        assert live_llm_calls_allowed() is True
+
+    def test_only_exactly_one_enables_it(self, monkeypatch):
+        for value in ("", "0", "true", "yes"):
+            monkeypatch.setenv("CORESMITH_ALLOW_LIVE_LLM_IN_TESTS", value)
+            assert live_llm_calls_allowed() is False
+
+
+@pytest.mark.live_llm
+def test_live_llm_marked_tests_keep_the_real_cli():
+    """A test that opts in is left alone -- the marker is the opt-in."""
+    stub_marker = "no-live-llm"
+    assert stub_marker not in os.environ.get("CLAUDE_CLI_PATH", "")

--- a/orchestrator/tests/test_stage_fixtures.py
+++ b/orchestrator/tests/test_stage_fixtures.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,15 @@ pytestmark = pytest.mark.stage_fixture
 
 _REPO = Path(__file__).resolve().parents[2]
 _STAGE_FIXTURES = Path(__file__).parent / "fixtures" / "stage"
+
+# These waits assert P1 -- "the graph TERMINATES", i.e. the resume does not run
+# away unbounded. They are not throughput assertions, so the budget only has to
+# be comfortably larger than a healthy run, never tuned to a runner's speed. A
+# 30 s budget used to lose the race on a loaded GitHub runner and reddened the
+# suite for reasons unrelated to termination.
+_GRAPH_TERMINATION_TIMEOUT_S = float(
+    os.environ.get("CORESMITH_TEST_GRAPH_TIMEOUT_S", "") or 120
+)
 
 
 def _load_snapshot_module():
@@ -121,7 +131,8 @@ async def _drive_to_post_uarch(record_root: Path, thread_id: str) -> None:
             checkpointer=saver, interrupt_after=["generate_uarch_spec"])
         cfg = {"configurable": {"thread_id": thread_id}}
         await asyncio.wait_for(
-            graph.ainvoke(_block_state(str(record_root)), cfg), timeout=30)
+            graph.ainvoke(_block_state(str(record_root)), cfg),
+            timeout=_GRAPH_TERMINATION_TIMEOUT_S)
         snap = await graph.aget_state(cfg)
         assert snap.next == ("review_uarch_spec",), snap.next  # parked post-uarch
     finally:
@@ -192,7 +203,9 @@ class TestSyntheticCheckpointResume:
             assert snap.next == ("review_uarch_spec",)  # still parked post-uarch
 
             n0 = len(fault_backend.call_log)
-            await asyncio.wait_for(ctx.graph.ainvoke(None, ctx.config), timeout=30)
+            await asyncio.wait_for(
+                ctx.graph.ainvoke(None, ctx.config),
+                timeout=_GRAPH_TERMINATION_TIMEOUT_S)
             snap2 = await ctx.aget_state()
             # P1: terminated within budget.
             assert snap2.next == ()

--- a/orchestrator/tests/test_wavekit_audit_api_compat.py
+++ b/orchestrator/tests/test_wavekit_audit_api_compat.py
@@ -133,10 +133,31 @@ class TestBothWavekitApiShapes:
             assert old[key] == new[key], key
 
 
+def _wavekit_importable() -> bool:
+    """Can THIS interpreter import wavekit -- without betting the session on it?
+
+    ``pytest.importorskip("wavekit")`` imports in-process, and wavekit pulls in
+    the native ``wavekit.readers.value_change``. On a GitHub runner whose CPU
+    predates whatever the published wheel was built for, that import dies with
+    SIGILL, taking the whole pytest process down (exit 132) after the ~3450
+    tests before it have already passed. It is not catchable: an illegal
+    instruction is not a Python exception.
+
+    ``run_wavekit_vcd_audit`` already probes wavekit out-of-process for exactly
+    this reason (pipeline_helpers ``has_wavekit``). Do the same here, so an
+    unusable wheel is a skip rather than a crashed suite.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", "import wavekit"],
+        capture_output=True, timeout=60,
+    ).returncode == 0
+
+
 class TestAgainstInstalledWavekit:
     def test_real_wavekit_audit_passes(self, tmp_path):
         """End-to-end against whatever WaveKit is actually installed."""
-        pytest.importorskip("wavekit")
+        if not _wavekit_importable():
+            pytest.skip("wavekit is not importable in this interpreter")
         from orchestrator.langgraph.pipeline_helpers import run_wavekit_vcd_audit
 
         vcd = tmp_path / "toy.vcd"

--- a/orchestrator/vscode-ext/serve.py
+++ b/orchestrator/vscode-ext/serve.py
@@ -47,9 +47,13 @@ def _resolve_project_root() -> Path:
 PROJECT_ROOT = _resolve_project_root()
 # Add both the data root and the code root to sys.path
 _CODE_ROOT = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(PROJECT_ROOT))
-if str(_CODE_ROOT) != str(PROJECT_ROOT):
-    sys.path.insert(0, str(_CODE_ROOT))
+for _root in (str(PROJECT_ROOT), str(_CODE_ROOT)):
+    # Idempotent: this module is re-executed per test (the webview tests load
+    # it by path with a fresh PROJECT_ROOT each time), and an unguarded insert
+    # grew sys.path by two entries per test -- every later import then paid a
+    # linear scan over the accumulated stale entries.
+    if _root not in sys.path:
+        sys.path.insert(0, _root)
 
 # Initialise lightweight OTel tracing (no-op if already done)
 from orchestrator.telemetry import init_telemetry


### PR DESCRIPTION
`test (3.12)` on #91 failed after 5 h 54 m. The diff had zero Python, so this was never about #91. The suite itself was the problem, and had been for months: main has run 2.5–6 h, and run `30994350130` was cancelled at GitHub's 6 h job ceiling.

**Result: 3.12 goes 5 h 54 m → 58 s, 3.11 goes 1 h 43 m → 71 s, and both legs are green (3500 / 3499 passed).**

## Root cause

Two fixtures in `test_full_model_dv.py` needed a `simulate()` that never returns, so the stall-localization gate would time out. They spelled it:

```python
def simulate(stimulus):
    while True:
        pass
```

`_simulate_with_timeout` runs `simulate()` on a **daemon thread** and, on timeout, returns and abandons it — deliberately, and correctly for the daemon, where the process exits shortly after. A pytest session does not exit: it runs ~2200 more tests. So the two tests that exercise the timeout leaked two threads spinning at 100 % CPU for the rest of the run, thrashing the GIL.

Instrumenting threads/fds/`sys.path`/gc per test makes the cliff exact:

```
test 1287   0.002 s   threads=2   ...test_probe_never_raises_on_a_missing_or_unparseable_dir
test 1288   1.081 s   threads=3   ...test_timeout_violation_says_WHERE
test 1289   2.629 s   threads=4   ...test_localization_can_be_switched_off
            ...every test thereafter 1–3 s instead of ~10 ms
```

That one step explains the whole shape of every CI log going back months — the first ~1240 tests always ran at ~0.00–0.04 s and everything after at 1.2–2.8 s. It also explains the matrix asymmetry: 3.11 and 3.12 schedule contending threads differently, which is why the *same commit* took 1 h 43 m on one leg and 5 h 54 m on the other, and why 3.12 was the leg that lost a fixed 30 s wall-clock race and went red.

Sleeping honours the identical contract — `simulate()` does not return within the timeout — for no CPU. The production helper is left alone: a Python thread cannot be killed, so abandoning it is the only option the gate has. The fix belongs in the fixture, which is what made the abandoned thread pathological.

## Also fixed

- **Live provider CLI in the PR suite.** `_detect_provider()` defaults to `claude_cli`, so any node reaching a real `ClaudeLLM.call()` launched `claude -p --model opus --max-turns 50`. `test_pipeline_graph`'s end-to-end walks stub `integration_check` / `integration_dv` / `validation_dv` but not `uarch_integration_review`, and carry no `live_llm` marker. Every test not marked `live_llm` now resolves the five provider CLIs to a stub that exits non-zero immediately; `CORESMITH_ALLOW_LIVE_LLM_IN_TESTS=1` restores the old behavior and both branches are covered by tests. Nothing is deleted or skipped — the marker is the opt-in, as it was always meant to be. (Worth ~30 % of CI time, and it was costing real money on developer machines, where the CLI is authenticated and the call actually runs.)
- **The 3.12 red itself.** The two fixed 30 s waits in `test_stage_fixtures.py` assert *termination*, not throughput, so they now read a budget generous by default and tunable via `CORESMITH_TEST_GRAPH_TIMEOUT_S`.
- **`wavekit` SIGILL.** With the suite finishing in ~40 s, CI reached test 3458 for the first time in months and died at exit 132: `pytest.importorskip("wavekit")` imports in-process, pulling in the native `wavekit.readers.value_change`, which executes an illegal instruction on some runner CPUs and takes the process down after ~3450 tests have passed. SIGILL is not catchable. `run_wavekit_vcd_audit` already probes wavekit out-of-process for exactly this reason; the test now does the same, so an unusable wheel is a skip rather than a crashed suite. (This is why 3.11 reports one more skip than 3.12.)
- **`vscode-ext/serve.py`** inserted two unguarded `sys.path` entries at import. The webview tests re-execute it per test with a fresh `PROJECT_ROOT`, so `sys.path` grew by two entries per test (measured 7 → 119 across that one file). Now idempotent; insertion order unchanged.
- **A 120-minute job ceiling**, so a future runaway is a fast, legible failure rather than a silent burn into GitHub's 6 h cancel.

Everything here is test-only except the two-line `serve.py` idempotency guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F69UPThv61UrLyEfrRxizL
